### PR TITLE
feat(dx): add contribution guardrails — CI validation, pre-commit hook, and PR feedback

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Line ending normalization
+* text=auto
+*.md text eol=lf
+
+# Auto-generated directories — collapsed in PR diffs
+exports/** linguist-generated=true
+skills/** linguist-generated=true
+rules/** linguist-generated=true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Description
+
+<!-- Briefly describe the changes in this PR -->
+
+---
+
+## Contribution Checklist
+
+Before submitting, please verify:
+
+- [ ] **Source files only**: Edited skill files in `tracks/{track}/skills/{name}/skill.md`, not in `skills/`, `exports/`, or `rules/` directories
+- [ ] **Correct file name**: Skill file is named `skill.md` (lowercase), not `SKILL.md` or other variants
+- [ ] **Frontmatter complete**: Includes `name`, `description`, and `metadata` with `track` and `tags` fields
+- [ ] **Validation passed**: Ran `bun run validate` and all hard checks pass
+- [ ] **Exports regenerated**: Ran `bun run export` and committed both source and generated files
+- [ ] **Skill name format**: Uses kebab-case and is unique across the repository
+- [ ] **Track directory correct**: Track name in frontmatter matches the directory structure
+
+---
+
+## Related Issues
+
+<!-- Link to related issues if applicable -->

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,130 @@
+name: PR Validation
+
+on:
+  pull_request:
+    paths:
+      - 'tracks/**'
+      - 'scripts/**'
+      - '_templates/**'
+      - 'skills/**'
+      - 'exports/**'
+      - 'rules/**'
+      - 'package.json'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: changes
+        run: |
+          changed=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} 2>/dev/null || git diff --name-only HEAD~1)
+
+          source_changed=false
+          generated_changed=false
+
+          if echo "$changed" | grep -q '^tracks/'; then
+            source_changed=true
+          fi
+
+          if echo "$changed" | grep -qE '^(skills/|exports/|rules/)'; then
+            generated_changed=true
+          fi
+
+          echo "source_changed=$source_changed" >> $GITHUB_OUTPUT
+          echo "generated_changed=$generated_changed" >> $GITHUB_OUTPUT
+
+      - name: Warn about generated file edits
+        if: steps.changes.outputs.generated_changed == 'true' && steps.changes.outputs.source_changed == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR=${{ github.event.pull_request.number }}
+
+          {
+            echo "⚠️ **Generated files modified without source changes**"
+            echo ""
+            echo "The following directories are auto-generated from \`tracks/\` and should not be edited directly:"
+            echo "- \`skills/\` — OpenCode export"
+            echo "- \`exports/\` — all platform exports"
+            echo "- \`rules/\` — Cursor rules export"
+            echo ""
+            echo "These files are regenerated on every merge to \`main\`. Any manual edits will be **overwritten**."
+            echo ""
+            echo "👉 Edit the source files in \`tracks/{track}/skills/{name}/skill.md\` instead, then run \`bun run export\`."
+            echo ""
+            echo "<!-- vtex-skills-pr-validation -->"
+          } > /tmp/warning-body.txt
+
+          gh pr comment "$PR" --edit-last --body-file /tmp/warning-body.txt || \
+            gh pr comment "$PR" --body-file /tmp/warning-body.txt
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run validation
+        id: validate
+        shell: bash
+        run: |
+          set +e
+          bun run validate --ci 2>&1 | tee /tmp/validation-output.txt
+          exit_code=${PIPESTATUS[0]}
+          echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
+          exit $exit_code
+
+      - name: Post results
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          EXIT_CODE="${{ steps.validate.outputs.exit_code }}"
+
+          if [ -z "$EXIT_CODE" ]; then
+            SUMMARY="❌ **Validation failed** — setup error, validation did not run"
+          elif [ "$EXIT_CODE" = "0" ]; then
+            SUMMARY="✅ **Validation passed** — all checks OK"
+          else
+            SUMMARY="❌ **Validation failed** — see annotations above"
+          fi
+
+          {
+            echo "$SUMMARY"
+            echo ""
+            if [ "${{ steps.changes.outputs.generated_changed }}" = "true" ] && \
+               [ "${{ steps.changes.outputs.source_changed }}" != "true" ]; then
+              echo "> ⚠️ **Generated files modified without source changes** — edits to \`skills/\`, \`exports/\`, \`rules/\` will be overwritten. Edit \`tracks/\` instead."
+              echo ""
+            fi
+            echo "<details>"
+            echo "<summary>Full validation output</summary>"
+            echo ""
+            echo '```'
+            if [ -f /tmp/validation-output.txt ]; then
+              cat /tmp/validation-output.txt
+            else
+              echo "Validation did not run"
+            fi
+            echo '```'
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "<!-- vtex-skills-pr-validation -->"
+          } > /tmp/comment-body.txt
+
+          gh pr comment "$PR" --edit-last --body-file /tmp/comment-body.txt || \
+            gh pr comment "$PR" --body-file /tmp/comment-body.txt

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+echo "Running skill validation..."
+bun run validate
+exit_code=$?
+
+if [ $exit_code -ne 0 ]; then
+  echo ""
+  echo "❌ Pre-commit validation failed!"
+  echo "Fix the issues above, then try committing again."
+  echo "To skip this check: git commit --no-verify"
+fi
+
+exit $exit_code

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@types/node": "^25.5.0",
         "fast-check": "^4.6.0",
         "glob": "^13.0.6",
+        "husky": "^9.1.7",
       },
     },
   },
@@ -32,6 +33,8 @@
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "description": "VTEX External Developer Skills - AI agent skills for VTEX platform development",
   "scripts": {
+    "prepare": "husky",
     "export": "bun run scripts/export.ts",
     "validate": "bun run scripts/validate.ts",
     "export:cursor": "bun run scripts/export.ts --platform cursor",
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@types/node": "^25.5.0",
     "fast-check": "^4.6.0",
-    "glob": "^13.0.6"
+    "glob": "^13.0.6",
+    "husky": "^9.1.7"
   }
 }

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -500,6 +500,7 @@ const validationChecks: ValidationCheck[] = [
 ];
 
 async function main(): Promise<void> {
+  const ciMode = process.argv.includes("--ci");
   const skills = discoverSkills();
 
   if (skills.length === 0) {
@@ -569,6 +570,12 @@ async function main(): Promise<void> {
       for (const f of softFailures) {
         const lineInfo = f.line !== undefined ? ` (line ${f.line})` : "";
         console.log(`   WARN: [${f.checkName}] — ${f.message}${lineInfo}`);
+        if (ciMode) {
+          const lineParam = f.line !== undefined ? `,line=${f.line}` : "";
+          console.log(
+            `::warning file=${skill.filePath}${lineParam},title=${f.checkName}::${f.message}`
+          );
+        }
       }
       totalWarned++;
     } else {
@@ -578,10 +585,22 @@ async function main(): Promise<void> {
       for (const f of hardFailures) {
         const lineInfo = f.line !== undefined ? ` (line ${f.line})` : "";
         console.log(`   FAIL: [${f.checkName}] — ${f.message}${lineInfo}`);
+        if (ciMode) {
+          const lineParam = f.line !== undefined ? `,line=${f.line}` : "";
+          console.log(
+            `::error file=${skill.filePath}${lineParam},title=${f.checkName}::${f.message}`
+          );
+        }
       }
       for (const f of softFailures) {
         const lineInfo = f.line !== undefined ? ` (line ${f.line})` : "";
         console.log(`   WARN: [${f.checkName}] — ${f.message}${lineInfo}`);
+        if (ciMode) {
+          const lineParam = f.line !== undefined ? `,line=${f.line}` : "";
+          console.log(
+            `::warning file=${skill.filePath}${lineParam},title=${f.checkName}::${f.message}`
+          );
+        }
       }
       totalFailed++;
     }

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1,6 +1,6 @@
 import { readFileSync, readdirSync, statSync } from "fs";
 import matter from "gray-matter";
-import { join } from "path";
+import { dirname, join } from "path";
 
 interface SkillFrontmatter {
   name: string;
@@ -484,6 +484,53 @@ const globsFormat: ValidationCheck = {
   },
 };
 
+// ─── Check 12: Filename Casing ─────────────────────────────────────────────
+const filenameCasing: ValidationCheck = {
+  name: "filename-casing",
+  severity: "hard",
+  check(skill: Skill): ValidationResult[] {
+    const skillDir = dirname(skill.filePath);
+    const results: ValidationResult[] = [];
+
+    try {
+      const files = readdirSync(skillDir);
+      const markdownFiles = files.filter((f) => f.endsWith(".md"));
+
+      // Check if skill.md exists with correct casing
+      if (markdownFiles.includes("skill.md")) {
+        results.push({ passed: true, message: `File is correctly named "skill.md"` });
+        return results;
+      }
+
+      // Check for case-insensitive matches (e.g., SKILL.md, Skill.md)
+      const wrongCasing = markdownFiles.find(
+        (f) => f.toLowerCase() === "skill.md" && f !== "skill.md"
+      );
+
+      if (wrongCasing) {
+        results.push({
+          passed: false,
+          message: `Source file must be named "skill.md" (lowercase), found "${wrongCasing}"`,
+        });
+        return results;
+      }
+
+      // If no markdown file found at all
+      results.push({
+        passed: false,
+        message: `No "skill.md" file found in directory`,
+      });
+    } catch (error) {
+      results.push({
+        passed: false,
+        message: `Could not read directory: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+
+    return results;
+  },
+};
+
 // ─── All checks ─────────────────────────────────────────────────────────────────
 const validationChecks: ValidationCheck[] = [
   yamlValidity,
@@ -497,6 +544,7 @@ const validationChecks: ValidationCheck[] = [
   sizeBounds,
   trackConsistency,
   globsFormat,
+  filenameCasing,
 ];
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Summary

Add layered feedback mechanisms to prevent common contribution errors (editing generated directories, wrong filename casing, missing metadata):

- **PR validation workflow** with inline GitHub Actions annotations and smart generated-file detection
- **Validator `--ci` flag** emitting `::error`/`::warning` workflow commands for PR annotations
- **Filename casing hard check** catching `SKILL.md` vs `skill.md` mismatches (macOS vs Linux)
- **`.gitattributes`** marking generated dirs (`exports/`, `skills/`, `rules/`) as collapsed in PR diffs
- **Husky pre-commit hook** running `bun run validate` before every commit
- **PR template** with 7-item contribution checklist

## Motivation

PR #56 edited `skills/` (auto-generated) instead of `tracks/` (source). PR #57 used `SKILL.md` instead of `skill.md` and was missing required metadata. These guardrails catch those classes of errors at multiple stages: locally (pre-commit), on PR (CI annotations + smart comments), and visually (collapsed generated diffs + checklist).

## Changes

| File | What |
|------|------|
| `scripts/validate.ts` | `--ci` flag + `filename-casing` hard check (12 checks: 8 hard, 4 soft) |
| `.github/workflows/pr-validation.yml` | PR workflow: detect changes → smart warning → validate --ci → post results |
| `.husky/pre-commit` | Pre-commit hook running `bun run validate` |
| `.gitattributes` | `linguist-generated=true` on `exports/**`, `skills/**`, `rules/**` |
| `.github/pull_request_template.md` | 7-item contribution checklist |
| `package.json` | husky devDep + `prepare` script |

## Design Decisions

- **Zero new third-party Actions** — uses only `actions/checkout`, `oven-sh/setup-bun`, plus `bash`/`gh` CLI
- **Smart detection** — warns about generated file edits only when source (`tracks/`) is NOT also changed
- **`--edit-last` comment strategy** — prevents comment spam on multiple pushes to the same PR
- **Pre-commit is convenience, CI is the gate** — hook can be bypassed with `--no-verify`
- **Backward compatible** — `bun run validate` (no flag) produces identical output to before

## Verification

All 4 final verification reviewers passed:
- ✅ Plan Compliance: Must Have [4/4] · Must NOT Have [7/7] · Tasks [6/6]
- ✅ Code Quality: Build [PASS] · Files [6 clean / 0 issues]
- ✅ Manual QA: Scenarios [10/10] · Integration [2/2] · Edge Cases [3]
- ✅ Scope Fidelity: Tasks [6/6 compliant] · Contamination [CLEAN] · Unaccounted [CLEAN]