### PR TITLE
docs: clarify source vs auto-generated files for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides instructions for AI coding agents working on this repository.
 
 ## Quick rules
 
-1. **Source files only**: Edit skill files in `tracks/{track}/skills/{name}/skill.md`. Never edit files in `exports/`, `skills/`, or `rules/` — they are auto-generated.
+1. **Source files only**: Edit skill files in `tracks/{track}/skills/{name}/skill.md`. Never edit `exports/`, `skills/`, or `rules/` — they are auto-generated and will be silently overwritten the next time `bun run export` runs.
 2. **Validate before committing**: Run `bun run validate`. All 11 checks must pass.
 3. **Regenerate exports**: Run `bun run export` after any skill change. Commit both source and generated files.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,24 @@
 
 This guide covers everything you need to add skills, tracks, and export platforms to this repository.
 
+## How this repository works
+
+> **Edit source files only.** Files in `exports/`, `skills/`, and `rules/` are auto-generated
+> and will be silently overwritten the next time `bun run export` runs.
+
+The workflow is always: **edit `tracks/` → validate → export → commit both.**
+
+| Path | What it is | Editable? |
+|---|---|---|
+| `tracks/{track}/skills/{name}/skill.md` | Skill source of truth | ✅ Edit here |
+| `exports/` | All platform exports (cursor, copilot, agents-md, etc.) | ❌ Auto-generated |
+| `skills/` *(root-level)* | OpenCode exports | ❌ Auto-generated |
+| `rules/` | Cursor `.mdc` exports | ❌ Auto-generated |
+
+> **Common trap**: There is a `skills/` directory at the repository root that looks like source
+> files. It is not — it is the auto-generated OpenCode export. Source files live under
+> `tracks/{track}/skills/`, not at the root.
+
 ## Table of Contents
 
 - [Adding a New Skill](#adding-a-new-skill)
@@ -23,6 +41,8 @@ Skills live at `tracks/{track}/skills/{skill-name}/skill.md`. Create the directo
 mkdir -p tracks/faststore/skills/faststore-my-new-skill
 touch tracks/faststore/skills/faststore-my-new-skill/skill.md
 ```
+
+> **Not** `skills/{skill-name}/` at the repo root — that directory is the auto-generated OpenCode export and will be overwritten on the next `bun run export`.
 
 ### Step 2: Copy the template
 
@@ -259,6 +279,7 @@ Before submitting a pull request, verify all of these:
 
 - [ ] `bun run validate` passes with no errors
 - [ ] `bun run export` completes with exit code 0
+- [ ] All edits are in `tracks/`, not in `exports/`, `skills/`, or `rules/`
 - [ ] No `TBD`, `TODO`, or `[placeholder]` text in prose sections
 - [ ] All code blocks have language annotations on opening fences
 - [ ] The `description` frontmatter field starts with `Apply when ...`

--- a/README.md
+++ b/README.md
@@ -228,16 +228,7 @@ Compatible tools (Cursor, Claude Code, and others implementing the Open Plugins 
 vtex_skills/
   _templates/
     skill-template.md       # Canonical template for new skills
-  exports/
-    agents-md/              # AGENTS.md format (6 files)
-    claude/                 # Claude Projects format (26 files)
-    copilot/                # GitHub Copilot format (6 files)
-    cursor/                 # Cursor .mdc format (26 files)
-    opencode/               # OpenCode SKILL.md format (21 files)
-  scripts/
-    export.ts               # Generates all platform exports
-    validate.ts             # Validates all skill files
-  tracks/
+  tracks/                   # SOURCE — edit skill files here
     faststore/
       index.md
       skills/
@@ -274,6 +265,17 @@ vtex_skills/
         vtex-io-react-apps/skill.md
         vtex-io-graphql-api/skill.md
         vtex-io-masterdata/skill.md
+  exports/                  # auto-generated — do not edit
+    agents-md/              # AGENTS.md format (6 files)
+    claude/                 # Claude Projects format (26 files)
+    copilot/                # GitHub Copilot format (6 files)
+    cursor/                 # Cursor .mdc format (26 files)
+    opencode/               # OpenCode SKILL.md format (21 files)
+  skills/                   # auto-generated — do not edit (OpenCode export)
+  rules/                    # auto-generated — do not edit (Cursor export)
+  scripts/
+    export.ts               # Generates all platform exports
+    validate.ts             # Validates all skill files
   package.json
   tsconfig.json
 ```


### PR DESCRIPTION
## Summary

- Adds a **\"How this repository works\"** section to `CONTRIBUTING.md` (before the Table of Contents) with a source/generated table and an explicit callout about the root-level `skills/` naming trap — the most likely place contributors would accidentally edit the wrong files
- Strengthens `AGENTS.md` Rule #1 by stating the consequence: edits to generated directories will be silently overwritten by `bun run export`
- Adds a **Quality Checklist item**: \"All edits are in `tracks/`, not in `exports/`, `skills/`, or `rules/`\"
- Reorders the README directory tree to show `tracks/` (the source of truth) first, then `exports/`, `skills/`, and `rules/` — each labelled as auto-generated

## Motivation

The root-level `skills/` directory mirrors the `tracks/*/skills/` naming pattern contributors are supposed to use, making it an easy trap. Nothing in `CONTRIBUTING.md` warned about this before the contributor reached step 1 — and even then there was no mention of the generated directories.