### PR TITLE
fix(ci): trigger release pipeline after cleaning empty releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,4 @@
 
 * rewrite README with hero section, badges, and Quick Start guide ([99c2d90](https://github.com/vtexdocs/ai-skills/commit/99c2d90))
 * add VTEX IO track index with skill groupings and learning order ([8fe6f5d](https://github.com/vtexdocs/ai-skills/commit/8fe6f5d))
+


### PR DESCRIPTION
Triggers Release Please after deleting the empty v1.1.0 and v1.1.1 releases. The next release will be v1.1.2 with all tarballs attached.