### PR TITLE
quote description containing colons in payment-provider-protocol SKIL…

### DIFF
--- a/exports/opencode/payment-provider-protocol/SKILL.md
+++ b/exports/opencode/payment-provider-protocol/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: payment-provider-protocol
-description: Apply when implementing a VTEX Payment Provider Protocol (PPP) connector or working with payment/connector endpoint files. Covers all nine required endpoints: Manifest, Create Payment, Cancel, Capture/Settle, Refund, Inbound Request, Create Auth Token, Provider Auth Redirect, and Get Credentials. Use for building or debugging any payment connector that integrates with the VTEX Payment Gateway.
+description: "Apply when implementing a VTEX Payment Provider Protocol (PPP) connector or working with payment/connector endpoint files. Covers all nine required endpoints: Manifest, Create Payment, Cancel, Capture/Settle, Refund, Inbound Request, Create Auth Token, Provider Auth Redirect, and Get Credentials. Use for building or debugging any payment connector that integrates with the VTEX Payment Gateway."
 ---
 
 # PPP Endpoint Implementation


### PR DESCRIPTION
The description field contained unquoted colons (:), causing a "malformed YAML frontmatter" error when uploading to Claude.ai Skills. Wrapped the value in double quotes to fix the YAML parsing.