### PR TITLE
fix(ci): restore post-merge export commit using REPO_TOKEN

### DIFF
--- a/.github/workflows/generate-exports.yml
+++ b/.github/workflows/generate-exports.yml
@@ -1,6 +1,13 @@
 name: Generate Skill Exports
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'tracks/**/*.md'
+      - 'scripts/**/*.ts'
+      - '_templates/**'
+      - 'package.json'
   pull_request:
     paths:
       - 'tracks/**/*.md'
@@ -17,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.REPO_TOKEN || github.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -31,3 +40,26 @@ jobs:
 
       - name: Generate exports
         run: bun run export
+
+      - name: Sync plugin directories
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          rm -f rules/*.mdc
+          cp exports/cursor/*.mdc rules/
+          rm -rf skills/
+          cp -r exports/opencode/. skills/
+
+      - name: Check for changes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: changes
+        run: |
+          git diff --quiet exports/ rules/ skills/ || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit generated exports
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add exports/ rules/ skills/
+          git commit -m "chore: regenerate skill exports"
+          git push


### PR DESCRIPTION
Restores the push trigger and auto-commit behaviour that was removed in PR #8.

The previous attempt failed because `github-actions[bot]` cannot bypass branch protection on free org plans (confirmed: neither the UI nor the API `bypass_pull_request_allowances` field works).

**Fix**: Use a fine-grained PAT (`REPO_TOKEN` secret, scoped to this repo, `contents: read/write`) passed to `actions/checkout`. This wires the remote auth so the subsequent `git push` uses the PAT rather than the default `GITHUB_TOKEN`.

- On **PR**: falls back to `github.token` (read-only is fine for validate+export smoke test)
- On **push to main**: uses `REPO_TOKEN` → can commit back past branch protection

Merging this PR is the live test — the post-merge run should commit regenerated exports without the `GH006` error.