### PR TITLE
refactor(payment): replace fixed delayToCancel with method-specific v…

### DIFF
--- a/tracks/payment/skills/payment-async-flow/skill.md
+++ b/tracks/payment/skills/payment-async-flow/skill.md
@@ -3,8 +3,8 @@ name: payment-async-flow
 description: >
   Apply when implementing asynchronous payment methods (Boleto, Pix, bank redirects) or working with
   callback URLs in payment connector code. Covers undefined status response, callbackUrl notification,
-  X-VTEX-signature validation, sync vs async handling, and the 7-day retry window. Use for any payment
-  flow where authorization does not complete synchronously.
+  X-VTEX-signature validation, sync vs async handling, and correct delayToCancel configuration for
+  each async method.
 metadata:
   track: payment
   tags:
@@ -20,7 +20,7 @@ metadata:
     - "**/payment/**/*.ts"
     - "**/callback/**/*.ts"
   version: "1.0"
-  purpose: Implement async payment flows correctly using undefined status, callbacks, and the 7-day retry window
+  purpose: Implement async payment flows correctly using undefined status, callbacks, and correct delayToCancel configuration
   applies_to:
     - implementing Boleto or Pix payment methods
     - handling acquirer webhooks with callback notifications
@@ -59,7 +59,10 @@ Do not use this skill for:
 - **Without VTEX IO**: the `callbackUrl` is a notification endpoint — POST the updated status with `X-VTEX-API-AppKey`/`X-VTEX-API-AppToken` headers.
 - **With VTEX IO**: the `callbackUrl` is a retry endpoint — POST to it (no payload) to trigger the Gateway to re-call POST `/payments`.
 - Always preserve the `X-VTEX-signature` query parameter in the `callbackUrl` — never strip or modify it.
-- Set `delayToCancel` to 604800 (7 days) for async methods to match the Gateway's retry window.
+- For asynchronous methods, `delayToCancel` MUST reflect the actual validity of the payment method, not the 7‑day internal Gateway retry window:
+  - Pix: between 900 and 3600 seconds (15–60 minutes), aligned with QR code expiration.
+  - BankInvoice (Boleto): aligned with the invoice due date / payment deadline configured in the provider.
+  - Other async methods: aligned with the provider's documented expiry SLA.
 
 ## Hard constraints
 
@@ -84,7 +87,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   if (isAsync) {
     const pending = await acquirer.initiateAsyncPayment(req.body);
 
-    // Store callbackUrl for later notification
+    // Store payment and callbackUrl for later notification
     await store.save(paymentId, {
       paymentId,
       status: "undefined",
@@ -103,19 +106,56 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer action",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: computeDelayToCancel(paymentMethod, pending),
       paymentUrl: pending.qrCodeUrl ?? pending.boletoUrl ?? undefined,
     });
+
     return;
   }
 
   // Synchronous methods (credit card) can return final status
   const result = await acquirer.authorizeSyncPayment(req.body);
+
   res.status(200).json({
     paymentId,
     status: result.status,  // "approved" or "denied" is OK for sync
-    // ... other fields
+    authorizationId: result.authorizationId ?? null,
+    nsu: result.nsu ?? null,
+    tid: result.tid ?? null,
+    acquirer: "MyProvider",
+    code: result.code ?? null,
+    message: result.message ?? null,
+    delayToAutoSettle: 21600,
+    delayToAutoSettleAfterAntifraud: 1800,
+    delayToCancel: 21600,
   });
+}
+
+const PIX_MIN_DELAY = 900;   // 15 minutes
+const PIX_MAX_DELAY = 3600;  // 60 minutes
+
+function computeDelayToCancel(paymentMethod: string, pending: any): number {
+  if (paymentMethod === "Pix") {
+    // Use provider QR TTL but clamp to 15–60 minutes
+    const providerTtlSeconds = pending.pixTtlSeconds ?? 1800; // default 30 min
+    return Math.min(Math.max(providerTtlSeconds, PIX_MIN_DELAY), PIX_MAX_DELAY);
+  }
+
+  if (paymentMethod === "BankInvoice") {
+    // Example: seconds until boleto due date
+    const now = Date.now();
+    const dueDate = new Date(pending.dueDate).getTime();
+    const diffSeconds = Math.max(Math.floor((dueDate - now) / 1000), 0);
+    return diffSeconds;
+  }
+
+  // Other async methods: follow provider SLA if provided
+  if (pending.expirySeconds) {
+    return pending.expirySeconds;
+  }
+
+  // Conservative fallback: 24h
+  return 86400;
 }
 ```
 
@@ -166,17 +206,36 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     callbackUrl,  // Stored exactly as received, including query params
   });
 
-  // ... return undefined response
+  // Return async "undefined" response (see previous constraint)
+  res.status(200).json({
+    paymentId,
+    status: "undefined",
+    authorizationId: null,
+    nsu: null,
+    tid: null,
+    acquirer: "MyProvider",
+    code: "PENDING",
+    message: "Awaiting customer action",
+    delayToAutoSettle: 21600,
+    delayToAutoSettleAfterAntifraud: 1800,
+    delayToCancel: 86400,
+  });
 }
 
 // When the acquirer webhook arrives, use the stored callbackUrl
 async function handleAcquirerWebhook(req: Request, res: Response): Promise<void> {
   const { paymentReference, status } = req.body;
-  const payment = await store.findByAcquirerRef(paymentReference);
-  if (!payment) { res.status(404).send(); return; }
 
-  // Update local state
-  await store.updateStatus(payment.paymentId, status === "paid" ? "approved" : "denied");
+  const payment = await store.findByAcquirerRef(paymentReference);
+  if (!payment) {
+    res.status(404).send();
+    return;
+  }
+
+  const pppStatus = status === "paid" ? "approved" : "denied";
+
+  // Update local state first
+  await store.updateStatus(payment.paymentId, pppStatus);
 
   // Use the EXACT stored callbackUrl — do not modify it
   await fetch(payment.callbackUrl, {
@@ -188,7 +247,7 @@ async function handleAcquirerWebhook(req: Request, res: Response): Promise<void>
     },
     body: JSON.stringify({
       paymentId: payment.paymentId,
-      status: status === "paid" ? "approved" : "denied",
+      status: pppStatus,
     }),
   });
 
@@ -217,34 +276,71 @@ async function handleAcquirerWebhook(req: Request, res: Response): Promise<void>
 }
 ```
 
-### Constraint: MUST be ready for repeated Create Payment calls
+### Constraint: MUST be ready for repeated Create Payment calls (idempotent, but status can evolve)
 
-The connector MUST handle the Gateway calling Create Payment with the same `paymentId` multiple times during the 7-day retry window. Each call must return the current payment status (which may have been updated via callback since the last call).
+The connector MUST handle the Gateway calling Create Payment (POST `/payments`) with the same `paymentId` multiple times during the retry window. Each call MUST not create a new charge at the acquirer, must return a response based on the locally persisted state for that `paymentId`, and must reflect the current status (`"undefined"`, `"approved"`, or `"denied"`) which may have changed after a callback.
+
+Idempotency is about side effects on the acquirer: the first call creates the charge, retries MUST NOT call the acquirer again. For async methods, the response status may legitimately evolve from `"undefined"` to `"approved"` or `"denied"`, but only because your local store was updated by the webhook.
 
 **Why this matters**
-The Gateway retries `undefined` payments automatically. If the connector treats each call as a new payment, it will create duplicate charges. If the connector always returns the original `undefined` status without checking for updates, the Gateway never learns that the payment was approved, and eventually cancels it.
+The Gateway retries `POST /payments` for `undefined` payments automatically for up to 7 days. If the connector treats each call as a new payment, it will create duplicate charges at the acquirer. If the connector always returns the original `"undefined"` response without checking for an updated status, the Gateway never learns that the payment was approved, and eventually cancels it.
 
 **Detection**
-If the Create Payment handler does not check for an existing `paymentId` and return the latest status, STOP. The handler must support idempotent retries that reflect the current state.
+If the Create Payment handler does not check for an existing `paymentId` before calling the acquirer, or always returns the original response without looking at the current status in storage, the agent MUST stop and guide the developer to implement proper idempotency with status evolution based on stored state only.
 
 **Correct**
 ```typescript
 async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId } = req.body;
+  const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Check for existing payment — may have been updated via callback
   const existing = await store.findByPaymentId(paymentId);
   if (existing) {
-    // Return current status — may have changed from "undefined" to "approved"
+    // Do NOT call the acquirer again.
+    // Return a response derived from the current stored state.
     res.status(200).json({
       ...existing.response,
-      status: existing.status,  // Reflects the latest state
+      status: existing.status,  // Reflect the latest state: "undefined" | "approved" | "denied"
     });
     return;
   }
 
-  // First time — create new payment
-  // ...
+  // First time — call the acquirer once
+  const asyncMethods = ["BankInvoice", "Pix"];
+  const isAsync = asyncMethods.includes(paymentMethod);
+
+  const acquirerResult = await acquirer.authorize(req.body);
+
+  const initialStatus = isAsync ? "undefined" : acquirerResult.status;
+
+  const response = {
+    paymentId,
+    status: initialStatus,
+    authorizationId: acquirerResult.authorizationId ?? null,
+    nsu: acquirerResult.nsu ?? null,
+    tid: acquirerResult.tid ?? null,
+    acquirer: "MyProvider",
+    code: acquirerResult.code ?? null,
+    message: acquirerResult.message ?? null,
+    delayToAutoSettle: 21600,
+    delayToAutoSettleAfterAntifraud: 1800,
+    delayToCancel: isAsync
+      ? computeDelayToCancel(paymentMethod, acquirerResult)
+      : 21600,
+    ...(acquirerResult.paymentUrl
+      ? { paymentUrl: acquirerResult.paymentUrl }
+      : {}),
+  };
+
+  await store.save(paymentId, {
+    paymentId,
+    status: initialStatus,
+    response,
+    callbackUrl,
+    acquirerReference: acquirerResult.reference,
+  });
+
+  res.status(200).json(response);
 }
 ```
 
@@ -253,12 +349,79 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 async function createPaymentHandler(req: Request, res: Response): Promise<void> {
   const { paymentId } = req.body;
 
-  // WRONG: Always returns the original cached response without checking
-  // if the status has been updated. Gateway never sees "approved".
-  const existing = await store.findByPaymentId(paymentId);
-  if (existing) {
-    // Always returns the stale "undefined" response — never updates
-    res.status(200).json(existing.originalResponse);
+  // WRONG: No idempotency — every retry hits the acquirer again
+  const result = await acquirer.authorize(req.body);
+
+  res.status(200).json({
+    paymentId,
+    status: result.status,
+    authorizationId: result.authorizationId ?? null,
+    nsu: result.nsu ?? null,
+    tid: result.tid ?? null,
+    acquirer: "MyProvider",
+    code: null,
+    message: null,
+    delayToAutoSettle: 21600,
+    delayToAutoSettleAfterAntifraud: 1800,
+    delayToCancel: 21600,
+  });
+}
+```
+
+### Constraint: MUST align `delayToCancel` with payment validity (not always 7 days)
+
+For asynchronous methods, the `delayToCancel` field in the Create Payment response MUST represent how long that payment is considered valid for the shopper. It defines when the Gateway is allowed to automatically cancel payments that never reached a final status.
+
+Rules:
+- Pix: `delayToCancel` MUST be between 900 and 3600 seconds (15–60 minutes). This value MUST match the QR code validity configured on the provider.
+- BankInvoice (Boleto): `delayToCancel` MUST be computed from the configured due date / payment deadline (for example, seconds until invoice due date). It MUST NOT be hardcoded to 7 days just to "match" the Gateway's internal retry window.
+- Other async methods: `delayToCancel` MUST follow the expiry SLA defined by the provider (hours or days, as applicable). It MUST NEVER exceed the actual validity of the underlying payment from the provider's perspective.
+
+The 7‑day window is an internal Gateway safety limit for retries on `undefined` status. It does not mean every async method should use `delayToCancel = 604800`.
+
+**Why this matters**
+For Pix, using a multi‑day `delayToCancel` keeps orders stuck in "Authorizing" with expired QR codes, creating poor UX and operational noise. For Boleto, cancelling before the real due date loses sales; cancelling much later creates reconciliation risk and "zombie" orders. Misaligned `delayToCancel` breaks the consistency between the provider's notion of a valid payment and when VTEX auto‑cancels the payment.
+
+**Detection**
+If the connector always uses `delayToCancel = 604800` for any async method, or sets `delayToCancel` greater than the Pix or Boleto validity window, the agent MUST warn that `delayToCancel` is misconfigured.
+
+**Correct**
+
+(See the `computeDelayToCancel` function in the "MUST return undefined" example above.)
+
+**Wrong**
+```typescript
+async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+  const { paymentId, paymentMethod, callbackUrl } = req.body;
+
+  const isAsync = ["BankInvoice", "Pix"].includes(paymentMethod);
+
+  if (isAsync) {
+    const pending = await acquirer.initiateAsyncPayment(req.body);
+
+    await store.save(paymentId, {
+      paymentId,
+      status: "undefined",
+      callbackUrl,
+      acquirerReference: pending.reference,
+    });
+
+    res.status(200).json({
+      paymentId,
+      status: "undefined",
+      authorizationId: pending.authorizationId ?? null,
+      nsu: pending.nsu ?? null,
+      tid: pending.tid ?? null,
+      acquirer: "MyProvider",
+      code: "PENDING",
+      message: "Awaiting customer action",
+      delayToAutoSettle: 21600,
+      delayToAutoSettleAfterAntifraud: 1800,
+      // WRONG: hardcoded 7 days for every async method
+      delayToCancel: 604800,
+      paymentUrl: pending.qrCodeUrl ?? pending.boletoUrl ?? undefined,
+    });
+
     return;
   }
 
@@ -369,6 +532,7 @@ async function notifyGateway(callbackUrl: string, payload: object): Promise<void
 - **Hardcoding callback URLs** — Constructing callback URLs manually instead of using the one from the request, stripping the `X-VTEX-signature` parameter. The Gateway rejects the callback and the payment stays stuck in `undefined`.
 - **No retry logic for failed callbacks** — Calling the `callbackUrl` once and silently dropping the notification on failure. The Gateway never learns the payment was approved, and the payment sits in `undefined` until the next retry or is auto-cancelled.
 - **Returning stale status on retries** — Always returning the original `undefined` response without checking if the status was updated via callback. The Gateway never sees the `approved` status and eventually cancels the payment.
+- **Misaligned `delayToCancel`** — Using 7 days for Pix, leaving expired QR codes with orders stuck in "Authorizing". Using arbitrary values for Boleto that do not match invoice due dates.
 
 ## Review checklist
 
@@ -378,8 +542,10 @@ async function notifyGateway(callbackUrl: string, payload: object): Promise<void
 - [ ] Is `X-VTEX-signature` preserved in the `callbackUrl` when calling it?
 - [ ] Are `X-VTEX-API-AppKey` and `X-VTEX-API-AppToken` headers included in notification callbacks (non-VTEX IO)?
 - [ ] Is there retry logic with exponential backoff for failed callback calls?
-- [ ] Does the Create Payment handler return the latest status (not stale) on Gateway retries?
-- [ ] Is `delayToCancel` set to 604800 (7 days) for async methods?
+- [ ] Does the Create Payment handler check for an existing `paymentId`, avoid calling the acquirer again for retries, and return a response derived from the current stored state (status may evolve from `"undefined"` to `"approved"`/`"denied"` after callback)?
+- [ ] For Pix, is `delayToCancel` between 900 and 3600 seconds (15–60 minutes), aligned with QR code validity?
+- [ ] For BankInvoice (Boleto), does `delayToCancel` reflect the real payment deadline / due date configured in the provider?
+- [ ] For other async methods, is `delayToCancel` aligned with the provider's documented expiry SLA (and never greater than the actual payment validity)?
 
 ## Related skills
 


### PR DESCRIPTION
Replace hardcoded delayToCancel = 604800 (7 days) with method-specific values: Pix (900–3600s aligned with QR code TTL), BankInvoice (aligned with due date), and other async methods (per provider SLA). Clarify the idempotency model for Gateway retries — the connector must not create new charges on retries but may return an evolved status based on locally stored state after callbacks. Add new hard constraint for delayToCancel alignment, expand code examples across existing constraints, and update review checklist accordingly.