### PR TITLE
fix(ci): migrate from deprecated google-github-actions to googleapis/release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.REPO_TOKEN }}
           release-type: node


### PR DESCRIPTION
The old `google-github-actions/release-please-action` is deprecated and returning 502 errors. Switches to the maintained `googleapis/release-please-action@v4`.