### PR TITLE
fix(ci): remove post-merge export commit, let release.yml own exports

### DIFF
--- a/.github/workflows/generate-exports.yml
+++ b/.github/workflows/generate-exports.yml
@@ -1,13 +1,6 @@
 name: Generate Skill Exports
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'tracks/**/*.md'
-      - 'scripts/**/*.ts'
-      - '_templates/**'
-      - 'package.json'
   pull_request:
     paths:
       - 'tracks/**/*.md'
@@ -16,7 +9,7 @@ on:
       - 'package.json'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   validate-and-export:
@@ -38,26 +31,3 @@ jobs:
 
       - name: Generate exports
         run: bun run export
-
-      - name: Sync plugin directories
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          rm -f rules/*.mdc
-          cp exports/cursor/*.mdc rules/
-          rm -rf skills/
-          cp -r exports/opencode/. skills/
-
-      - name: Check for changes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        id: changes
-        run: |
-          git diff --quiet exports/ rules/ skills/ || echo "changed=true" >> $GITHUB_OUTPUT
-
-      - name: Commit generated exports
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.changes.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add exports/ rules/ skills/
-          git commit -m "chore: regenerate skill exports"
-          git push


### PR DESCRIPTION
## Problem

The `generate-exports.yml` workflow fails on every merge to `main` with:

```
GH006: Protected branch update failed for refs/heads/main
```

The auto-commit step tries to push directly to `main`, which is blocked by branch protection.

## Fix

Remove the push trigger and all commit-back steps entirely. Exports are freshly generated inside `release.yml` at tag time — that's the authoritative source for release artifacts. No need to keep `exports/` continuously in sync between releases.

**Before**: PR trigger (validate + export) + push trigger (validate + export + sync + commit back)
**After**: PR trigger only (validate + export as smoke test)

`contents` permission downgraded from `write` to `read` since nothing writes back.

## No user impact

- `bun run validate` and `bun run export` still run on every PR as a quality gate
- Release tarballs are still freshly generated on every tag push via `release.yml`
- Contributors never needed to run export manually (by design)