### PR TITLE
fix(ci): use REPO_TOKEN in release-please to trigger downstream workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v4
         with:
+          token: ${{ secrets.REPO_TOKEN }}
           release-type: node
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Problem

v1.1.0 and v1.1.1 both have zero release assets. The `Create Release` workflow (which packages tarballs) never fires.

**Root cause chain:**
1. PR #14 fixed the trigger: `push: tags` → `release: published` ✅
2. But Release Please uses `GITHUB_TOKEN` to create releases
3. GitHub intentionally prevents `GITHUB_TOKEN` from triggering cascading workflow events
4. So `release: published` fires but no other workflow sees it

## Fix

Pass `REPO_TOKEN` (the fine-grained PAT) to `release-please-action`. This makes the release event attributable to a real user, allowing the `Create Release` workflow to trigger.

## After merging

1. Delete the empty v1.1.1 release: `gh release delete v1.1.1 --repo vtexdocs/ai-skills -y`
2. Delete the v1.1.1 tag: `gh api repos/vtexdocs/ai-skills/git/refs/tags/v1.1.1 -X DELETE`
3. The next Release Please cycle will create v1.1.1 fresh with the PAT → `Create Release` fires → assets uploaded