### PR TITLE
Add references and grammar fixes in IO GraphQL Skill

### DIFF
--- a/skills/vtex-io-graphql-api/SKILL.md
+++ b/skills/vtex-io-graphql-api/SKILL.md
@@ -388,6 +388,7 @@ export default new Service({
 - [Developing a GraphQL API in Service Apps](https://developers.vtex.com/docs/guides/developing-a-graphql-api-in-service-apps) — Step-by-step tutorial for building GraphQL APIs
 - [Integrating an App with a GraphQL API](https://developers.vtex.com/docs/guides/integrating-an-app-with-a-graphql-api) — How to consume GraphQL APIs from other VTEX IO apps
 - [GraphQL authorization in IO apps](https://developers.vtex.com/docs/guides/graphql-authorization-in-io-apps) — How to implement and use the `@auth` directive for protected GraphQL operations
+- [Implementing cache in GraphQL APIs for IO apps](https://developers.vtex.com/docs/guides/implementing-cache-in-graphql-apis-for-io-apps) — How to implement and use the `@cacheControl` directive for GraphQL operations
 - [VTEX IO Clients](https://developers.vtex.com/docs/guides/vtex-io-documentation-clients) — How to use ctx.clients in resolvers for data access
 
  


### PR DESCRIPTION
Made the following changes in the `vtex-io-graphql-api` Skill:

- Add documentation references related to `@auth` and `@cacheControl` directives.
- Grammar fixes.