### PR TITLE
docs: backfill changelog with v1.0.0 history and missing v1.1.0 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,57 @@
 ## [1.1.0](https://github.com/vtexdocs/ai-skills/compare/v1.0.0...v1.1.0) (2026-03-17)
 
 
-### Features
+### New Skills & Features
 
 * **release:** add Release Please for automated version bumping ([2d758be](https://github.com/vtexdocs/ai-skills/commit/2d758be95da02b1956d0209bae463700d19cb04a))
 * **tooling:** support dual-format frontmatter in export script and fix description quoting ([1e11a64](https://github.com/vtexdocs/ai-skills/commit/1e11a64c725b4a18614b21bed548bf2c2c23cf82))
 * **tooling:** support dual-format frontmatter in validator ([203e811](https://github.com/vtexdocs/ai-skills/commit/203e811a0af7853bc6495b7038e9177c46372a4f))
 
 
+### Skill Improvements
+
+* **faststore:** convert 4 skills to decision-oriented template ([31e4e47](https://github.com/vtexdocs/ai-skills/commit/31e4e47))
+* **headless:** convert 4 skills to decision-oriented template ([b69ea7c](https://github.com/vtexdocs/ai-skills/commit/b69ea7c))
+* **marketplace:** convert 4 skills to decision-oriented template ([848962a](https://github.com/vtexdocs/ai-skills/commit/848962a))
+* **payment:** convert 4 skills to decision-oriented template ([4a0bff7](https://github.com/vtexdocs/ai-skills/commit/4a0bff7))
+* **vtex-io:** convert and rename 5 skills to decision-oriented template ([4c8ce8e](https://github.com/vtexdocs/ai-skills/commit/4c8ce8e))
+
+
 ### Bug Fixes
 
 * **ci:** remove post-merge export commit, let release.yml own exports ([2ca8887](https://github.com/vtexdocs/ai-skills/commit/2ca8887f87fbd2120a6e138af2bc4521ab70f3e4))
+* **ci:** restore post-merge export commit using REPO_TOKEN ([eda05ae](https://github.com/vtexdocs/ai-skills/commit/eda05ae))
+
+
+### Documentation
+
+* add AGENTS.md with template and validation guidance for AI contributors ([db5129f](https://github.com/vtexdocs/ai-skills/commit/db5129f))
+
+
+---
+
+## [1.0.0](https://github.com/vtexdocs/ai-skills/commits/v1.0.0) (2026-03-16)
+
+
+### New Skills & Features
+
+* initial release of 21 VTEX AI skills across 5 tracks ([718d18c](https://github.com/vtexdocs/ai-skills/commit/718d18c))
+  * FastStore: overrides, theming, state management, data fetching
+  * Payment: provider protocol, idempotency, async flow, PCI security
+  * VTEX IO: app structure, service apps, React apps, GraphQL, MasterData
+  * Marketplace: catalog sync, order hook, fulfillment, rate limiting
+  * Headless: BFF architecture, Intelligent Search, checkout proxy, caching strategy
+* add Open Plugin format compatibility — `rules/` and `skills/` root directories ([6eac001](https://github.com/vtexdocs/ai-skills/commit/6eac001))
+* add GitHub release workflow with per-platform tarballs ([4caf3b5](https://github.com/vtexdocs/ai-skills/commit/4caf3b5))
+* add decision-oriented skill template replacing tutorial-oriented format ([f509412](https://github.com/vtexdocs/ai-skills/commit/f509412))
+
+
+### Skill Improvements
+
+* refine GraphQL skill: schema structure, `@cacheControl`, `@auth` directives ([1909d9d](https://github.com/vtexdocs/ai-skills/commit/1909d9d))
+
+
+### Documentation
+
+* rewrite README with hero section, badges, and Quick Start guide ([99c2d90](https://github.com/vtexdocs/ai-skills/commit/99c2d90))
+* add VTEX IO track index with skill groupings and learning order ([8fe6f5d](https://github.com/vtexdocs/ai-skills/commit/8fe6f5d))


### PR DESCRIPTION
## What

Manually backfills the CHANGELOG with entries that Release Please missed — it only started tracking commits after it was set up, so the pre-automation history was undocumented.

## What was added

**v1.0.0 section (new)**
- Initial release of 21 skills across 5 tracks
- Open Plugin format (`rules/` + `skills/`)
- GitHub release workflow
- Decision-oriented template (PR #3)
- GraphQL skill refinement (PR #2)
- README rewrite

**v1.1.0 section (completed)**
- Added missing `Skill Improvements` entries — all 5 refactor track conversions
- Added missing `Documentation` entry — AGENTS.md
- Added missing `Bug Fixes` entry — REPO_TOKEN CI fix

## Why PR instead of force-push

A normal merge preserves history and gives a clean audit trail. Release Please won't be confused by a manual CHANGELOG edit — it tracks versions via `.release-please-manifest.json`, not the file contents.