### PR TITLE
feat(sales-app): sales app extensibility skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">VTEX Skills</h1>
 <p align="center">
-  <strong>39 AI agent skills for VTEX platform development — one source, six export formats.</strong>
+  <strong>40 AI agent skills for VTEX platform development — one source, six export formats.</strong>
 </p>
 <p align="center">
   <a href="#quick-start">Quick Start</a> •
@@ -13,8 +13,8 @@
   <a href="#contributing">Contributing</a>
 </p>
 <p align="center">
-  <img src="https://img.shields.io/badge/skills-39-F71963" alt="39 skills">
-  <img src="https://img.shields.io/badge/tracks-6-blue" alt="6 tracks">
+  <img src="https://img.shields.io/badge/skills-40-F71963" alt="40 skills">
+  <img src="https://img.shields.io/badge/tracks-7-blue" alt="7 tracks">
   <img src="https://img.shields.io/badge/platforms-6-green" alt="6 platforms">
   <img src="https://img.shields.io/github/license/vtex/skills" alt="License">
   <img src="https://img.shields.io/github/actions/workflow/status/vtex/skills/generate-exports.yml?label=exports" alt="Build">
@@ -205,6 +205,17 @@ BFF architecture, Intelligent Search API, checkout proxy patterns, and caching s
 
 </details>
 
+<details>
+<summary><strong>Track 7: Sales App Extension Development</strong> — 1 skill for Sales App extensions</summary>
+
+Complete 6-step workflow for building VTEX Sales App extensions. Covers extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, secure API integration patterns, code generation, validation, and deployment.
+
+| Skill | Description |
+|---|---|
+| `sales-app-extensibility` | Full lifecycle of Sales App extension development — prerequisites, discovery, code generation, validation, and deployment |
+
+</details>
+
 ---
 
 ## Open Plugins / Cursor Directory
@@ -258,6 +269,13 @@ vtex_skills/
         marketplace-rate-limiting/skill.md
     payment/
       index.md
+      skills/
+        payment-provider-protocol/skill.md
+        ...
+    sales-app/
+      index.md
+      skills/
+        sales-app-extensibility/skill.md
       skills/
         payment-provider-protocol/skill.md
         payment-provider-framework/skill.md

--- a/exports/agents-md/AGENTS.md
+++ b/exports/agents-md/AGENTS.md
@@ -43,6 +43,12 @@ See [`payment/AGENTS.md`](./payment/AGENTS.md) for detailed instructions.
   - **payment-provider-framework**: Apply when designing or implementing a Payment Connector in VTEX IO. Covers PPF implementation, TypeScript 3.9.7 builder-hub constraints and safe dependency resolutions, configuration.json schema validation, PaymentProviderService clients wiring, Secure Proxy scope (authorize-only), ExternalClient vs SecureExternalClient patterns, IOContext access, PPF response helpers, PSP integration checklist, and vtex link debugging. Use for any implementation of a Payment Connector hosted in VTEX IO.
   - **payment-provider-protocol**: Apply when implementing a VTEX Payment Provider Protocol (PPP) connector or working with payment/connector endpoint files. Covers all nine required endpoints: Manifest, Create Payment, Cancel, Capture/Settle, Refund, Inbound Request, Create Auth Token, Provider Auth Redirect, and Get Credentials. Use for building or debugging any payment connector that integrates with the VTEX Payment Gateway.
 
+## sales-app
+
+See [`sales-app/AGENTS.md`](./sales-app/AGENTS.md) for detailed instructions.
+
+  - **sales-app-extensibility**: Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns.
+
 ## Custom VTEX IO Apps
 
 See [`vtex-io/AGENTS.md`](./vtex-io/AGENTS.md) for detailed instructions.

--- a/exports/agents-md/AGENTS.md
+++ b/exports/agents-md/AGENTS.md
@@ -47,7 +47,7 @@ See [`payment/AGENTS.md`](./payment/AGENTS.md) for detailed instructions.
 
 See [`sales-app/AGENTS.md`](./sales-app/AGENTS.md) for detailed instructions.
 
-  - **sales-app-extensibility**: Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns.
+  - **sales-app-extensibility**: Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 7-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, secure API integration patterns, and API documentation ingestion (OpenAPI, URLs, or inline specs) to generate typed integrations.
 
 ## Custom VTEX IO Apps
 

--- a/exports/agents-md/sales-app/AGENTS.md
+++ b/exports/agents-md/sales-app/AGENTS.md
@@ -1,0 +1,389 @@
+# AGENTS.md — sales-app
+
+These instructions guide AI agents working on VTEX sales-app tasks.
+Follow these patterns and constraints when assisting developers.
+
+## sales-app-extensibility
+
+> Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns.
+
+# Sales App Extensibility
+
+## When this skill applies
+
+Use this skill when building, customizing, or deploying extensions for VTEX Sales App.
+
+- Adding features to the cart page (promotions, loyalty, services)
+- Adding features to the Product Detail Page (badges, recommendations, warranties)
+- Adding features to the menu (user profile, navigation, metrics)
+- Integrating external APIs into Sales App extensions
+- Generating, scaffolding, or validating extension code for Sales App
+
+Do not use this skill for:
+- Regular FastStore storefront customization (use `faststore-storefront`)
+- Building VTEX IO apps (use `vtex-io-*` skills)
+- Sales App core development or framework modifications
+
+### Prerequisite: FastStore project
+
+The project root must contain: `biome.json`, `faststore.json`, `package.json`, `tsconfig.json`, `turbo.json`.
+
+If any are missing, **STOP**. The user must install FastStore first:
+
+```bash
+npx @vtex/fsp-cli init
+# Prompt: "What is the application name?" → enter name or press Enter for default
+cd <application-name> && yarn
+```
+
+Documentation: https://beta.fast.store/getting-started
+
+### Prerequisite: Sales App module
+
+Inside the FastStore project, a Sales App workspace must exist (typically at `packages/sales-app`) with `src/`, `package.json`, and `tsconfig.json`. Check root `package.json` `"workspaces"` for a path containing `sales-app`. If missing, **STOP**:
+
+```bash
+yarn add @vtex/sales-app -D -W
+npx fsp create
+# Prompts: account name → "Sales App" → path (default or custom)
+# Then add the path to root package.json "workspaces" array
+yarn install
+```
+
+Documentation: https://beta.fast.store/sales-app/setting-up
+
+**Do NOT proceed to discovery or code generation until both prerequisites are confirmed.**
+
+## Decision rules
+
+Follow the mandatory 6-step workflow in order. Do not skip steps.
+
+| Step | Purpose | Gate |
+|------|---------|------|
+| 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
+| 1 | Discovery | Understand what the user wants to build |
+| 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
+| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 4 | Local Testing | Provide dev commands and URLs |
+| 5 | Build & Deploy | Build command → deployment guide |
+
+### Extension point selection
+
+| Extension Point | Category | Available Hooks | Layout Shift |
+|----------------|----------|----------------|--------------|
+| `cart.cart-list.after` | Cart | useCart, useExtension | No |
+| `cart.cart-item.after` | Cart | useCart, useCartItem, useExtension | Yes |
+| `cart.order-summary.after` | Cart | useCart, useExtension | Yes |
+| `pdp.sidebar.before` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.sidebar.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.content.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `menu.item` | Menu | useExtension | No |
+| `menu.drawer-content` | Menu | useCurrentUser, useExtension | No |
+
+### Hook availability
+
+- **useCart** → all cart + PDP extensions
+- **useCartItem** → `cart.cart-item.after` only
+- **useCurrentUser** → `menu.drawer-content` only
+- **usePDP** → PDP extensions only
+- **useExtension** → all extension points
+
+### Template selection
+
+- No API + no hooks → **simple template**
+- No API + hooks → **hook template**
+- API + no auth → **API template**
+- API + VTEX IO proxy → **IO proxy template** (recommended)
+- API + direct auth → **direct auth template** (insecure, warn user)
+
+### API authentication strategy
+
+1. **Recommended: VTEX IO Proxy App** — IO app stores keys server-side. Extension uses `credentials: 'include'` with a **relative path** (`/_v/my-api/data`).
+2. **Insecure: Direct Auth** — Keys in frontend code, visible in browser. Testing/development only.
+
+## Hard constraints
+
+### Constraint: Component must return JSX.Element, never null
+
+`defineExtensions` expects `ExtensionPointComponent` which returns `Element`, not `Element | null`.
+
+**Why this matters**
+Returning `null` causes a TypeScript compilation error. The build will fail.
+
+**Detection**
+`return null` in any component registered with `defineExtensions`.
+
+**Correct**
+
+```typescript
+export function MyExtension(): JSX.Element {
+  if (!data) return (<></>);
+  return <div>{data.value}</div>;
+}
+```
+
+**Wrong**
+
+```typescript
+export function MyExtension(): JSX.Element | null {
+  if (!data) return null;
+  return <div>{data.value}</div>;
+}
+```
+
+### Constraint: Guard optional properties before use
+
+`CartItem.manualPrice` (number | undefined), `CartItem.productRefId` (string | undefined), `CartItem.attachments` (Attachment[] | undefined) must be guarded.
+
+**Why this matters**
+TypeScript strict mode rejects accessing possibly-undefined values.
+
+**Detection**
+`item.manualPrice`, `item.productRefId`, or `item.attachments` without `?.`, `??`, `&&`, or `!= null`.
+
+**Correct**
+
+```typescript
+const price = item.manualPrice ?? item.sellingPrice;
+const refId = item.productRefId ?? 'N/A';
+const count = item.attachments?.length ?? 0;
+```
+
+**Wrong**
+
+```typescript
+const price = item.manualPrice;
+const refId = item.productRefId.toUpperCase();
+const count = item.attachments.length;
+```
+
+### Constraint: useCartItem().item may be undefined
+
+`item` from `useCartItem()` is `CartItem | undefined`.
+
+**Why this matters**
+Accessing properties on `undefined` causes a runtime crash.
+
+**Detection**
+Destructured `item` from `useCartItem()` used without `if (!item)` guard.
+
+**Correct**
+
+```typescript
+const { item } = useCartItem();
+if (!item) return (<></>);
+return <div>{item.name}</div>;
+```
+
+**Wrong**
+
+```typescript
+const { item } = useCartItem();
+return <div>{item.name}</div>;
+```
+
+### Constraint: Never expose authentication keys in frontend code
+
+API keys in `fetch` headers are visible in the browser network tab.
+
+**Why this matters**
+Leaked keys compromise the external service.
+
+**Detection**
+Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
+
+**Correct**
+
+```typescript
+const response = await fetch('/_v/my-api/data', {
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+**Wrong**
+
+```typescript
+const response = await fetch('https://api.example.com/data', {
+  headers: { 'x-api-key': 'sk-secret-key-12345' },
+});
+```
+
+### Constraint: IO Proxy must use relative paths only
+
+The Sales App internal proxy resolves the domain automatically.
+
+**Why this matters**
+A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
+
+**Detection**
+`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
+
+**Correct**
+
+```typescript
+await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
+```
+
+**Wrong**
+
+```typescript
+await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
+```
+
+### Constraint: defineExtensions is required in index.tsx
+
+Entry point must use `defineExtensions` from `@vtex/sales-app`.
+
+**Why this matters**
+Without it, the build succeeds but no extensions render.
+
+**Detection**
+Missing `defineExtensions` import or call in `index.tsx`.
+
+**Correct**
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+export default defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+import { MyExtension } from './components/MyExtension';
+export default { 'cart.cart-list.after': MyExtension };
+```
+
+### Constraint: Extension point names must match exactly
+
+IDs are a fixed set. Non-existent names silently fail.
+
+**Why this matters**
+The extension renders nowhere. No build error — invisible at runtime.
+
+**Detection**
+Any name not in: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`, `menu.item`, `menu.drawer-content`.
+
+**Correct**
+
+```typescript
+defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+defineExtensions({ 'cart.list.after': MyExtension });
+```
+
+### Constraint: Hooks must be used in compatible extension points
+
+Each hook has an `available_in` restriction.
+
+**Why this matters**
+Hook context is only mounted for specific extension points. Using elsewhere throws runtime errors.
+
+**Detection**
+`useCartItem` in PDP/menu. `useCurrentUser` in cart. `usePDP` in menu/cart-list.
+
+**Correct**
+
+```typescript
+// useCartItem in cart.cart-item.after ✓
+defineExtensions({ 'cart.cart-item.after': ItemWarranty });
+```
+
+**Wrong**
+
+```typescript
+// useCartItem in pdp.sidebar.after ✗ — will fail at runtime
+defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
+```
+
+### Constraint: Always present execution plan and wait for approval
+
+Do not generate code until the user confirms the plan.
+
+**Why this matters**
+Generating without agreement wastes effort and may produce the wrong extension.
+
+**Detection**
+Jumping from discovery to code generation without presenting a plan.
+
+**Correct**
+Discovery → Requirements → Present plan → **User approves** → Generate code.
+
+**Wrong**
+Discovery → Generate code immediately.
+
+## Preferred pattern
+
+### Workflow overview
+
+**Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
+
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+
+**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+
+**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+## Reference Files
+
+Load these on demand based on what the task requires. Do not load all of them upfront.
+
+| File | Load when… |
+|------|-----------|
+| [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+
+## Common failure modes
+
+- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
+- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
+- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
+- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
+- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
+- **Placing code outside packages/sales-app/src/** — Not included in build.
+- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
+- **Not presenting plan** — User may want a different approach. Always confirm.
+- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+
+## Review checklist
+
+- [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
+- [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
+- [ ] Discovery completed and use case identified?
+- [ ] Execution plan approved by user?
+- [ ] Extension point is valid (from the 8-point reference)?
+- [ ] Hooks compatible with chosen extension point?
+- [ ] Component returns JSX.Element, never null?
+- [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
+- [ ] useCartItem().item checked for undefined?
+- [ ] No auth credentials exposed in frontend code?
+- [ ] IO Proxy uses relative path (/_v/...)?
+- [ ] defineExtensions configured in index.tsx?
+- [ ] CSS file path matches component name?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+## Related skills
+
+- `faststore-storefront` — storefront customization outside Sales App
+- `vtex-io-app-contract` — building VTEX IO proxy apps for secure API integration
+
+## Reference
+
+- Sales App setup: https://beta.fast.store/sales-app/setting-up
+- FastStore getting started: https://beta.fast.store/getting-started
+- VTEX Sales App documentation: https://help.vtex.com/en/tracks/instore-getting-started-and-setting-up
+- VTEX IO app development: https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-an-app

--- a/exports/agents-md/sales-app/AGENTS.md
+++ b/exports/agents-md/sales-app/AGENTS.md
@@ -5,7 +5,7 @@ Follow these patterns and constraints when assisting developers.
 
 ## sales-app-extensibility
 
-> Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns.
+> Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 7-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, secure API integration patterns, and API documentation ingestion (OpenAPI, URLs, or inline specs) to generate typed integrations.
 
 # Sales App Extensibility
 
@@ -64,8 +64,9 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
 | 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
-| 4 | Local Testing | Provide dev commands and URLs |
-| 5 | Build & Deploy | Build command → deployment guide |
+| 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
+| 5 | Local Testing | Provide dev commands and URLs |
+| 6 | Build & Deploy | Build command → deployment guide |
 
 ### Extension point selection
 
@@ -95,6 +96,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 - API + no auth → **API template**
 - API + VTEX IO proxy → **IO proxy template** (recommended)
 - API + direct auth → **direct auth template** (insecure, warn user)
+- API doc provided → generate TypeScript interfaces from extracted response shapes; no API doc → use `${DATA_INTERFACE}` placeholder
 
 ### API authentication strategy
 
@@ -324,15 +326,67 @@ Discovery → Generate code immediately.
 
 **Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
 
-**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
-**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
-**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS module file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+Template for the documentation file:
+
+````markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.module.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+````
+
+**Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 6** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
 ## Reference Files
 
@@ -343,7 +397,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
-| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 
 ## Common failure modes
 
@@ -357,6 +411,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
+- **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
+- **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
 
 ## Review checklist
 
@@ -373,6 +431,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
 - [ ] CSS file path matches component name?
+- [ ] Documentation generated at `docs/<ExtensionName>.md`?
+- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/claude/sales-app-sales-app-extensibility.md
+++ b/exports/claude/sales-app-sales-app-extensibility.md
@@ -1,4 +1,4 @@
-This skill provides guidance for AI agents working with VTEX sales-app. Apply these constraints and patterns when assisting developers with apply when building, customizing, or deploying extensions for vtex sales app. covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, pdp, menu), react hooks (usecart, usepdp, usecartitem, usecurrentuser, useextension), typescript types, and secure api integration patterns.
+This skill provides guidance for AI agents working with VTEX sales-app. Apply these constraints and patterns when assisting developers with apply when building, customizing, or deploying extensions for vtex sales app. covers the complete 7-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, pdp, menu), react hooks (usecart, usepdp, usecartitem, usecurrentuser, useextension), typescript types, secure api integration patterns, and api documentation ingestion (openapi, urls, or inline specs) to generate typed integrations.
 
 # Sales App Extensibility
 
@@ -57,8 +57,9 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
 | 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
-| 4 | Local Testing | Provide dev commands and URLs |
-| 5 | Build & Deploy | Build command → deployment guide |
+| 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
+| 5 | Local Testing | Provide dev commands and URLs |
+| 6 | Build & Deploy | Build command → deployment guide |
 
 ### Extension point selection
 
@@ -88,6 +89,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 - API + no auth → **API template**
 - API + VTEX IO proxy → **IO proxy template** (recommended)
 - API + direct auth → **direct auth template** (insecure, warn user)
+- API doc provided → generate TypeScript interfaces from extracted response shapes; no API doc → use `${DATA_INTERFACE}` placeholder
 
 ### API authentication strategy
 
@@ -317,15 +319,67 @@ Discovery → Generate code immediately.
 
 **Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
 
-**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
-**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
-**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS module file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+Template for the documentation file:
+
+````markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.module.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+````
+
+**Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 6** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
 ## Reference Files
 
@@ -336,7 +390,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
-| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 
 ## Common failure modes
 
@@ -350,6 +404,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
+- **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
+- **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
 
 ## Review checklist
 
@@ -366,6 +424,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
 - [ ] CSS file path matches component name?
+- [ ] Documentation generated at `docs/<ExtensionName>.md`?
+- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/claude/sales-app-sales-app-extensibility.md
+++ b/exports/claude/sales-app-sales-app-extensibility.md
@@ -1,0 +1,382 @@
+This skill provides guidance for AI agents working with VTEX sales-app. Apply these constraints and patterns when assisting developers with apply when building, customizing, or deploying extensions for vtex sales app. covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, pdp, menu), react hooks (usecart, usepdp, usecartitem, usecurrentuser, useextension), typescript types, and secure api integration patterns.
+
+# Sales App Extensibility
+
+## When this skill applies
+
+Use this skill when building, customizing, or deploying extensions for VTEX Sales App.
+
+- Adding features to the cart page (promotions, loyalty, services)
+- Adding features to the Product Detail Page (badges, recommendations, warranties)
+- Adding features to the menu (user profile, navigation, metrics)
+- Integrating external APIs into Sales App extensions
+- Generating, scaffolding, or validating extension code for Sales App
+
+Do not use this skill for:
+- Regular FastStore storefront customization (use `faststore-storefront`)
+- Building VTEX IO apps (use `vtex-io-*` skills)
+- Sales App core development or framework modifications
+
+### Prerequisite: FastStore project
+
+The project root must contain: `biome.json`, `faststore.json`, `package.json`, `tsconfig.json`, `turbo.json`.
+
+If any are missing, **STOP**. The user must install FastStore first:
+
+```bash
+npx @vtex/fsp-cli init
+# Prompt: "What is the application name?" → enter name or press Enter for default
+cd <application-name> && yarn
+```
+
+Documentation: https://beta.fast.store/getting-started
+
+### Prerequisite: Sales App module
+
+Inside the FastStore project, a Sales App workspace must exist (typically at `packages/sales-app`) with `src/`, `package.json`, and `tsconfig.json`. Check root `package.json` `"workspaces"` for a path containing `sales-app`. If missing, **STOP**:
+
+```bash
+yarn add @vtex/sales-app -D -W
+npx fsp create
+# Prompts: account name → "Sales App" → path (default or custom)
+# Then add the path to root package.json "workspaces" array
+yarn install
+```
+
+Documentation: https://beta.fast.store/sales-app/setting-up
+
+**Do NOT proceed to discovery or code generation until both prerequisites are confirmed.**
+
+## Decision rules
+
+Follow the mandatory 6-step workflow in order. Do not skip steps.
+
+| Step | Purpose | Gate |
+|------|---------|------|
+| 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
+| 1 | Discovery | Understand what the user wants to build |
+| 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
+| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 4 | Local Testing | Provide dev commands and URLs |
+| 5 | Build & Deploy | Build command → deployment guide |
+
+### Extension point selection
+
+| Extension Point | Category | Available Hooks | Layout Shift |
+|----------------|----------|----------------|--------------|
+| `cart.cart-list.after` | Cart | useCart, useExtension | No |
+| `cart.cart-item.after` | Cart | useCart, useCartItem, useExtension | Yes |
+| `cart.order-summary.after` | Cart | useCart, useExtension | Yes |
+| `pdp.sidebar.before` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.sidebar.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.content.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `menu.item` | Menu | useExtension | No |
+| `menu.drawer-content` | Menu | useCurrentUser, useExtension | No |
+
+### Hook availability
+
+- **useCart** → all cart + PDP extensions
+- **useCartItem** → `cart.cart-item.after` only
+- **useCurrentUser** → `menu.drawer-content` only
+- **usePDP** → PDP extensions only
+- **useExtension** → all extension points
+
+### Template selection
+
+- No API + no hooks → **simple template**
+- No API + hooks → **hook template**
+- API + no auth → **API template**
+- API + VTEX IO proxy → **IO proxy template** (recommended)
+- API + direct auth → **direct auth template** (insecure, warn user)
+
+### API authentication strategy
+
+1. **Recommended: VTEX IO Proxy App** — IO app stores keys server-side. Extension uses `credentials: 'include'` with a **relative path** (`/_v/my-api/data`).
+2. **Insecure: Direct Auth** — Keys in frontend code, visible in browser. Testing/development only.
+
+## Hard constraints
+
+### Constraint: Component must return JSX.Element, never null
+
+`defineExtensions` expects `ExtensionPointComponent` which returns `Element`, not `Element | null`.
+
+**Why this matters**
+Returning `null` causes a TypeScript compilation error. The build will fail.
+
+**Detection**
+`return null` in any component registered with `defineExtensions`.
+
+**Correct**
+
+```typescript
+export function MyExtension(): JSX.Element {
+  if (!data) return (<></>);
+  return <div>{data.value}</div>;
+}
+```
+
+**Wrong**
+
+```typescript
+export function MyExtension(): JSX.Element | null {
+  if (!data) return null;
+  return <div>{data.value}</div>;
+}
+```
+
+### Constraint: Guard optional properties before use
+
+`CartItem.manualPrice` (number | undefined), `CartItem.productRefId` (string | undefined), `CartItem.attachments` (Attachment[] | undefined) must be guarded.
+
+**Why this matters**
+TypeScript strict mode rejects accessing possibly-undefined values.
+
+**Detection**
+`item.manualPrice`, `item.productRefId`, or `item.attachments` without `?.`, `??`, `&&`, or `!= null`.
+
+**Correct**
+
+```typescript
+const price = item.manualPrice ?? item.sellingPrice;
+const refId = item.productRefId ?? 'N/A';
+const count = item.attachments?.length ?? 0;
+```
+
+**Wrong**
+
+```typescript
+const price = item.manualPrice;
+const refId = item.productRefId.toUpperCase();
+const count = item.attachments.length;
+```
+
+### Constraint: useCartItem().item may be undefined
+
+`item` from `useCartItem()` is `CartItem | undefined`.
+
+**Why this matters**
+Accessing properties on `undefined` causes a runtime crash.
+
+**Detection**
+Destructured `item` from `useCartItem()` used without `if (!item)` guard.
+
+**Correct**
+
+```typescript
+const { item } = useCartItem();
+if (!item) return (<></>);
+return <div>{item.name}</div>;
+```
+
+**Wrong**
+
+```typescript
+const { item } = useCartItem();
+return <div>{item.name}</div>;
+```
+
+### Constraint: Never expose authentication keys in frontend code
+
+API keys in `fetch` headers are visible in the browser network tab.
+
+**Why this matters**
+Leaked keys compromise the external service.
+
+**Detection**
+Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
+
+**Correct**
+
+```typescript
+const response = await fetch('/_v/my-api/data', {
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+**Wrong**
+
+```typescript
+const response = await fetch('https://api.example.com/data', {
+  headers: { 'x-api-key': 'sk-secret-key-12345' },
+});
+```
+
+### Constraint: IO Proxy must use relative paths only
+
+The Sales App internal proxy resolves the domain automatically.
+
+**Why this matters**
+A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
+
+**Detection**
+`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
+
+**Correct**
+
+```typescript
+await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
+```
+
+**Wrong**
+
+```typescript
+await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
+```
+
+### Constraint: defineExtensions is required in index.tsx
+
+Entry point must use `defineExtensions` from `@vtex/sales-app`.
+
+**Why this matters**
+Without it, the build succeeds but no extensions render.
+
+**Detection**
+Missing `defineExtensions` import or call in `index.tsx`.
+
+**Correct**
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+export default defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+import { MyExtension } from './components/MyExtension';
+export default { 'cart.cart-list.after': MyExtension };
+```
+
+### Constraint: Extension point names must match exactly
+
+IDs are a fixed set. Non-existent names silently fail.
+
+**Why this matters**
+The extension renders nowhere. No build error — invisible at runtime.
+
+**Detection**
+Any name not in: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`, `menu.item`, `menu.drawer-content`.
+
+**Correct**
+
+```typescript
+defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+defineExtensions({ 'cart.list.after': MyExtension });
+```
+
+### Constraint: Hooks must be used in compatible extension points
+
+Each hook has an `available_in` restriction.
+
+**Why this matters**
+Hook context is only mounted for specific extension points. Using elsewhere throws runtime errors.
+
+**Detection**
+`useCartItem` in PDP/menu. `useCurrentUser` in cart. `usePDP` in menu/cart-list.
+
+**Correct**
+
+```typescript
+// useCartItem in cart.cart-item.after ✓
+defineExtensions({ 'cart.cart-item.after': ItemWarranty });
+```
+
+**Wrong**
+
+```typescript
+// useCartItem in pdp.sidebar.after ✗ — will fail at runtime
+defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
+```
+
+### Constraint: Always present execution plan and wait for approval
+
+Do not generate code until the user confirms the plan.
+
+**Why this matters**
+Generating without agreement wastes effort and may produce the wrong extension.
+
+**Detection**
+Jumping from discovery to code generation without presenting a plan.
+
+**Correct**
+Discovery → Requirements → Present plan → **User approves** → Generate code.
+
+**Wrong**
+Discovery → Generate code immediately.
+
+## Preferred pattern
+
+### Workflow overview
+
+**Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
+
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+
+**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+
+**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+## Reference Files
+
+Load these on demand based on what the task requires. Do not load all of them upfront.
+
+| File | Load when… |
+|------|-----------|
+| [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+
+## Common failure modes
+
+- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
+- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
+- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
+- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
+- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
+- **Placing code outside packages/sales-app/src/** — Not included in build.
+- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
+- **Not presenting plan** — User may want a different approach. Always confirm.
+- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+
+## Review checklist
+
+- [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
+- [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
+- [ ] Discovery completed and use case identified?
+- [ ] Execution plan approved by user?
+- [ ] Extension point is valid (from the 8-point reference)?
+- [ ] Hooks compatible with chosen extension point?
+- [ ] Component returns JSX.Element, never null?
+- [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
+- [ ] useCartItem().item checked for undefined?
+- [ ] No auth credentials exposed in frontend code?
+- [ ] IO Proxy uses relative path (/_v/...)?
+- [ ] defineExtensions configured in index.tsx?
+- [ ] CSS file path matches component name?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+## Related skills
+
+- `faststore-storefront` — storefront customization outside Sales App
+- `vtex-io-app-contract` — building VTEX IO proxy apps for secure API integration
+
+## Reference
+
+- Sales App setup: https://beta.fast.store/sales-app/setting-up
+- FastStore getting started: https://beta.fast.store/getting-started
+- VTEX Sales App documentation: https://help.vtex.com/en/tracks/instore-getting-started-and-setting-up
+- VTEX IO app development: https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-an-app

--- a/exports/claude/sales-app.md
+++ b/exports/claude/sales-app.md
@@ -1,4 +1,4 @@
-This skill provides guidance for AI agents working with VTEX sales-app. Apply these constraints and patterns when assisting developers with apply when building, customizing, or deploying extensions for vtex sales app. covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, pdp, menu), react hooks (usecart, usepdp, usecartitem, usecurrentuser, useextension), typescript types, and secure api integration patterns.
+This skill provides guidance for AI agents working with VTEX sales-app. Apply these constraints and patterns when assisting developers with apply when building, customizing, or deploying extensions for vtex sales app. covers the complete 7-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, pdp, menu), react hooks (usecart, usepdp, usecartitem, usecurrentuser, useextension), typescript types, secure api integration patterns, and api documentation ingestion (openapi, urls, or inline specs) to generate typed integrations.
 
 # Sales App Extensibility
 
@@ -57,8 +57,9 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
 | 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
-| 4 | Local Testing | Provide dev commands and URLs |
-| 5 | Build & Deploy | Build command → deployment guide |
+| 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
+| 5 | Local Testing | Provide dev commands and URLs |
+| 6 | Build & Deploy | Build command → deployment guide |
 
 ### Extension point selection
 
@@ -88,6 +89,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 - API + no auth → **API template**
 - API + VTEX IO proxy → **IO proxy template** (recommended)
 - API + direct auth → **direct auth template** (insecure, warn user)
+- API doc provided → generate TypeScript interfaces from extracted response shapes; no API doc → use `${DATA_INTERFACE}` placeholder
 
 ### API authentication strategy
 
@@ -317,15 +319,67 @@ Discovery → Generate code immediately.
 
 **Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
 
-**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
-**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
-**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS module file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+Template for the documentation file:
+
+````markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.module.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+````
+
+**Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 6** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
 ## Reference Files
 
@@ -336,7 +390,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
-| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 
 ## Common failure modes
 
@@ -350,6 +404,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
+- **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
+- **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
 
 ## Review checklist
 
@@ -366,6 +424,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
 - [ ] CSS file path matches component name?
+- [ ] Documentation generated at `docs/<ExtensionName>.md`?
+- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/claude/sales-app.md
+++ b/exports/claude/sales-app.md
@@ -1,0 +1,382 @@
+This skill provides guidance for AI agents working with VTEX sales-app. Apply these constraints and patterns when assisting developers with apply when building, customizing, or deploying extensions for vtex sales app. covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, pdp, menu), react hooks (usecart, usepdp, usecartitem, usecurrentuser, useextension), typescript types, and secure api integration patterns.
+
+# Sales App Extensibility
+
+## When this skill applies
+
+Use this skill when building, customizing, or deploying extensions for VTEX Sales App.
+
+- Adding features to the cart page (promotions, loyalty, services)
+- Adding features to the Product Detail Page (badges, recommendations, warranties)
+- Adding features to the menu (user profile, navigation, metrics)
+- Integrating external APIs into Sales App extensions
+- Generating, scaffolding, or validating extension code for Sales App
+
+Do not use this skill for:
+- Regular FastStore storefront customization (use `faststore-storefront`)
+- Building VTEX IO apps (use `vtex-io-*` skills)
+- Sales App core development or framework modifications
+
+### Prerequisite: FastStore project
+
+The project root must contain: `biome.json`, `faststore.json`, `package.json`, `tsconfig.json`, `turbo.json`.
+
+If any are missing, **STOP**. The user must install FastStore first:
+
+```bash
+npx @vtex/fsp-cli init
+# Prompt: "What is the application name?" → enter name or press Enter for default
+cd <application-name> && yarn
+```
+
+Documentation: https://beta.fast.store/getting-started
+
+### Prerequisite: Sales App module
+
+Inside the FastStore project, a Sales App workspace must exist (typically at `packages/sales-app`) with `src/`, `package.json`, and `tsconfig.json`. Check root `package.json` `"workspaces"` for a path containing `sales-app`. If missing, **STOP**:
+
+```bash
+yarn add @vtex/sales-app -D -W
+npx fsp create
+# Prompts: account name → "Sales App" → path (default or custom)
+# Then add the path to root package.json "workspaces" array
+yarn install
+```
+
+Documentation: https://beta.fast.store/sales-app/setting-up
+
+**Do NOT proceed to discovery or code generation until both prerequisites are confirmed.**
+
+## Decision rules
+
+Follow the mandatory 6-step workflow in order. Do not skip steps.
+
+| Step | Purpose | Gate |
+|------|---------|------|
+| 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
+| 1 | Discovery | Understand what the user wants to build |
+| 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
+| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 4 | Local Testing | Provide dev commands and URLs |
+| 5 | Build & Deploy | Build command → deployment guide |
+
+### Extension point selection
+
+| Extension Point | Category | Available Hooks | Layout Shift |
+|----------------|----------|----------------|--------------|
+| `cart.cart-list.after` | Cart | useCart, useExtension | No |
+| `cart.cart-item.after` | Cart | useCart, useCartItem, useExtension | Yes |
+| `cart.order-summary.after` | Cart | useCart, useExtension | Yes |
+| `pdp.sidebar.before` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.sidebar.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.content.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `menu.item` | Menu | useExtension | No |
+| `menu.drawer-content` | Menu | useCurrentUser, useExtension | No |
+
+### Hook availability
+
+- **useCart** → all cart + PDP extensions
+- **useCartItem** → `cart.cart-item.after` only
+- **useCurrentUser** → `menu.drawer-content` only
+- **usePDP** → PDP extensions only
+- **useExtension** → all extension points
+
+### Template selection
+
+- No API + no hooks → **simple template**
+- No API + hooks → **hook template**
+- API + no auth → **API template**
+- API + VTEX IO proxy → **IO proxy template** (recommended)
+- API + direct auth → **direct auth template** (insecure, warn user)
+
+### API authentication strategy
+
+1. **Recommended: VTEX IO Proxy App** — IO app stores keys server-side. Extension uses `credentials: 'include'` with a **relative path** (`/_v/my-api/data`).
+2. **Insecure: Direct Auth** — Keys in frontend code, visible in browser. Testing/development only.
+
+## Hard constraints
+
+### Constraint: Component must return JSX.Element, never null
+
+`defineExtensions` expects `ExtensionPointComponent` which returns `Element`, not `Element | null`.
+
+**Why this matters**
+Returning `null` causes a TypeScript compilation error. The build will fail.
+
+**Detection**
+`return null` in any component registered with `defineExtensions`.
+
+**Correct**
+
+```typescript
+export function MyExtension(): JSX.Element {
+  if (!data) return (<></>);
+  return <div>{data.value}</div>;
+}
+```
+
+**Wrong**
+
+```typescript
+export function MyExtension(): JSX.Element | null {
+  if (!data) return null;
+  return <div>{data.value}</div>;
+}
+```
+
+### Constraint: Guard optional properties before use
+
+`CartItem.manualPrice` (number | undefined), `CartItem.productRefId` (string | undefined), `CartItem.attachments` (Attachment[] | undefined) must be guarded.
+
+**Why this matters**
+TypeScript strict mode rejects accessing possibly-undefined values.
+
+**Detection**
+`item.manualPrice`, `item.productRefId`, or `item.attachments` without `?.`, `??`, `&&`, or `!= null`.
+
+**Correct**
+
+```typescript
+const price = item.manualPrice ?? item.sellingPrice;
+const refId = item.productRefId ?? 'N/A';
+const count = item.attachments?.length ?? 0;
+```
+
+**Wrong**
+
+```typescript
+const price = item.manualPrice;
+const refId = item.productRefId.toUpperCase();
+const count = item.attachments.length;
+```
+
+### Constraint: useCartItem().item may be undefined
+
+`item` from `useCartItem()` is `CartItem | undefined`.
+
+**Why this matters**
+Accessing properties on `undefined` causes a runtime crash.
+
+**Detection**
+Destructured `item` from `useCartItem()` used without `if (!item)` guard.
+
+**Correct**
+
+```typescript
+const { item } = useCartItem();
+if (!item) return (<></>);
+return <div>{item.name}</div>;
+```
+
+**Wrong**
+
+```typescript
+const { item } = useCartItem();
+return <div>{item.name}</div>;
+```
+
+### Constraint: Never expose authentication keys in frontend code
+
+API keys in `fetch` headers are visible in the browser network tab.
+
+**Why this matters**
+Leaked keys compromise the external service.
+
+**Detection**
+Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
+
+**Correct**
+
+```typescript
+const response = await fetch('/_v/my-api/data', {
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+**Wrong**
+
+```typescript
+const response = await fetch('https://api.example.com/data', {
+  headers: { 'x-api-key': 'sk-secret-key-12345' },
+});
+```
+
+### Constraint: IO Proxy must use relative paths only
+
+The Sales App internal proxy resolves the domain automatically.
+
+**Why this matters**
+A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
+
+**Detection**
+`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
+
+**Correct**
+
+```typescript
+await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
+```
+
+**Wrong**
+
+```typescript
+await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
+```
+
+### Constraint: defineExtensions is required in index.tsx
+
+Entry point must use `defineExtensions` from `@vtex/sales-app`.
+
+**Why this matters**
+Without it, the build succeeds but no extensions render.
+
+**Detection**
+Missing `defineExtensions` import or call in `index.tsx`.
+
+**Correct**
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+export default defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+import { MyExtension } from './components/MyExtension';
+export default { 'cart.cart-list.after': MyExtension };
+```
+
+### Constraint: Extension point names must match exactly
+
+IDs are a fixed set. Non-existent names silently fail.
+
+**Why this matters**
+The extension renders nowhere. No build error — invisible at runtime.
+
+**Detection**
+Any name not in: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`, `menu.item`, `menu.drawer-content`.
+
+**Correct**
+
+```typescript
+defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+defineExtensions({ 'cart.list.after': MyExtension });
+```
+
+### Constraint: Hooks must be used in compatible extension points
+
+Each hook has an `available_in` restriction.
+
+**Why this matters**
+Hook context is only mounted for specific extension points. Using elsewhere throws runtime errors.
+
+**Detection**
+`useCartItem` in PDP/menu. `useCurrentUser` in cart. `usePDP` in menu/cart-list.
+
+**Correct**
+
+```typescript
+// useCartItem in cart.cart-item.after ✓
+defineExtensions({ 'cart.cart-item.after': ItemWarranty });
+```
+
+**Wrong**
+
+```typescript
+// useCartItem in pdp.sidebar.after ✗ — will fail at runtime
+defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
+```
+
+### Constraint: Always present execution plan and wait for approval
+
+Do not generate code until the user confirms the plan.
+
+**Why this matters**
+Generating without agreement wastes effort and may produce the wrong extension.
+
+**Detection**
+Jumping from discovery to code generation without presenting a plan.
+
+**Correct**
+Discovery → Requirements → Present plan → **User approves** → Generate code.
+
+**Wrong**
+Discovery → Generate code immediately.
+
+## Preferred pattern
+
+### Workflow overview
+
+**Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
+
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+
+**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+
+**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+## Reference Files
+
+Load these on demand based on what the task requires. Do not load all of them upfront.
+
+| File | Load when… |
+|------|-----------|
+| [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+
+## Common failure modes
+
+- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
+- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
+- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
+- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
+- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
+- **Placing code outside packages/sales-app/src/** — Not included in build.
+- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
+- **Not presenting plan** — User may want a different approach. Always confirm.
+- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+
+## Review checklist
+
+- [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
+- [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
+- [ ] Discovery completed and use case identified?
+- [ ] Execution plan approved by user?
+- [ ] Extension point is valid (from the 8-point reference)?
+- [ ] Hooks compatible with chosen extension point?
+- [ ] Component returns JSX.Element, never null?
+- [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
+- [ ] useCartItem().item checked for undefined?
+- [ ] No auth credentials exposed in frontend code?
+- [ ] IO Proxy uses relative path (/_v/...)?
+- [ ] defineExtensions configured in index.tsx?
+- [ ] CSS file path matches component name?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+## Related skills
+
+- `faststore-storefront` — storefront customization outside Sales App
+- `vtex-io-app-contract` — building VTEX IO proxy apps for secure API integration
+
+## Reference
+
+- Sales App setup: https://beta.fast.store/sales-app/setting-up
+- FastStore getting started: https://beta.fast.store/getting-started
+- VTEX Sales App documentation: https://help.vtex.com/en/tracks/instore-getting-started-and-setting-up
+- VTEX IO app development: https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-an-app

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -8536,8 +8536,9 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
 | 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
-| 4 | Local Testing | Provide dev commands and URLs |
-| 5 | Build & Deploy | Build command → deployment guide |
+| 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
+| 5 | Local Testing | Provide dev commands and URLs |
+| 6 | Build & Deploy | Build command → deployment guide |
 
 ### Extension point selection
 
@@ -8567,6 +8568,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 - API + no auth → **API template**
 - API + VTEX IO proxy → **IO proxy template** (recommended)
 - API + direct auth → **direct auth template** (insecure, warn user)
+- API doc provided → generate TypeScript interfaces from extracted response shapes; no API doc → use `${DATA_INTERFACE}` placeholder
 
 ### API authentication strategy
 
@@ -8796,15 +8798,67 @@ Discovery → Generate code immediately.
 
 **Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
 
-**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
-**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
-**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS module file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+Template for the documentation file:
+
+````markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.module.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+````
+
+**Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 6** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
 ## Reference Files
 
@@ -8815,7 +8869,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
-| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 
 ## Common failure modes
 
@@ -8829,6 +8883,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
+- **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
+- **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
 
 ## Review checklist
 
@@ -8845,6 +8903,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
 - [ ] CSS file path matches component name?
+- [ ] Documentation generated at `docs/<ExtensionName>.md`?
+- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -8477,6 +8477,391 @@ export default configRouter;
 
 ---
 
+# sales-app
+
+# Sales App Extensibility
+
+## When this skill applies
+
+Use this skill when building, customizing, or deploying extensions for VTEX Sales App.
+
+- Adding features to the cart page (promotions, loyalty, services)
+- Adding features to the Product Detail Page (badges, recommendations, warranties)
+- Adding features to the menu (user profile, navigation, metrics)
+- Integrating external APIs into Sales App extensions
+- Generating, scaffolding, or validating extension code for Sales App
+
+Do not use this skill for:
+- Regular FastStore storefront customization (use `faststore-storefront`)
+- Building VTEX IO apps (use `vtex-io-*` skills)
+- Sales App core development or framework modifications
+
+### Prerequisite: FastStore project
+
+The project root must contain: `biome.json`, `faststore.json`, `package.json`, `tsconfig.json`, `turbo.json`.
+
+If any are missing, **STOP**. The user must install FastStore first:
+
+```bash
+npx @vtex/fsp-cli init
+# Prompt: "What is the application name?" → enter name or press Enter for default
+cd <application-name> && yarn
+```
+
+Documentation: https://beta.fast.store/getting-started
+
+### Prerequisite: Sales App module
+
+Inside the FastStore project, a Sales App workspace must exist (typically at `packages/sales-app`) with `src/`, `package.json`, and `tsconfig.json`. Check root `package.json` `"workspaces"` for a path containing `sales-app`. If missing, **STOP**:
+
+```bash
+yarn add @vtex/sales-app -D -W
+npx fsp create
+# Prompts: account name → "Sales App" → path (default or custom)
+# Then add the path to root package.json "workspaces" array
+yarn install
+```
+
+Documentation: https://beta.fast.store/sales-app/setting-up
+
+**Do NOT proceed to discovery or code generation until both prerequisites are confirmed.**
+
+## Decision rules
+
+Follow the mandatory 6-step workflow in order. Do not skip steps.
+
+| Step | Purpose | Gate |
+|------|---------|------|
+| 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
+| 1 | Discovery | Understand what the user wants to build |
+| 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
+| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 4 | Local Testing | Provide dev commands and URLs |
+| 5 | Build & Deploy | Build command → deployment guide |
+
+### Extension point selection
+
+| Extension Point | Category | Available Hooks | Layout Shift |
+|----------------|----------|----------------|--------------|
+| `cart.cart-list.after` | Cart | useCart, useExtension | No |
+| `cart.cart-item.after` | Cart | useCart, useCartItem, useExtension | Yes |
+| `cart.order-summary.after` | Cart | useCart, useExtension | Yes |
+| `pdp.sidebar.before` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.sidebar.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.content.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `menu.item` | Menu | useExtension | No |
+| `menu.drawer-content` | Menu | useCurrentUser, useExtension | No |
+
+### Hook availability
+
+- **useCart** → all cart + PDP extensions
+- **useCartItem** → `cart.cart-item.after` only
+- **useCurrentUser** → `menu.drawer-content` only
+- **usePDP** → PDP extensions only
+- **useExtension** → all extension points
+
+### Template selection
+
+- No API + no hooks → **simple template**
+- No API + hooks → **hook template**
+- API + no auth → **API template**
+- API + VTEX IO proxy → **IO proxy template** (recommended)
+- API + direct auth → **direct auth template** (insecure, warn user)
+
+### API authentication strategy
+
+1. **Recommended: VTEX IO Proxy App** — IO app stores keys server-side. Extension uses `credentials: 'include'` with a **relative path** (`/_v/my-api/data`).
+2. **Insecure: Direct Auth** — Keys in frontend code, visible in browser. Testing/development only.
+
+## Hard constraints
+
+### Constraint: Component must return JSX.Element, never null
+
+`defineExtensions` expects `ExtensionPointComponent` which returns `Element`, not `Element | null`.
+
+**Why this matters**
+Returning `null` causes a TypeScript compilation error. The build will fail.
+
+**Detection**
+`return null` in any component registered with `defineExtensions`.
+
+**Correct**
+
+```typescript
+export function MyExtension(): JSX.Element {
+  if (!data) return (<></>);
+  return <div>{data.value}</div>;
+}
+```
+
+**Wrong**
+
+```typescript
+export function MyExtension(): JSX.Element | null {
+  if (!data) return null;
+  return <div>{data.value}</div>;
+}
+```
+
+### Constraint: Guard optional properties before use
+
+`CartItem.manualPrice` (number | undefined), `CartItem.productRefId` (string | undefined), `CartItem.attachments` (Attachment[] | undefined) must be guarded.
+
+**Why this matters**
+TypeScript strict mode rejects accessing possibly-undefined values.
+
+**Detection**
+`item.manualPrice`, `item.productRefId`, or `item.attachments` without `?.`, `??`, `&&`, or `!= null`.
+
+**Correct**
+
+```typescript
+const price = item.manualPrice ?? item.sellingPrice;
+const refId = item.productRefId ?? 'N/A';
+const count = item.attachments?.length ?? 0;
+```
+
+**Wrong**
+
+```typescript
+const price = item.manualPrice;
+const refId = item.productRefId.toUpperCase();
+const count = item.attachments.length;
+```
+
+### Constraint: useCartItem().item may be undefined
+
+`item` from `useCartItem()` is `CartItem | undefined`.
+
+**Why this matters**
+Accessing properties on `undefined` causes a runtime crash.
+
+**Detection**
+Destructured `item` from `useCartItem()` used without `if (!item)` guard.
+
+**Correct**
+
+```typescript
+const { item } = useCartItem();
+if (!item) return (<></>);
+return <div>{item.name}</div>;
+```
+
+**Wrong**
+
+```typescript
+const { item } = useCartItem();
+return <div>{item.name}</div>;
+```
+
+### Constraint: Never expose authentication keys in frontend code
+
+API keys in `fetch` headers are visible in the browser network tab.
+
+**Why this matters**
+Leaked keys compromise the external service.
+
+**Detection**
+Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
+
+**Correct**
+
+```typescript
+const response = await fetch('/_v/my-api/data', {
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+**Wrong**
+
+```typescript
+const response = await fetch('https://api.example.com/data', {
+  headers: { 'x-api-key': 'sk-secret-key-12345' },
+});
+```
+
+### Constraint: IO Proxy must use relative paths only
+
+The Sales App internal proxy resolves the domain automatically.
+
+**Why this matters**
+A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
+
+**Detection**
+`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
+
+**Correct**
+
+```typescript
+await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
+```
+
+**Wrong**
+
+```typescript
+await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
+```
+
+### Constraint: defineExtensions is required in index.tsx
+
+Entry point must use `defineExtensions` from `@vtex/sales-app`.
+
+**Why this matters**
+Without it, the build succeeds but no extensions render.
+
+**Detection**
+Missing `defineExtensions` import or call in `index.tsx`.
+
+**Correct**
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+export default defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+import { MyExtension } from './components/MyExtension';
+export default { 'cart.cart-list.after': MyExtension };
+```
+
+### Constraint: Extension point names must match exactly
+
+IDs are a fixed set. Non-existent names silently fail.
+
+**Why this matters**
+The extension renders nowhere. No build error — invisible at runtime.
+
+**Detection**
+Any name not in: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`, `menu.item`, `menu.drawer-content`.
+
+**Correct**
+
+```typescript
+defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+defineExtensions({ 'cart.list.after': MyExtension });
+```
+
+### Constraint: Hooks must be used in compatible extension points
+
+Each hook has an `available_in` restriction.
+
+**Why this matters**
+Hook context is only mounted for specific extension points. Using elsewhere throws runtime errors.
+
+**Detection**
+`useCartItem` in PDP/menu. `useCurrentUser` in cart. `usePDP` in menu/cart-list.
+
+**Correct**
+
+```typescript
+// useCartItem in cart.cart-item.after ✓
+defineExtensions({ 'cart.cart-item.after': ItemWarranty });
+```
+
+**Wrong**
+
+```typescript
+// useCartItem in pdp.sidebar.after ✗ — will fail at runtime
+defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
+```
+
+### Constraint: Always present execution plan and wait for approval
+
+Do not generate code until the user confirms the plan.
+
+**Why this matters**
+Generating without agreement wastes effort and may produce the wrong extension.
+
+**Detection**
+Jumping from discovery to code generation without presenting a plan.
+
+**Correct**
+Discovery → Requirements → Present plan → **User approves** → Generate code.
+
+**Wrong**
+Discovery → Generate code immediately.
+
+## Preferred pattern
+
+### Workflow overview
+
+**Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
+
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+
+**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+
+**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+## Reference Files
+
+Load these on demand based on what the task requires. Do not load all of them upfront.
+
+| File | Load when… |
+|------|-----------|
+| [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+
+## Common failure modes
+
+- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
+- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
+- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
+- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
+- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
+- **Placing code outside packages/sales-app/src/** — Not included in build.
+- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
+- **Not presenting plan** — User may want a different approach. Always confirm.
+- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+
+## Review checklist
+
+- [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
+- [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
+- [ ] Discovery completed and use case identified?
+- [ ] Execution plan approved by user?
+- [ ] Extension point is valid (from the 8-point reference)?
+- [ ] Hooks compatible with chosen extension point?
+- [ ] Component returns JSX.Element, never null?
+- [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
+- [ ] useCartItem().item checked for undefined?
+- [ ] No auth credentials exposed in frontend code?
+- [ ] IO Proxy uses relative path (/_v/...)?
+- [ ] defineExtensions configured in index.tsx?
+- [ ] CSS file path matches component name?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+## Related skills
+
+- `faststore-storefront` — storefront customization outside Sales App
+- `vtex-io-app-contract` — building VTEX IO proxy apps for secure API integration
+
+## Reference
+
+- Sales App setup: https://beta.fast.store/sales-app/setting-up
+- FastStore getting started: https://beta.fast.store/getting-started
+- VTEX Sales App documentation: https://help.vtex.com/en/tracks/instore-getting-started-and-setting-up
+- VTEX IO app development: https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-an-app
+
+---
+
 # Custom VTEX IO Apps
 
 # Admin React Interfaces

--- a/exports/copilot/sales-app.md
+++ b/exports/copilot/sales-app.md
@@ -57,8 +57,9 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
 | 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
-| 4 | Local Testing | Provide dev commands and URLs |
-| 5 | Build & Deploy | Build command → deployment guide |
+| 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
+| 5 | Local Testing | Provide dev commands and URLs |
+| 6 | Build & Deploy | Build command → deployment guide |
 
 ### Extension point selection
 
@@ -88,6 +89,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 - API + no auth → **API template**
 - API + VTEX IO proxy → **IO proxy template** (recommended)
 - API + direct auth → **direct auth template** (insecure, warn user)
+- API doc provided → generate TypeScript interfaces from extracted response shapes; no API doc → use `${DATA_INTERFACE}` placeholder
 
 ### API authentication strategy
 
@@ -317,15 +319,67 @@ Discovery → Generate code immediately.
 
 **Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
 
-**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
-**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
-**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS module file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+Template for the documentation file:
+
+````markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.module.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+````
+
+**Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 6** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
 ## Reference Files
 
@@ -336,7 +390,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
-| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 
 ## Common failure modes
 
@@ -350,6 +404,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
+- **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
+- **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
 
 ## Review checklist
 
@@ -366,6 +424,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
 - [ ] CSS file path matches component name?
+- [ ] Documentation generated at `docs/<ExtensionName>.md`?
+- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/copilot/sales-app.md
+++ b/exports/copilot/sales-app.md
@@ -1,0 +1,382 @@
+# sales-app
+
+# Sales App Extensibility
+
+## When this skill applies
+
+Use this skill when building, customizing, or deploying extensions for VTEX Sales App.
+
+- Adding features to the cart page (promotions, loyalty, services)
+- Adding features to the Product Detail Page (badges, recommendations, warranties)
+- Adding features to the menu (user profile, navigation, metrics)
+- Integrating external APIs into Sales App extensions
+- Generating, scaffolding, or validating extension code for Sales App
+
+Do not use this skill for:
+- Regular FastStore storefront customization (use `faststore-storefront`)
+- Building VTEX IO apps (use `vtex-io-*` skills)
+- Sales App core development or framework modifications
+
+### Prerequisite: FastStore project
+
+The project root must contain: `biome.json`, `faststore.json`, `package.json`, `tsconfig.json`, `turbo.json`.
+
+If any are missing, **STOP**. The user must install FastStore first:
+
+```bash
+npx @vtex/fsp-cli init
+# Prompt: "What is the application name?" → enter name or press Enter for default
+cd <application-name> && yarn
+```
+
+Documentation: https://beta.fast.store/getting-started
+
+### Prerequisite: Sales App module
+
+Inside the FastStore project, a Sales App workspace must exist (typically at `packages/sales-app`) with `src/`, `package.json`, and `tsconfig.json`. Check root `package.json` `"workspaces"` for a path containing `sales-app`. If missing, **STOP**:
+
+```bash
+yarn add @vtex/sales-app -D -W
+npx fsp create
+# Prompts: account name → "Sales App" → path (default or custom)
+# Then add the path to root package.json "workspaces" array
+yarn install
+```
+
+Documentation: https://beta.fast.store/sales-app/setting-up
+
+**Do NOT proceed to discovery or code generation until both prerequisites are confirmed.**
+
+## Decision rules
+
+Follow the mandatory 6-step workflow in order. Do not skip steps.
+
+| Step | Purpose | Gate |
+|------|---------|------|
+| 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
+| 1 | Discovery | Understand what the user wants to build |
+| 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
+| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 4 | Local Testing | Provide dev commands and URLs |
+| 5 | Build & Deploy | Build command → deployment guide |
+
+### Extension point selection
+
+| Extension Point | Category | Available Hooks | Layout Shift |
+|----------------|----------|----------------|--------------|
+| `cart.cart-list.after` | Cart | useCart, useExtension | No |
+| `cart.cart-item.after` | Cart | useCart, useCartItem, useExtension | Yes |
+| `cart.order-summary.after` | Cart | useCart, useExtension | Yes |
+| `pdp.sidebar.before` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.sidebar.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.content.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `menu.item` | Menu | useExtension | No |
+| `menu.drawer-content` | Menu | useCurrentUser, useExtension | No |
+
+### Hook availability
+
+- **useCart** → all cart + PDP extensions
+- **useCartItem** → `cart.cart-item.after` only
+- **useCurrentUser** → `menu.drawer-content` only
+- **usePDP** → PDP extensions only
+- **useExtension** → all extension points
+
+### Template selection
+
+- No API + no hooks → **simple template**
+- No API + hooks → **hook template**
+- API + no auth → **API template**
+- API + VTEX IO proxy → **IO proxy template** (recommended)
+- API + direct auth → **direct auth template** (insecure, warn user)
+
+### API authentication strategy
+
+1. **Recommended: VTEX IO Proxy App** — IO app stores keys server-side. Extension uses `credentials: 'include'` with a **relative path** (`/_v/my-api/data`).
+2. **Insecure: Direct Auth** — Keys in frontend code, visible in browser. Testing/development only.
+
+## Hard constraints
+
+### Constraint: Component must return JSX.Element, never null
+
+`defineExtensions` expects `ExtensionPointComponent` which returns `Element`, not `Element | null`.
+
+**Why this matters**
+Returning `null` causes a TypeScript compilation error. The build will fail.
+
+**Detection**
+`return null` in any component registered with `defineExtensions`.
+
+**Correct**
+
+```typescript
+export function MyExtension(): JSX.Element {
+  if (!data) return (<></>);
+  return <div>{data.value}</div>;
+}
+```
+
+**Wrong**
+
+```typescript
+export function MyExtension(): JSX.Element | null {
+  if (!data) return null;
+  return <div>{data.value}</div>;
+}
+```
+
+### Constraint: Guard optional properties before use
+
+`CartItem.manualPrice` (number | undefined), `CartItem.productRefId` (string | undefined), `CartItem.attachments` (Attachment[] | undefined) must be guarded.
+
+**Why this matters**
+TypeScript strict mode rejects accessing possibly-undefined values.
+
+**Detection**
+`item.manualPrice`, `item.productRefId`, or `item.attachments` without `?.`, `??`, `&&`, or `!= null`.
+
+**Correct**
+
+```typescript
+const price = item.manualPrice ?? item.sellingPrice;
+const refId = item.productRefId ?? 'N/A';
+const count = item.attachments?.length ?? 0;
+```
+
+**Wrong**
+
+```typescript
+const price = item.manualPrice;
+const refId = item.productRefId.toUpperCase();
+const count = item.attachments.length;
+```
+
+### Constraint: useCartItem().item may be undefined
+
+`item` from `useCartItem()` is `CartItem | undefined`.
+
+**Why this matters**
+Accessing properties on `undefined` causes a runtime crash.
+
+**Detection**
+Destructured `item` from `useCartItem()` used without `if (!item)` guard.
+
+**Correct**
+
+```typescript
+const { item } = useCartItem();
+if (!item) return (<></>);
+return <div>{item.name}</div>;
+```
+
+**Wrong**
+
+```typescript
+const { item } = useCartItem();
+return <div>{item.name}</div>;
+```
+
+### Constraint: Never expose authentication keys in frontend code
+
+API keys in `fetch` headers are visible in the browser network tab.
+
+**Why this matters**
+Leaked keys compromise the external service.
+
+**Detection**
+Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
+
+**Correct**
+
+```typescript
+const response = await fetch('/_v/my-api/data', {
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+**Wrong**
+
+```typescript
+const response = await fetch('https://api.example.com/data', {
+  headers: { 'x-api-key': 'sk-secret-key-12345' },
+});
+```
+
+### Constraint: IO Proxy must use relative paths only
+
+The Sales App internal proxy resolves the domain automatically.
+
+**Why this matters**
+A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
+
+**Detection**
+`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
+
+**Correct**
+
+```typescript
+await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
+```
+
+**Wrong**
+
+```typescript
+await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
+```
+
+### Constraint: defineExtensions is required in index.tsx
+
+Entry point must use `defineExtensions` from `@vtex/sales-app`.
+
+**Why this matters**
+Without it, the build succeeds but no extensions render.
+
+**Detection**
+Missing `defineExtensions` import or call in `index.tsx`.
+
+**Correct**
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+export default defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+import { MyExtension } from './components/MyExtension';
+export default { 'cart.cart-list.after': MyExtension };
+```
+
+### Constraint: Extension point names must match exactly
+
+IDs are a fixed set. Non-existent names silently fail.
+
+**Why this matters**
+The extension renders nowhere. No build error — invisible at runtime.
+
+**Detection**
+Any name not in: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`, `menu.item`, `menu.drawer-content`.
+
+**Correct**
+
+```typescript
+defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+defineExtensions({ 'cart.list.after': MyExtension });
+```
+
+### Constraint: Hooks must be used in compatible extension points
+
+Each hook has an `available_in` restriction.
+
+**Why this matters**
+Hook context is only mounted for specific extension points. Using elsewhere throws runtime errors.
+
+**Detection**
+`useCartItem` in PDP/menu. `useCurrentUser` in cart. `usePDP` in menu/cart-list.
+
+**Correct**
+
+```typescript
+// useCartItem in cart.cart-item.after ✓
+defineExtensions({ 'cart.cart-item.after': ItemWarranty });
+```
+
+**Wrong**
+
+```typescript
+// useCartItem in pdp.sidebar.after ✗ — will fail at runtime
+defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
+```
+
+### Constraint: Always present execution plan and wait for approval
+
+Do not generate code until the user confirms the plan.
+
+**Why this matters**
+Generating without agreement wastes effort and may produce the wrong extension.
+
+**Detection**
+Jumping from discovery to code generation without presenting a plan.
+
+**Correct**
+Discovery → Requirements → Present plan → **User approves** → Generate code.
+
+**Wrong**
+Discovery → Generate code immediately.
+
+## Preferred pattern
+
+### Workflow overview
+
+**Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
+
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+
+**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+
+**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+## Reference Files
+
+Load these on demand based on what the task requires. Do not load all of them upfront.
+
+| File | Load when… |
+|------|-----------|
+| [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+
+## Common failure modes
+
+- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
+- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
+- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
+- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
+- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
+- **Placing code outside packages/sales-app/src/** — Not included in build.
+- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
+- **Not presenting plan** — User may want a different approach. Always confirm.
+- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+
+## Review checklist
+
+- [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
+- [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
+- [ ] Discovery completed and use case identified?
+- [ ] Execution plan approved by user?
+- [ ] Extension point is valid (from the 8-point reference)?
+- [ ] Hooks compatible with chosen extension point?
+- [ ] Component returns JSX.Element, never null?
+- [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
+- [ ] useCartItem().item checked for undefined?
+- [ ] No auth credentials exposed in frontend code?
+- [ ] IO Proxy uses relative path (/_v/...)?
+- [ ] defineExtensions configured in index.tsx?
+- [ ] CSS file path matches component name?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+## Related skills
+
+- `faststore-storefront` — storefront customization outside Sales App
+- `vtex-io-app-contract` — building VTEX IO proxy apps for secure API integration
+
+## Reference
+
+- Sales App setup: https://beta.fast.store/sales-app/setting-up
+- FastStore getting started: https://beta.fast.store/getting-started
+- VTEX Sales App documentation: https://help.vtex.com/en/tracks/instore-getting-started-and-setting-up
+- VTEX IO app development: https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-an-app

--- a/exports/cursor/sales-app-all.mdc
+++ b/exports/cursor/sales-app-all.mdc
@@ -1,0 +1,386 @@
+---
+description: "Composite skill for the sales-app track. Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns."
+globs: "packages/sales-app/**/*.tsx","packages/sales-app/**/*.ts","packages/sales-app/**/*.css","packages/sales-app/src/index.tsx"
+alwaysApply: false
+---
+
+# Sales App Extensibility
+
+## When this skill applies
+
+Use this skill when building, customizing, or deploying extensions for VTEX Sales App.
+
+- Adding features to the cart page (promotions, loyalty, services)
+- Adding features to the Product Detail Page (badges, recommendations, warranties)
+- Adding features to the menu (user profile, navigation, metrics)
+- Integrating external APIs into Sales App extensions
+- Generating, scaffolding, or validating extension code for Sales App
+
+Do not use this skill for:
+- Regular FastStore storefront customization (use `faststore-storefront`)
+- Building VTEX IO apps (use `vtex-io-*` skills)
+- Sales App core development or framework modifications
+
+### Prerequisite: FastStore project
+
+The project root must contain: `biome.json`, `faststore.json`, `package.json`, `tsconfig.json`, `turbo.json`.
+
+If any are missing, **STOP**. The user must install FastStore first:
+
+```bash
+npx @vtex/fsp-cli init
+# Prompt: "What is the application name?" → enter name or press Enter for default
+cd <application-name> && yarn
+```
+
+Documentation: https://beta.fast.store/getting-started
+
+### Prerequisite: Sales App module
+
+Inside the FastStore project, a Sales App workspace must exist (typically at `packages/sales-app`) with `src/`, `package.json`, and `tsconfig.json`. Check root `package.json` `"workspaces"` for a path containing `sales-app`. If missing, **STOP**:
+
+```bash
+yarn add @vtex/sales-app -D -W
+npx fsp create
+# Prompts: account name → "Sales App" → path (default or custom)
+# Then add the path to root package.json "workspaces" array
+yarn install
+```
+
+Documentation: https://beta.fast.store/sales-app/setting-up
+
+**Do NOT proceed to discovery or code generation until both prerequisites are confirmed.**
+
+## Decision rules
+
+Follow the mandatory 6-step workflow in order. Do not skip steps.
+
+| Step | Purpose | Gate |
+|------|---------|------|
+| 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
+| 1 | Discovery | Understand what the user wants to build |
+| 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
+| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 4 | Local Testing | Provide dev commands and URLs |
+| 5 | Build & Deploy | Build command → deployment guide |
+
+### Extension point selection
+
+| Extension Point | Category | Available Hooks | Layout Shift |
+|----------------|----------|----------------|--------------|
+| `cart.cart-list.after` | Cart | useCart, useExtension | No |
+| `cart.cart-item.after` | Cart | useCart, useCartItem, useExtension | Yes |
+| `cart.order-summary.after` | Cart | useCart, useExtension | Yes |
+| `pdp.sidebar.before` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.sidebar.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.content.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `menu.item` | Menu | useExtension | No |
+| `menu.drawer-content` | Menu | useCurrentUser, useExtension | No |
+
+### Hook availability
+
+- **useCart** → all cart + PDP extensions
+- **useCartItem** → `cart.cart-item.after` only
+- **useCurrentUser** → `menu.drawer-content` only
+- **usePDP** → PDP extensions only
+- **useExtension** → all extension points
+
+### Template selection
+
+- No API + no hooks → **simple template**
+- No API + hooks → **hook template**
+- API + no auth → **API template**
+- API + VTEX IO proxy → **IO proxy template** (recommended)
+- API + direct auth → **direct auth template** (insecure, warn user)
+
+### API authentication strategy
+
+1. **Recommended: VTEX IO Proxy App** — IO app stores keys server-side. Extension uses `credentials: 'include'` with a **relative path** (`/_v/my-api/data`).
+2. **Insecure: Direct Auth** — Keys in frontend code, visible in browser. Testing/development only.
+
+## Hard constraints
+
+### Constraint: Component must return JSX.Element, never null
+
+`defineExtensions` expects `ExtensionPointComponent` which returns `Element`, not `Element | null`.
+
+**Why this matters**
+Returning `null` causes a TypeScript compilation error. The build will fail.
+
+**Detection**
+`return null` in any component registered with `defineExtensions`.
+
+**Correct**
+
+```typescript
+export function MyExtension(): JSX.Element {
+  if (!data) return (<></>);
+  return <div>{data.value}</div>;
+}
+```
+
+**Wrong**
+
+```typescript
+export function MyExtension(): JSX.Element | null {
+  if (!data) return null;
+  return <div>{data.value}</div>;
+}
+```
+
+### Constraint: Guard optional properties before use
+
+`CartItem.manualPrice` (number | undefined), `CartItem.productRefId` (string | undefined), `CartItem.attachments` (Attachment[] | undefined) must be guarded.
+
+**Why this matters**
+TypeScript strict mode rejects accessing possibly-undefined values.
+
+**Detection**
+`item.manualPrice`, `item.productRefId`, or `item.attachments` without `?.`, `??`, `&&`, or `!= null`.
+
+**Correct**
+
+```typescript
+const price = item.manualPrice ?? item.sellingPrice;
+const refId = item.productRefId ?? 'N/A';
+const count = item.attachments?.length ?? 0;
+```
+
+**Wrong**
+
+```typescript
+const price = item.manualPrice;
+const refId = item.productRefId.toUpperCase();
+const count = item.attachments.length;
+```
+
+### Constraint: useCartItem().item may be undefined
+
+`item` from `useCartItem()` is `CartItem | undefined`.
+
+**Why this matters**
+Accessing properties on `undefined` causes a runtime crash.
+
+**Detection**
+Destructured `item` from `useCartItem()` used without `if (!item)` guard.
+
+**Correct**
+
+```typescript
+const { item } = useCartItem();
+if (!item) return (<></>);
+return <div>{item.name}</div>;
+```
+
+**Wrong**
+
+```typescript
+const { item } = useCartItem();
+return <div>{item.name}</div>;
+```
+
+### Constraint: Never expose authentication keys in frontend code
+
+API keys in `fetch` headers are visible in the browser network tab.
+
+**Why this matters**
+Leaked keys compromise the external service.
+
+**Detection**
+Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
+
+**Correct**
+
+```typescript
+const response = await fetch('/_v/my-api/data', {
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+**Wrong**
+
+```typescript
+const response = await fetch('https://api.example.com/data', {
+  headers: { 'x-api-key': 'sk-secret-key-12345' },
+});
+```
+
+### Constraint: IO Proxy must use relative paths only
+
+The Sales App internal proxy resolves the domain automatically.
+
+**Why this matters**
+A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
+
+**Detection**
+`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
+
+**Correct**
+
+```typescript
+await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
+```
+
+**Wrong**
+
+```typescript
+await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
+```
+
+### Constraint: defineExtensions is required in index.tsx
+
+Entry point must use `defineExtensions` from `@vtex/sales-app`.
+
+**Why this matters**
+Without it, the build succeeds but no extensions render.
+
+**Detection**
+Missing `defineExtensions` import or call in `index.tsx`.
+
+**Correct**
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+export default defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+import { MyExtension } from './components/MyExtension';
+export default { 'cart.cart-list.after': MyExtension };
+```
+
+### Constraint: Extension point names must match exactly
+
+IDs are a fixed set. Non-existent names silently fail.
+
+**Why this matters**
+The extension renders nowhere. No build error — invisible at runtime.
+
+**Detection**
+Any name not in: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`, `menu.item`, `menu.drawer-content`.
+
+**Correct**
+
+```typescript
+defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+defineExtensions({ 'cart.list.after': MyExtension });
+```
+
+### Constraint: Hooks must be used in compatible extension points
+
+Each hook has an `available_in` restriction.
+
+**Why this matters**
+Hook context is only mounted for specific extension points. Using elsewhere throws runtime errors.
+
+**Detection**
+`useCartItem` in PDP/menu. `useCurrentUser` in cart. `usePDP` in menu/cart-list.
+
+**Correct**
+
+```typescript
+// useCartItem in cart.cart-item.after ✓
+defineExtensions({ 'cart.cart-item.after': ItemWarranty });
+```
+
+**Wrong**
+
+```typescript
+// useCartItem in pdp.sidebar.after ✗ — will fail at runtime
+defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
+```
+
+### Constraint: Always present execution plan and wait for approval
+
+Do not generate code until the user confirms the plan.
+
+**Why this matters**
+Generating without agreement wastes effort and may produce the wrong extension.
+
+**Detection**
+Jumping from discovery to code generation without presenting a plan.
+
+**Correct**
+Discovery → Requirements → Present plan → **User approves** → Generate code.
+
+**Wrong**
+Discovery → Generate code immediately.
+
+## Preferred pattern
+
+### Workflow overview
+
+**Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
+
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+
+**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+
+**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+## Reference Files
+
+Load these on demand based on what the task requires. Do not load all of them upfront.
+
+| File | Load when… |
+|------|-----------|
+| [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+
+## Common failure modes
+
+- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
+- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
+- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
+- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
+- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
+- **Placing code outside packages/sales-app/src/** — Not included in build.
+- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
+- **Not presenting plan** — User may want a different approach. Always confirm.
+- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+
+## Review checklist
+
+- [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
+- [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
+- [ ] Discovery completed and use case identified?
+- [ ] Execution plan approved by user?
+- [ ] Extension point is valid (from the 8-point reference)?
+- [ ] Hooks compatible with chosen extension point?
+- [ ] Component returns JSX.Element, never null?
+- [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
+- [ ] useCartItem().item checked for undefined?
+- [ ] No auth credentials exposed in frontend code?
+- [ ] IO Proxy uses relative path (/_v/...)?
+- [ ] defineExtensions configured in index.tsx?
+- [ ] CSS file path matches component name?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+## Related skills
+
+- `faststore-storefront` — storefront customization outside Sales App
+- `vtex-io-app-contract` — building VTEX IO proxy apps for secure API integration
+
+## Reference
+
+- Sales App setup: https://beta.fast.store/sales-app/setting-up
+- FastStore getting started: https://beta.fast.store/getting-started
+- VTEX Sales App documentation: https://help.vtex.com/en/tracks/instore-getting-started-and-setting-up
+- VTEX IO app development: https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-an-app

--- a/exports/cursor/sales-app-all.mdc
+++ b/exports/cursor/sales-app-all.mdc
@@ -1,5 +1,5 @@
 ---
-description: "Composite skill for the sales-app track. Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns."
+description: "Composite skill for the sales-app track. Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 7-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, secure API integration patterns, and API documentation ingestion (OpenAPI, URLs, or inline specs) to generate typed integrations."
 globs: "packages/sales-app/**/*.tsx","packages/sales-app/**/*.ts","packages/sales-app/**/*.css","packages/sales-app/src/index.tsx"
 alwaysApply: false
 ---
@@ -61,8 +61,9 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
 | 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
-| 4 | Local Testing | Provide dev commands and URLs |
-| 5 | Build & Deploy | Build command → deployment guide |
+| 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
+| 5 | Local Testing | Provide dev commands and URLs |
+| 6 | Build & Deploy | Build command → deployment guide |
 
 ### Extension point selection
 
@@ -92,6 +93,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 - API + no auth → **API template**
 - API + VTEX IO proxy → **IO proxy template** (recommended)
 - API + direct auth → **direct auth template** (insecure, warn user)
+- API doc provided → generate TypeScript interfaces from extracted response shapes; no API doc → use `${DATA_INTERFACE}` placeholder
 
 ### API authentication strategy
 
@@ -321,15 +323,67 @@ Discovery → Generate code immediately.
 
 **Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
 
-**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
-**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
-**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS module file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+Template for the documentation file:
+
+````markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.module.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+````
+
+**Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 6** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
 ## Reference Files
 
@@ -340,7 +394,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
-| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 
 ## Common failure modes
 
@@ -354,6 +408,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
+- **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
+- **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
 
 ## Review checklist
 
@@ -370,6 +428,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
 - [ ] CSS file path matches component name?
+- [ ] Documentation generated at `docs/<ExtensionName>.md`?
+- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/cursor/sales-app-sales-app-extensibility.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility.mdc
@@ -1,0 +1,386 @@
+---
+description: "Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns."
+globs: "packages/sales-app/**/*.tsx","packages/sales-app/**/*.ts","packages/sales-app/**/*.css","packages/sales-app/src/index.tsx"
+alwaysApply: false
+---
+
+# Sales App Extensibility
+
+## When this skill applies
+
+Use this skill when building, customizing, or deploying extensions for VTEX Sales App.
+
+- Adding features to the cart page (promotions, loyalty, services)
+- Adding features to the Product Detail Page (badges, recommendations, warranties)
+- Adding features to the menu (user profile, navigation, metrics)
+- Integrating external APIs into Sales App extensions
+- Generating, scaffolding, or validating extension code for Sales App
+
+Do not use this skill for:
+- Regular FastStore storefront customization (use `faststore-storefront`)
+- Building VTEX IO apps (use `vtex-io-*` skills)
+- Sales App core development or framework modifications
+
+### Prerequisite: FastStore project
+
+The project root must contain: `biome.json`, `faststore.json`, `package.json`, `tsconfig.json`, `turbo.json`.
+
+If any are missing, **STOP**. The user must install FastStore first:
+
+```bash
+npx @vtex/fsp-cli init
+# Prompt: "What is the application name?" → enter name or press Enter for default
+cd <application-name> && yarn
+```
+
+Documentation: https://beta.fast.store/getting-started
+
+### Prerequisite: Sales App module
+
+Inside the FastStore project, a Sales App workspace must exist (typically at `packages/sales-app`) with `src/`, `package.json`, and `tsconfig.json`. Check root `package.json` `"workspaces"` for a path containing `sales-app`. If missing, **STOP**:
+
+```bash
+yarn add @vtex/sales-app -D -W
+npx fsp create
+# Prompts: account name → "Sales App" → path (default or custom)
+# Then add the path to root package.json "workspaces" array
+yarn install
+```
+
+Documentation: https://beta.fast.store/sales-app/setting-up
+
+**Do NOT proceed to discovery or code generation until both prerequisites are confirmed.**
+
+## Decision rules
+
+Follow the mandatory 6-step workflow in order. Do not skip steps.
+
+| Step | Purpose | Gate |
+|------|---------|------|
+| 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
+| 1 | Discovery | Understand what the user wants to build |
+| 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
+| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 4 | Local Testing | Provide dev commands and URLs |
+| 5 | Build & Deploy | Build command → deployment guide |
+
+### Extension point selection
+
+| Extension Point | Category | Available Hooks | Layout Shift |
+|----------------|----------|----------------|--------------|
+| `cart.cart-list.after` | Cart | useCart, useExtension | No |
+| `cart.cart-item.after` | Cart | useCart, useCartItem, useExtension | Yes |
+| `cart.order-summary.after` | Cart | useCart, useExtension | Yes |
+| `pdp.sidebar.before` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.sidebar.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.content.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `menu.item` | Menu | useExtension | No |
+| `menu.drawer-content` | Menu | useCurrentUser, useExtension | No |
+
+### Hook availability
+
+- **useCart** → all cart + PDP extensions
+- **useCartItem** → `cart.cart-item.after` only
+- **useCurrentUser** → `menu.drawer-content` only
+- **usePDP** → PDP extensions only
+- **useExtension** → all extension points
+
+### Template selection
+
+- No API + no hooks → **simple template**
+- No API + hooks → **hook template**
+- API + no auth → **API template**
+- API + VTEX IO proxy → **IO proxy template** (recommended)
+- API + direct auth → **direct auth template** (insecure, warn user)
+
+### API authentication strategy
+
+1. **Recommended: VTEX IO Proxy App** — IO app stores keys server-side. Extension uses `credentials: 'include'` with a **relative path** (`/_v/my-api/data`).
+2. **Insecure: Direct Auth** — Keys in frontend code, visible in browser. Testing/development only.
+
+## Hard constraints
+
+### Constraint: Component must return JSX.Element, never null
+
+`defineExtensions` expects `ExtensionPointComponent` which returns `Element`, not `Element | null`.
+
+**Why this matters**
+Returning `null` causes a TypeScript compilation error. The build will fail.
+
+**Detection**
+`return null` in any component registered with `defineExtensions`.
+
+**Correct**
+
+```typescript
+export function MyExtension(): JSX.Element {
+  if (!data) return (<></>);
+  return <div>{data.value}</div>;
+}
+```
+
+**Wrong**
+
+```typescript
+export function MyExtension(): JSX.Element | null {
+  if (!data) return null;
+  return <div>{data.value}</div>;
+}
+```
+
+### Constraint: Guard optional properties before use
+
+`CartItem.manualPrice` (number | undefined), `CartItem.productRefId` (string | undefined), `CartItem.attachments` (Attachment[] | undefined) must be guarded.
+
+**Why this matters**
+TypeScript strict mode rejects accessing possibly-undefined values.
+
+**Detection**
+`item.manualPrice`, `item.productRefId`, or `item.attachments` without `?.`, `??`, `&&`, or `!= null`.
+
+**Correct**
+
+```typescript
+const price = item.manualPrice ?? item.sellingPrice;
+const refId = item.productRefId ?? 'N/A';
+const count = item.attachments?.length ?? 0;
+```
+
+**Wrong**
+
+```typescript
+const price = item.manualPrice;
+const refId = item.productRefId.toUpperCase();
+const count = item.attachments.length;
+```
+
+### Constraint: useCartItem().item may be undefined
+
+`item` from `useCartItem()` is `CartItem | undefined`.
+
+**Why this matters**
+Accessing properties on `undefined` causes a runtime crash.
+
+**Detection**
+Destructured `item` from `useCartItem()` used without `if (!item)` guard.
+
+**Correct**
+
+```typescript
+const { item } = useCartItem();
+if (!item) return (<></>);
+return <div>{item.name}</div>;
+```
+
+**Wrong**
+
+```typescript
+const { item } = useCartItem();
+return <div>{item.name}</div>;
+```
+
+### Constraint: Never expose authentication keys in frontend code
+
+API keys in `fetch` headers are visible in the browser network tab.
+
+**Why this matters**
+Leaked keys compromise the external service.
+
+**Detection**
+Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
+
+**Correct**
+
+```typescript
+const response = await fetch('/_v/my-api/data', {
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+**Wrong**
+
+```typescript
+const response = await fetch('https://api.example.com/data', {
+  headers: { 'x-api-key': 'sk-secret-key-12345' },
+});
+```
+
+### Constraint: IO Proxy must use relative paths only
+
+The Sales App internal proxy resolves the domain automatically.
+
+**Why this matters**
+A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
+
+**Detection**
+`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
+
+**Correct**
+
+```typescript
+await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
+```
+
+**Wrong**
+
+```typescript
+await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
+```
+
+### Constraint: defineExtensions is required in index.tsx
+
+Entry point must use `defineExtensions` from `@vtex/sales-app`.
+
+**Why this matters**
+Without it, the build succeeds but no extensions render.
+
+**Detection**
+Missing `defineExtensions` import or call in `index.tsx`.
+
+**Correct**
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+export default defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+import { MyExtension } from './components/MyExtension';
+export default { 'cart.cart-list.after': MyExtension };
+```
+
+### Constraint: Extension point names must match exactly
+
+IDs are a fixed set. Non-existent names silently fail.
+
+**Why this matters**
+The extension renders nowhere. No build error — invisible at runtime.
+
+**Detection**
+Any name not in: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`, `menu.item`, `menu.drawer-content`.
+
+**Correct**
+
+```typescript
+defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+defineExtensions({ 'cart.list.after': MyExtension });
+```
+
+### Constraint: Hooks must be used in compatible extension points
+
+Each hook has an `available_in` restriction.
+
+**Why this matters**
+Hook context is only mounted for specific extension points. Using elsewhere throws runtime errors.
+
+**Detection**
+`useCartItem` in PDP/menu. `useCurrentUser` in cart. `usePDP` in menu/cart-list.
+
+**Correct**
+
+```typescript
+// useCartItem in cart.cart-item.after ✓
+defineExtensions({ 'cart.cart-item.after': ItemWarranty });
+```
+
+**Wrong**
+
+```typescript
+// useCartItem in pdp.sidebar.after ✗ — will fail at runtime
+defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
+```
+
+### Constraint: Always present execution plan and wait for approval
+
+Do not generate code until the user confirms the plan.
+
+**Why this matters**
+Generating without agreement wastes effort and may produce the wrong extension.
+
+**Detection**
+Jumping from discovery to code generation without presenting a plan.
+
+**Correct**
+Discovery → Requirements → Present plan → **User approves** → Generate code.
+
+**Wrong**
+Discovery → Generate code immediately.
+
+## Preferred pattern
+
+### Workflow overview
+
+**Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
+
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+
+**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+
+**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+## Reference Files
+
+Load these on demand based on what the task requires. Do not load all of them upfront.
+
+| File | Load when… |
+|------|-----------|
+| [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+
+## Common failure modes
+
+- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
+- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
+- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
+- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
+- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
+- **Placing code outside packages/sales-app/src/** — Not included in build.
+- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
+- **Not presenting plan** — User may want a different approach. Always confirm.
+- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+
+## Review checklist
+
+- [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
+- [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
+- [ ] Discovery completed and use case identified?
+- [ ] Execution plan approved by user?
+- [ ] Extension point is valid (from the 8-point reference)?
+- [ ] Hooks compatible with chosen extension point?
+- [ ] Component returns JSX.Element, never null?
+- [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
+- [ ] useCartItem().item checked for undefined?
+- [ ] No auth credentials exposed in frontend code?
+- [ ] IO Proxy uses relative path (/_v/...)?
+- [ ] defineExtensions configured in index.tsx?
+- [ ] CSS file path matches component name?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+## Related skills
+
+- `faststore-storefront` — storefront customization outside Sales App
+- `vtex-io-app-contract` — building VTEX IO proxy apps for secure API integration
+
+## Reference
+
+- Sales App setup: https://beta.fast.store/sales-app/setting-up
+- FastStore getting started: https://beta.fast.store/getting-started
+- VTEX Sales App documentation: https://help.vtex.com/en/tracks/instore-getting-started-and-setting-up
+- VTEX IO app development: https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-an-app

--- a/exports/cursor/sales-app-sales-app-extensibility.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility.mdc
@@ -1,5 +1,5 @@
 ---
-description: "Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns."
+description: "Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 7-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, secure API integration patterns, and API documentation ingestion (OpenAPI, URLs, or inline specs) to generate typed integrations."
 globs: "packages/sales-app/**/*.tsx","packages/sales-app/**/*.ts","packages/sales-app/**/*.css","packages/sales-app/src/index.tsx"
 alwaysApply: false
 ---
@@ -61,8 +61,9 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
 | 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
-| 4 | Local Testing | Provide dev commands and URLs |
-| 5 | Build & Deploy | Build command → deployment guide |
+| 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
+| 5 | Local Testing | Provide dev commands and URLs |
+| 6 | Build & Deploy | Build command → deployment guide |
 
 ### Extension point selection
 
@@ -92,6 +93,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 - API + no auth → **API template**
 - API + VTEX IO proxy → **IO proxy template** (recommended)
 - API + direct auth → **direct auth template** (insecure, warn user)
+- API doc provided → generate TypeScript interfaces from extracted response shapes; no API doc → use `${DATA_INTERFACE}` placeholder
 
 ### API authentication strategy
 
@@ -321,15 +323,67 @@ Discovery → Generate code immediately.
 
 **Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
 
-**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
-**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
-**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS module file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+Template for the documentation file:
+
+````markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.module.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+````
+
+**Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 6** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
 ## Reference Files
 
@@ -340,7 +394,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
-| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 
 ## Common failure modes
 
@@ -354,6 +408,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
+- **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
+- **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
 
 ## Review checklist
 
@@ -370,6 +428,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
 - [ ] CSS file path matches component name?
+- [ ] Documentation generated at `docs/<ExtensionName>.md`?
+- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/kiro/POWER.md
+++ b/exports/kiro/POWER.md
@@ -43,6 +43,10 @@ em `steering/` fornecem orientação contextual baseada nos globs dos skills.
 - **payment-provider-framework**: Apply when designing or implementing a Payment Connector in VTEX IO. Covers PPF implementation, TypeScript 3.9.7 builder-hub constraints and safe dependency resolutions, configuration.json schema validation, PaymentProviderService clients wiring, Secure Proxy scope (authorize-only), ExternalClient vs SecureExternalClient patterns, IOContext access, PPF response helpers, PSP integration checklist, and vtex link debugging. Use for any implementation of a Payment Connector hosted in VTEX IO.
 - **payment-provider-protocol**: Apply when implementing a VTEX Payment Provider Protocol (PPP) connector or working with payment/connector endpoint files. Covers all nine required endpoints: Manifest, Create Payment, Cancel, Capture/Settle, Refund, Inbound Request, Create Auth Token, Provider Auth Redirect, and Get Credentials. Use for building or debugging any payment connector that integrates with the VTEX Payment Gateway.
 
+### sales-app
+
+- **sales-app-extensibility**: Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns.
+
 ### Custom VTEX IO Apps
 
 - **vtex-io-admin-react**: Apply when building VTEX IO admin-facing React interfaces under the admin builder. Covers VTEX Styleguide and Shoreline usage, admin page composition, data-heavy admin interactions, and keeping administrative interfaces consistent with the VTEX Admin environment. Use for settings pages, moderation tools, dashboards, or operational UIs inside VTEX Admin.

--- a/exports/kiro/POWER.md
+++ b/exports/kiro/POWER.md
@@ -45,7 +45,7 @@ em `steering/` fornecem orientação contextual baseada nos globs dos skills.
 
 ### sales-app
 
-- **sales-app-extensibility**: Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns.
+- **sales-app-extensibility**: Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 7-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, secure API integration patterns, and API documentation ingestion (OpenAPI, URLs, or inline specs) to generate typed integrations.
 
 ### Custom VTEX IO Apps
 

--- a/exports/kiro/steering/sales-app-all.md
+++ b/exports/kiro/steering/sales-app-all.md
@@ -57,8 +57,9 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
 | 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
-| 4 | Local Testing | Provide dev commands and URLs |
-| 5 | Build & Deploy | Build command → deployment guide |
+| 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
+| 5 | Local Testing | Provide dev commands and URLs |
+| 6 | Build & Deploy | Build command → deployment guide |
 
 ### Extension point selection
 
@@ -88,6 +89,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 - API + no auth → **API template**
 - API + VTEX IO proxy → **IO proxy template** (recommended)
 - API + direct auth → **direct auth template** (insecure, warn user)
+- API doc provided → generate TypeScript interfaces from extracted response shapes; no API doc → use `${DATA_INTERFACE}` placeholder
 
 ### API authentication strategy
 
@@ -317,15 +319,67 @@ Discovery → Generate code immediately.
 
 **Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
 
-**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
-**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
-**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS module file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+Template for the documentation file:
+
+````markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.module.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+````
+
+**Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 6** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
 ## Reference Files
 
@@ -336,7 +390,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
-| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 
 ## Common failure modes
 
@@ -350,6 +404,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
+- **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
+- **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
 
 ## Review checklist
 
@@ -366,6 +424,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
 - [ ] CSS file path matches component name?
+- [ ] Documentation generated at `docs/<ExtensionName>.md`?
+- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/kiro/steering/sales-app-all.md
+++ b/exports/kiro/steering/sales-app-all.md
@@ -1,0 +1,382 @@
+# sales-app
+
+# Sales App Extensibility
+
+## When this skill applies
+
+Use this skill when building, customizing, or deploying extensions for VTEX Sales App.
+
+- Adding features to the cart page (promotions, loyalty, services)
+- Adding features to the Product Detail Page (badges, recommendations, warranties)
+- Adding features to the menu (user profile, navigation, metrics)
+- Integrating external APIs into Sales App extensions
+- Generating, scaffolding, or validating extension code for Sales App
+
+Do not use this skill for:
+- Regular FastStore storefront customization (use `faststore-storefront`)
+- Building VTEX IO apps (use `vtex-io-*` skills)
+- Sales App core development or framework modifications
+
+### Prerequisite: FastStore project
+
+The project root must contain: `biome.json`, `faststore.json`, `package.json`, `tsconfig.json`, `turbo.json`.
+
+If any are missing, **STOP**. The user must install FastStore first:
+
+```bash
+npx @vtex/fsp-cli init
+# Prompt: "What is the application name?" → enter name or press Enter for default
+cd <application-name> && yarn
+```
+
+Documentation: https://beta.fast.store/getting-started
+
+### Prerequisite: Sales App module
+
+Inside the FastStore project, a Sales App workspace must exist (typically at `packages/sales-app`) with `src/`, `package.json`, and `tsconfig.json`. Check root `package.json` `"workspaces"` for a path containing `sales-app`. If missing, **STOP**:
+
+```bash
+yarn add @vtex/sales-app -D -W
+npx fsp create
+# Prompts: account name → "Sales App" → path (default or custom)
+# Then add the path to root package.json "workspaces" array
+yarn install
+```
+
+Documentation: https://beta.fast.store/sales-app/setting-up
+
+**Do NOT proceed to discovery or code generation until both prerequisites are confirmed.**
+
+## Decision rules
+
+Follow the mandatory 6-step workflow in order. Do not skip steps.
+
+| Step | Purpose | Gate |
+|------|---------|------|
+| 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
+| 1 | Discovery | Understand what the user wants to build |
+| 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
+| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 4 | Local Testing | Provide dev commands and URLs |
+| 5 | Build & Deploy | Build command → deployment guide |
+
+### Extension point selection
+
+| Extension Point | Category | Available Hooks | Layout Shift |
+|----------------|----------|----------------|--------------|
+| `cart.cart-list.after` | Cart | useCart, useExtension | No |
+| `cart.cart-item.after` | Cart | useCart, useCartItem, useExtension | Yes |
+| `cart.order-summary.after` | Cart | useCart, useExtension | Yes |
+| `pdp.sidebar.before` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.sidebar.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.content.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `menu.item` | Menu | useExtension | No |
+| `menu.drawer-content` | Menu | useCurrentUser, useExtension | No |
+
+### Hook availability
+
+- **useCart** → all cart + PDP extensions
+- **useCartItem** → `cart.cart-item.after` only
+- **useCurrentUser** → `menu.drawer-content` only
+- **usePDP** → PDP extensions only
+- **useExtension** → all extension points
+
+### Template selection
+
+- No API + no hooks → **simple template**
+- No API + hooks → **hook template**
+- API + no auth → **API template**
+- API + VTEX IO proxy → **IO proxy template** (recommended)
+- API + direct auth → **direct auth template** (insecure, warn user)
+
+### API authentication strategy
+
+1. **Recommended: VTEX IO Proxy App** — IO app stores keys server-side. Extension uses `credentials: 'include'` with a **relative path** (`/_v/my-api/data`).
+2. **Insecure: Direct Auth** — Keys in frontend code, visible in browser. Testing/development only.
+
+## Hard constraints
+
+### Constraint: Component must return JSX.Element, never null
+
+`defineExtensions` expects `ExtensionPointComponent` which returns `Element`, not `Element | null`.
+
+**Why this matters**
+Returning `null` causes a TypeScript compilation error. The build will fail.
+
+**Detection**
+`return null` in any component registered with `defineExtensions`.
+
+**Correct**
+
+```typescript
+export function MyExtension(): JSX.Element {
+  if (!data) return (<></>);
+  return <div>{data.value}</div>;
+}
+```
+
+**Wrong**
+
+```typescript
+export function MyExtension(): JSX.Element | null {
+  if (!data) return null;
+  return <div>{data.value}</div>;
+}
+```
+
+### Constraint: Guard optional properties before use
+
+`CartItem.manualPrice` (number | undefined), `CartItem.productRefId` (string | undefined), `CartItem.attachments` (Attachment[] | undefined) must be guarded.
+
+**Why this matters**
+TypeScript strict mode rejects accessing possibly-undefined values.
+
+**Detection**
+`item.manualPrice`, `item.productRefId`, or `item.attachments` without `?.`, `??`, `&&`, or `!= null`.
+
+**Correct**
+
+```typescript
+const price = item.manualPrice ?? item.sellingPrice;
+const refId = item.productRefId ?? 'N/A';
+const count = item.attachments?.length ?? 0;
+```
+
+**Wrong**
+
+```typescript
+const price = item.manualPrice;
+const refId = item.productRefId.toUpperCase();
+const count = item.attachments.length;
+```
+
+### Constraint: useCartItem().item may be undefined
+
+`item` from `useCartItem()` is `CartItem | undefined`.
+
+**Why this matters**
+Accessing properties on `undefined` causes a runtime crash.
+
+**Detection**
+Destructured `item` from `useCartItem()` used without `if (!item)` guard.
+
+**Correct**
+
+```typescript
+const { item } = useCartItem();
+if (!item) return (<></>);
+return <div>{item.name}</div>;
+```
+
+**Wrong**
+
+```typescript
+const { item } = useCartItem();
+return <div>{item.name}</div>;
+```
+
+### Constraint: Never expose authentication keys in frontend code
+
+API keys in `fetch` headers are visible in the browser network tab.
+
+**Why this matters**
+Leaked keys compromise the external service.
+
+**Detection**
+Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
+
+**Correct**
+
+```typescript
+const response = await fetch('/_v/my-api/data', {
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+**Wrong**
+
+```typescript
+const response = await fetch('https://api.example.com/data', {
+  headers: { 'x-api-key': 'sk-secret-key-12345' },
+});
+```
+
+### Constraint: IO Proxy must use relative paths only
+
+The Sales App internal proxy resolves the domain automatically.
+
+**Why this matters**
+A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
+
+**Detection**
+`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
+
+**Correct**
+
+```typescript
+await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
+```
+
+**Wrong**
+
+```typescript
+await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
+```
+
+### Constraint: defineExtensions is required in index.tsx
+
+Entry point must use `defineExtensions` from `@vtex/sales-app`.
+
+**Why this matters**
+Without it, the build succeeds but no extensions render.
+
+**Detection**
+Missing `defineExtensions` import or call in `index.tsx`.
+
+**Correct**
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+export default defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+import { MyExtension } from './components/MyExtension';
+export default { 'cart.cart-list.after': MyExtension };
+```
+
+### Constraint: Extension point names must match exactly
+
+IDs are a fixed set. Non-existent names silently fail.
+
+**Why this matters**
+The extension renders nowhere. No build error — invisible at runtime.
+
+**Detection**
+Any name not in: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`, `menu.item`, `menu.drawer-content`.
+
+**Correct**
+
+```typescript
+defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+defineExtensions({ 'cart.list.after': MyExtension });
+```
+
+### Constraint: Hooks must be used in compatible extension points
+
+Each hook has an `available_in` restriction.
+
+**Why this matters**
+Hook context is only mounted for specific extension points. Using elsewhere throws runtime errors.
+
+**Detection**
+`useCartItem` in PDP/menu. `useCurrentUser` in cart. `usePDP` in menu/cart-list.
+
+**Correct**
+
+```typescript
+// useCartItem in cart.cart-item.after ✓
+defineExtensions({ 'cart.cart-item.after': ItemWarranty });
+```
+
+**Wrong**
+
+```typescript
+// useCartItem in pdp.sidebar.after ✗ — will fail at runtime
+defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
+```
+
+### Constraint: Always present execution plan and wait for approval
+
+Do not generate code until the user confirms the plan.
+
+**Why this matters**
+Generating without agreement wastes effort and may produce the wrong extension.
+
+**Detection**
+Jumping from discovery to code generation without presenting a plan.
+
+**Correct**
+Discovery → Requirements → Present plan → **User approves** → Generate code.
+
+**Wrong**
+Discovery → Generate code immediately.
+
+## Preferred pattern
+
+### Workflow overview
+
+**Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
+
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+
+**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+
+**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+## Reference Files
+
+Load these on demand based on what the task requires. Do not load all of them upfront.
+
+| File | Load when… |
+|------|-----------|
+| [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+
+## Common failure modes
+
+- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
+- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
+- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
+- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
+- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
+- **Placing code outside packages/sales-app/src/** — Not included in build.
+- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
+- **Not presenting plan** — User may want a different approach. Always confirm.
+- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+
+## Review checklist
+
+- [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
+- [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
+- [ ] Discovery completed and use case identified?
+- [ ] Execution plan approved by user?
+- [ ] Extension point is valid (from the 8-point reference)?
+- [ ] Hooks compatible with chosen extension point?
+- [ ] Component returns JSX.Element, never null?
+- [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
+- [ ] useCartItem().item checked for undefined?
+- [ ] No auth credentials exposed in frontend code?
+- [ ] IO Proxy uses relative path (/_v/...)?
+- [ ] defineExtensions configured in index.tsx?
+- [ ] CSS file path matches component name?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+## Related skills
+
+- `faststore-storefront` — storefront customization outside Sales App
+- `vtex-io-app-contract` — building VTEX IO proxy apps for secure API integration
+
+## Reference
+
+- Sales App setup: https://beta.fast.store/sales-app/setting-up
+- FastStore getting started: https://beta.fast.store/getting-started
+- VTEX Sales App documentation: https://help.vtex.com/en/tracks/instore-getting-started-and-setting-up
+- VTEX IO app development: https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-an-app

--- a/exports/kiro/steering/sales-app-sales-app-extensibility.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility.md
@@ -1,6 +1,6 @@
 <!-- globs: packages/sales-app/**/*.tsx, packages/sales-app/**/*.ts, packages/sales-app/**/*.css, packages/sales-app/src/index.tsx -->
 
-Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns.
+Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 7-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, secure API integration patterns, and API documentation ingestion (OpenAPI, URLs, or inline specs) to generate typed integrations.
 
 # Sales App Extensibility
 
@@ -59,8 +59,9 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
 | 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
-| 4 | Local Testing | Provide dev commands and URLs |
-| 5 | Build & Deploy | Build command → deployment guide |
+| 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
+| 5 | Local Testing | Provide dev commands and URLs |
+| 6 | Build & Deploy | Build command → deployment guide |
 
 ### Extension point selection
 
@@ -90,6 +91,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 - API + no auth → **API template**
 - API + VTEX IO proxy → **IO proxy template** (recommended)
 - API + direct auth → **direct auth template** (insecure, warn user)
+- API doc provided → generate TypeScript interfaces from extracted response shapes; no API doc → use `${DATA_INTERFACE}` placeholder
 
 ### API authentication strategy
 
@@ -319,15 +321,67 @@ Discovery → Generate code immediately.
 
 **Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
 
-**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
-**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
-**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS module file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+Template for the documentation file:
+
+````markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.module.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+````
+
+**Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 6** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
 ## Reference Files
 
@@ -338,7 +392,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
-| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 
 ## Common failure modes
 
@@ -352,6 +406,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
+- **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
+- **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
 
 ## Review checklist
 
@@ -368,6 +426,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
 - [ ] CSS file path matches component name?
+- [ ] Documentation generated at `docs/<ExtensionName>.md`?
+- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/kiro/steering/sales-app-sales-app-extensibility.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility.md
@@ -1,0 +1,384 @@
+<!-- globs: packages/sales-app/**/*.tsx, packages/sales-app/**/*.ts, packages/sales-app/**/*.css, packages/sales-app/src/index.tsx -->
+
+Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns.
+
+# Sales App Extensibility
+
+## When this skill applies
+
+Use this skill when building, customizing, or deploying extensions for VTEX Sales App.
+
+- Adding features to the cart page (promotions, loyalty, services)
+- Adding features to the Product Detail Page (badges, recommendations, warranties)
+- Adding features to the menu (user profile, navigation, metrics)
+- Integrating external APIs into Sales App extensions
+- Generating, scaffolding, or validating extension code for Sales App
+
+Do not use this skill for:
+- Regular FastStore storefront customization (use `faststore-storefront`)
+- Building VTEX IO apps (use `vtex-io-*` skills)
+- Sales App core development or framework modifications
+
+### Prerequisite: FastStore project
+
+The project root must contain: `biome.json`, `faststore.json`, `package.json`, `tsconfig.json`, `turbo.json`.
+
+If any are missing, **STOP**. The user must install FastStore first:
+
+```bash
+npx @vtex/fsp-cli init
+# Prompt: "What is the application name?" → enter name or press Enter for default
+cd <application-name> && yarn
+```
+
+Documentation: https://beta.fast.store/getting-started
+
+### Prerequisite: Sales App module
+
+Inside the FastStore project, a Sales App workspace must exist (typically at `packages/sales-app`) with `src/`, `package.json`, and `tsconfig.json`. Check root `package.json` `"workspaces"` for a path containing `sales-app`. If missing, **STOP**:
+
+```bash
+yarn add @vtex/sales-app -D -W
+npx fsp create
+# Prompts: account name → "Sales App" → path (default or custom)
+# Then add the path to root package.json "workspaces" array
+yarn install
+```
+
+Documentation: https://beta.fast.store/sales-app/setting-up
+
+**Do NOT proceed to discovery or code generation until both prerequisites are confirmed.**
+
+## Decision rules
+
+Follow the mandatory 6-step workflow in order. Do not skip steps.
+
+| Step | Purpose | Gate |
+|------|---------|------|
+| 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
+| 1 | Discovery | Understand what the user wants to build |
+| 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
+| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 4 | Local Testing | Provide dev commands and URLs |
+| 5 | Build & Deploy | Build command → deployment guide |
+
+### Extension point selection
+
+| Extension Point | Category | Available Hooks | Layout Shift |
+|----------------|----------|----------------|--------------|
+| `cart.cart-list.after` | Cart | useCart, useExtension | No |
+| `cart.cart-item.after` | Cart | useCart, useCartItem, useExtension | Yes |
+| `cart.order-summary.after` | Cart | useCart, useExtension | Yes |
+| `pdp.sidebar.before` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.sidebar.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.content.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `menu.item` | Menu | useExtension | No |
+| `menu.drawer-content` | Menu | useCurrentUser, useExtension | No |
+
+### Hook availability
+
+- **useCart** → all cart + PDP extensions
+- **useCartItem** → `cart.cart-item.after` only
+- **useCurrentUser** → `menu.drawer-content` only
+- **usePDP** → PDP extensions only
+- **useExtension** → all extension points
+
+### Template selection
+
+- No API + no hooks → **simple template**
+- No API + hooks → **hook template**
+- API + no auth → **API template**
+- API + VTEX IO proxy → **IO proxy template** (recommended)
+- API + direct auth → **direct auth template** (insecure, warn user)
+
+### API authentication strategy
+
+1. **Recommended: VTEX IO Proxy App** — IO app stores keys server-side. Extension uses `credentials: 'include'` with a **relative path** (`/_v/my-api/data`).
+2. **Insecure: Direct Auth** — Keys in frontend code, visible in browser. Testing/development only.
+
+## Hard constraints
+
+### Constraint: Component must return JSX.Element, never null
+
+`defineExtensions` expects `ExtensionPointComponent` which returns `Element`, not `Element | null`.
+
+**Why this matters**
+Returning `null` causes a TypeScript compilation error. The build will fail.
+
+**Detection**
+`return null` in any component registered with `defineExtensions`.
+
+**Correct**
+
+```typescript
+export function MyExtension(): JSX.Element {
+  if (!data) return (<></>);
+  return <div>{data.value}</div>;
+}
+```
+
+**Wrong**
+
+```typescript
+export function MyExtension(): JSX.Element | null {
+  if (!data) return null;
+  return <div>{data.value}</div>;
+}
+```
+
+### Constraint: Guard optional properties before use
+
+`CartItem.manualPrice` (number | undefined), `CartItem.productRefId` (string | undefined), `CartItem.attachments` (Attachment[] | undefined) must be guarded.
+
+**Why this matters**
+TypeScript strict mode rejects accessing possibly-undefined values.
+
+**Detection**
+`item.manualPrice`, `item.productRefId`, or `item.attachments` without `?.`, `??`, `&&`, or `!= null`.
+
+**Correct**
+
+```typescript
+const price = item.manualPrice ?? item.sellingPrice;
+const refId = item.productRefId ?? 'N/A';
+const count = item.attachments?.length ?? 0;
+```
+
+**Wrong**
+
+```typescript
+const price = item.manualPrice;
+const refId = item.productRefId.toUpperCase();
+const count = item.attachments.length;
+```
+
+### Constraint: useCartItem().item may be undefined
+
+`item` from `useCartItem()` is `CartItem | undefined`.
+
+**Why this matters**
+Accessing properties on `undefined` causes a runtime crash.
+
+**Detection**
+Destructured `item` from `useCartItem()` used without `if (!item)` guard.
+
+**Correct**
+
+```typescript
+const { item } = useCartItem();
+if (!item) return (<></>);
+return <div>{item.name}</div>;
+```
+
+**Wrong**
+
+```typescript
+const { item } = useCartItem();
+return <div>{item.name}</div>;
+```
+
+### Constraint: Never expose authentication keys in frontend code
+
+API keys in `fetch` headers are visible in the browser network tab.
+
+**Why this matters**
+Leaked keys compromise the external service.
+
+**Detection**
+Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
+
+**Correct**
+
+```typescript
+const response = await fetch('/_v/my-api/data', {
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+**Wrong**
+
+```typescript
+const response = await fetch('https://api.example.com/data', {
+  headers: { 'x-api-key': 'sk-secret-key-12345' },
+});
+```
+
+### Constraint: IO Proxy must use relative paths only
+
+The Sales App internal proxy resolves the domain automatically.
+
+**Why this matters**
+A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
+
+**Detection**
+`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
+
+**Correct**
+
+```typescript
+await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
+```
+
+**Wrong**
+
+```typescript
+await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
+```
+
+### Constraint: defineExtensions is required in index.tsx
+
+Entry point must use `defineExtensions` from `@vtex/sales-app`.
+
+**Why this matters**
+Without it, the build succeeds but no extensions render.
+
+**Detection**
+Missing `defineExtensions` import or call in `index.tsx`.
+
+**Correct**
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+export default defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+import { MyExtension } from './components/MyExtension';
+export default { 'cart.cart-list.after': MyExtension };
+```
+
+### Constraint: Extension point names must match exactly
+
+IDs are a fixed set. Non-existent names silently fail.
+
+**Why this matters**
+The extension renders nowhere. No build error — invisible at runtime.
+
+**Detection**
+Any name not in: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`, `menu.item`, `menu.drawer-content`.
+
+**Correct**
+
+```typescript
+defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+defineExtensions({ 'cart.list.after': MyExtension });
+```
+
+### Constraint: Hooks must be used in compatible extension points
+
+Each hook has an `available_in` restriction.
+
+**Why this matters**
+Hook context is only mounted for specific extension points. Using elsewhere throws runtime errors.
+
+**Detection**
+`useCartItem` in PDP/menu. `useCurrentUser` in cart. `usePDP` in menu/cart-list.
+
+**Correct**
+
+```typescript
+// useCartItem in cart.cart-item.after ✓
+defineExtensions({ 'cart.cart-item.after': ItemWarranty });
+```
+
+**Wrong**
+
+```typescript
+// useCartItem in pdp.sidebar.after ✗ — will fail at runtime
+defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
+```
+
+### Constraint: Always present execution plan and wait for approval
+
+Do not generate code until the user confirms the plan.
+
+**Why this matters**
+Generating without agreement wastes effort and may produce the wrong extension.
+
+**Detection**
+Jumping from discovery to code generation without presenting a plan.
+
+**Correct**
+Discovery → Requirements → Present plan → **User approves** → Generate code.
+
+**Wrong**
+Discovery → Generate code immediately.
+
+## Preferred pattern
+
+### Workflow overview
+
+**Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
+
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+
+**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+
+**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+## Reference Files
+
+Load these on demand based on what the task requires. Do not load all of them upfront.
+
+| File | Load when… |
+|------|-----------|
+| [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+
+## Common failure modes
+
+- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
+- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
+- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
+- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
+- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
+- **Placing code outside packages/sales-app/src/** — Not included in build.
+- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
+- **Not presenting plan** — User may want a different approach. Always confirm.
+- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+
+## Review checklist
+
+- [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
+- [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
+- [ ] Discovery completed and use case identified?
+- [ ] Execution plan approved by user?
+- [ ] Extension point is valid (from the 8-point reference)?
+- [ ] Hooks compatible with chosen extension point?
+- [ ] Component returns JSX.Element, never null?
+- [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
+- [ ] useCartItem().item checked for undefined?
+- [ ] No auth credentials exposed in frontend code?
+- [ ] IO Proxy uses relative path (/_v/...)?
+- [ ] defineExtensions configured in index.tsx?
+- [ ] CSS file path matches component name?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+## Related skills
+
+- `faststore-storefront` — storefront customization outside Sales App
+- `vtex-io-app-contract` — building VTEX IO proxy apps for secure API integration
+
+## Reference
+
+- Sales App setup: https://beta.fast.store/sales-app/setting-up
+- FastStore getting started: https://beta.fast.store/getting-started
+- VTEX Sales App documentation: https://help.vtex.com/en/tracks/instore-getting-started-and-setting-up
+- VTEX IO app development: https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-an-app

--- a/exports/opencode/sales-app-extensibility/SKILL.md
+++ b/exports/opencode/sales-app-extensibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sales-app-extensibility
-description: "Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns."
+description: "Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 7-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, secure API integration patterns, and API documentation ingestion (OpenAPI, URLs, or inline specs) to generate typed integrations."
 ---
 
 # Sales App Extensibility
@@ -60,8 +60,9 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
 | 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
-| 4 | Local Testing | Provide dev commands and URLs |
-| 5 | Build & Deploy | Build command → deployment guide |
+| 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
+| 5 | Local Testing | Provide dev commands and URLs |
+| 6 | Build & Deploy | Build command → deployment guide |
 
 ### Extension point selection
 
@@ -91,6 +92,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 - API + no auth → **API template**
 - API + VTEX IO proxy → **IO proxy template** (recommended)
 - API + direct auth → **direct auth template** (insecure, warn user)
+- API doc provided → generate TypeScript interfaces from extracted response shapes; no API doc → use `${DATA_INTERFACE}` placeholder
 
 ### API authentication strategy
 
@@ -320,15 +322,67 @@ Discovery → Generate code immediately.
 
 **Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
 
-**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
-**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
-**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS module file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+Template for the documentation file:
+
+````markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.module.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+````
+
+**Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 6** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
 ## Reference Files
 
@@ -339,7 +393,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
-| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 
 ## Common failure modes
 
@@ -353,6 +407,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
+- **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
+- **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
 
 ## Review checklist
 
@@ -369,6 +427,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
 - [ ] CSS file path matches component name?
+- [ ] Documentation generated at `docs/<ExtensionName>.md`?
+- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/opencode/sales-app-extensibility/SKILL.md
+++ b/exports/opencode/sales-app-extensibility/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: sales-app-extensibility
+description: "Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns."
+---
+
+# Sales App Extensibility
+
+## When this skill applies
+
+Use this skill when building, customizing, or deploying extensions for VTEX Sales App.
+
+- Adding features to the cart page (promotions, loyalty, services)
+- Adding features to the Product Detail Page (badges, recommendations, warranties)
+- Adding features to the menu (user profile, navigation, metrics)
+- Integrating external APIs into Sales App extensions
+- Generating, scaffolding, or validating extension code for Sales App
+
+Do not use this skill for:
+- Regular FastStore storefront customization (use `faststore-storefront`)
+- Building VTEX IO apps (use `vtex-io-*` skills)
+- Sales App core development or framework modifications
+
+### Prerequisite: FastStore project
+
+The project root must contain: `biome.json`, `faststore.json`, `package.json`, `tsconfig.json`, `turbo.json`.
+
+If any are missing, **STOP**. The user must install FastStore first:
+
+```bash
+npx @vtex/fsp-cli init
+# Prompt: "What is the application name?" → enter name or press Enter for default
+cd <application-name> && yarn
+```
+
+Documentation: https://beta.fast.store/getting-started
+
+### Prerequisite: Sales App module
+
+Inside the FastStore project, a Sales App workspace must exist (typically at `packages/sales-app`) with `src/`, `package.json`, and `tsconfig.json`. Check root `package.json` `"workspaces"` for a path containing `sales-app`. If missing, **STOP**:
+
+```bash
+yarn add @vtex/sales-app -D -W
+npx fsp create
+# Prompts: account name → "Sales App" → path (default or custom)
+# Then add the path to root package.json "workspaces" array
+yarn install
+```
+
+Documentation: https://beta.fast.store/sales-app/setting-up
+
+**Do NOT proceed to discovery or code generation until both prerequisites are confirmed.**
+
+## Decision rules
+
+Follow the mandatory 6-step workflow in order. Do not skip steps.
+
+| Step | Purpose | Gate |
+|------|---------|------|
+| 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
+| 1 | Discovery | Understand what the user wants to build |
+| 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
+| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 4 | Local Testing | Provide dev commands and URLs |
+| 5 | Build & Deploy | Build command → deployment guide |
+
+### Extension point selection
+
+| Extension Point | Category | Available Hooks | Layout Shift |
+|----------------|----------|----------------|--------------|
+| `cart.cart-list.after` | Cart | useCart, useExtension | No |
+| `cart.cart-item.after` | Cart | useCart, useCartItem, useExtension | Yes |
+| `cart.order-summary.after` | Cart | useCart, useExtension | Yes |
+| `pdp.sidebar.before` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.sidebar.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.content.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `menu.item` | Menu | useExtension | No |
+| `menu.drawer-content` | Menu | useCurrentUser, useExtension | No |
+
+### Hook availability
+
+- **useCart** → all cart + PDP extensions
+- **useCartItem** → `cart.cart-item.after` only
+- **useCurrentUser** → `menu.drawer-content` only
+- **usePDP** → PDP extensions only
+- **useExtension** → all extension points
+
+### Template selection
+
+- No API + no hooks → **simple template**
+- No API + hooks → **hook template**
+- API + no auth → **API template**
+- API + VTEX IO proxy → **IO proxy template** (recommended)
+- API + direct auth → **direct auth template** (insecure, warn user)
+
+### API authentication strategy
+
+1. **Recommended: VTEX IO Proxy App** — IO app stores keys server-side. Extension uses `credentials: 'include'` with a **relative path** (`/_v/my-api/data`).
+2. **Insecure: Direct Auth** — Keys in frontend code, visible in browser. Testing/development only.
+
+## Hard constraints
+
+### Constraint: Component must return JSX.Element, never null
+
+`defineExtensions` expects `ExtensionPointComponent` which returns `Element`, not `Element | null`.
+
+**Why this matters**
+Returning `null` causes a TypeScript compilation error. The build will fail.
+
+**Detection**
+`return null` in any component registered with `defineExtensions`.
+
+**Correct**
+
+```typescript
+export function MyExtension(): JSX.Element {
+  if (!data) return (<></>);
+  return <div>{data.value}</div>;
+}
+```
+
+**Wrong**
+
+```typescript
+export function MyExtension(): JSX.Element | null {
+  if (!data) return null;
+  return <div>{data.value}</div>;
+}
+```
+
+### Constraint: Guard optional properties before use
+
+`CartItem.manualPrice` (number | undefined), `CartItem.productRefId` (string | undefined), `CartItem.attachments` (Attachment[] | undefined) must be guarded.
+
+**Why this matters**
+TypeScript strict mode rejects accessing possibly-undefined values.
+
+**Detection**
+`item.manualPrice`, `item.productRefId`, or `item.attachments` without `?.`, `??`, `&&`, or `!= null`.
+
+**Correct**
+
+```typescript
+const price = item.manualPrice ?? item.sellingPrice;
+const refId = item.productRefId ?? 'N/A';
+const count = item.attachments?.length ?? 0;
+```
+
+**Wrong**
+
+```typescript
+const price = item.manualPrice;
+const refId = item.productRefId.toUpperCase();
+const count = item.attachments.length;
+```
+
+### Constraint: useCartItem().item may be undefined
+
+`item` from `useCartItem()` is `CartItem | undefined`.
+
+**Why this matters**
+Accessing properties on `undefined` causes a runtime crash.
+
+**Detection**
+Destructured `item` from `useCartItem()` used without `if (!item)` guard.
+
+**Correct**
+
+```typescript
+const { item } = useCartItem();
+if (!item) return (<></>);
+return <div>{item.name}</div>;
+```
+
+**Wrong**
+
+```typescript
+const { item } = useCartItem();
+return <div>{item.name}</div>;
+```
+
+### Constraint: Never expose authentication keys in frontend code
+
+API keys in `fetch` headers are visible in the browser network tab.
+
+**Why this matters**
+Leaked keys compromise the external service.
+
+**Detection**
+Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
+
+**Correct**
+
+```typescript
+const response = await fetch('/_v/my-api/data', {
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+**Wrong**
+
+```typescript
+const response = await fetch('https://api.example.com/data', {
+  headers: { 'x-api-key': 'sk-secret-key-12345' },
+});
+```
+
+### Constraint: IO Proxy must use relative paths only
+
+The Sales App internal proxy resolves the domain automatically.
+
+**Why this matters**
+A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
+
+**Detection**
+`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
+
+**Correct**
+
+```typescript
+await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
+```
+
+**Wrong**
+
+```typescript
+await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
+```
+
+### Constraint: defineExtensions is required in index.tsx
+
+Entry point must use `defineExtensions` from `@vtex/sales-app`.
+
+**Why this matters**
+Without it, the build succeeds but no extensions render.
+
+**Detection**
+Missing `defineExtensions` import or call in `index.tsx`.
+
+**Correct**
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+export default defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+import { MyExtension } from './components/MyExtension';
+export default { 'cart.cart-list.after': MyExtension };
+```
+
+### Constraint: Extension point names must match exactly
+
+IDs are a fixed set. Non-existent names silently fail.
+
+**Why this matters**
+The extension renders nowhere. No build error — invisible at runtime.
+
+**Detection**
+Any name not in: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`, `menu.item`, `menu.drawer-content`.
+
+**Correct**
+
+```typescript
+defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+defineExtensions({ 'cart.list.after': MyExtension });
+```
+
+### Constraint: Hooks must be used in compatible extension points
+
+Each hook has an `available_in` restriction.
+
+**Why this matters**
+Hook context is only mounted for specific extension points. Using elsewhere throws runtime errors.
+
+**Detection**
+`useCartItem` in PDP/menu. `useCurrentUser` in cart. `usePDP` in menu/cart-list.
+
+**Correct**
+
+```typescript
+// useCartItem in cart.cart-item.after ✓
+defineExtensions({ 'cart.cart-item.after': ItemWarranty });
+```
+
+**Wrong**
+
+```typescript
+// useCartItem in pdp.sidebar.after ✗ — will fail at runtime
+defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
+```
+
+### Constraint: Always present execution plan and wait for approval
+
+Do not generate code until the user confirms the plan.
+
+**Why this matters**
+Generating without agreement wastes effort and may produce the wrong extension.
+
+**Detection**
+Jumping from discovery to code generation without presenting a plan.
+
+**Correct**
+Discovery → Requirements → Present plan → **User approves** → Generate code.
+
+**Wrong**
+Discovery → Generate code immediately.
+
+## Preferred pattern
+
+### Workflow overview
+
+**Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
+
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+
+**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+
+**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+## Reference Files
+
+Load these on demand based on what the task requires. Do not load all of them upfront.
+
+| File | Load when… |
+|------|-----------|
+| [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+
+## Common failure modes
+
+- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
+- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
+- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
+- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
+- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
+- **Placing code outside packages/sales-app/src/** — Not included in build.
+- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
+- **Not presenting plan** — User may want a different approach. Always confirm.
+- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+
+## Review checklist
+
+- [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
+- [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
+- [ ] Discovery completed and use case identified?
+- [ ] Execution plan approved by user?
+- [ ] Extension point is valid (from the 8-point reference)?
+- [ ] Hooks compatible with chosen extension point?
+- [ ] Component returns JSX.Element, never null?
+- [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
+- [ ] useCartItem().item checked for undefined?
+- [ ] No auth credentials exposed in frontend code?
+- [ ] IO Proxy uses relative path (/_v/...)?
+- [ ] defineExtensions configured in index.tsx?
+- [ ] CSS file path matches component name?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+## Related skills
+
+- `faststore-storefront` — storefront customization outside Sales App
+- `vtex-io-app-contract` — building VTEX IO proxy apps for secure API integration
+
+## Reference
+
+- Sales App setup: https://beta.fast.store/sales-app/setting-up
+- FastStore getting started: https://beta.fast.store/getting-started
+- VTEX Sales App documentation: https://help.vtex.com/en/tracks/instore-getting-started-and-setting-up
+- VTEX IO app development: https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-an-app

--- a/tracks/sales-app/index.md
+++ b/tracks/sales-app/index.md
@@ -1,0 +1,23 @@
+# Sales App Track
+
+Extension development for VTEX Sales App, the in-store assisted selling application. This track covers the complete lifecycle of building Sales App extensions — from prerequisites and discovery through code generation, validation, and deployment.
+
+## Skill
+
+| Skill | Description |
+|-------|-------------|
+| **[sales-app-extensibility](skills/sales-app-extensibility/skill.md)** | Complete 6-step workflow for building Sales App extensions — extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, API integration patterns, code generation, validation, and deployment. |
+
+## Key Constraints
+
+- **Always check prerequisites first** — FastStore and Sales App module must be installed before any work.
+- **Never skip discovery** — identify the use case and extension point before generating code.
+- **Components must return JSX.Element, never null** — `defineExtensions` requires `ExtensionPointComponent` which does not accept null.
+- **Never expose auth keys in frontend code** — use a VTEX IO proxy app for secure API integration.
+- **IO Proxy must use relative paths only** — the Sales App internal proxy resolves domains automatically.
+- **Always present the execution plan and wait for approval** before generating code.
+
+## Related Tracks
+
+- [FastStore Implementation](../faststore/index.md) — storefront customization outside Sales App.
+- [Custom VTEX IO Apps](../vtex-io/index.md) — building IO proxy apps for secure API integration.

--- a/tracks/sales-app/install.sh
+++ b/tracks/sales-app/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKILLS_DIR="${1:-$HOME/.cursor/skills}"
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+mkdir -p "$SKILLS_DIR"
+
+for skill_dir in "$REPO_DIR"/skills/*/; do
+  skill_name="$(basename "$skill_dir")"
+  target="$SKILLS_DIR/$skill_name"
+
+  if [ -L "$target" ]; then
+    existing="$(readlink "$target")"
+    if [ "$existing" = "$skill_dir" ] || [ "$existing" = "${skill_dir%/}" ]; then
+      echo "✓ $skill_name — symlink já existe"
+      continue
+    fi
+    echo "↻ $skill_name — atualizando symlink (apontava para $existing)"
+    rm "$target"
+  elif [ -e "$target" ]; then
+    echo "⚠ $skill_name — $target já existe e não é um symlink, pulando"
+    continue
+  fi
+
+  ln -s "${skill_dir%/}" "$target"
+  echo "✓ $skill_name — symlink criado → $target"
+done
+
+echo ""
+echo "Instalação concluída. Reinicie o Cursor ou abra um novo chat para carregar as skills."

--- a/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -76,7 +76,8 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 ```typescript
 // useCart — access cart data and mutations
 const cart = useCart();
-// cart.items, cart.value, cart.totalizers, cart.clientProfileData, cart.addItem()
+// cart.items, cart.value, cart.totalizers, cart.clientProfileData, cart.giftCards
+// cart.addItem(), cart.removeItem(), cart.addCoupon(), cart.addGiftCard(), cart.sync()
 
 // useCartItem — access individual cart item (cart.cart-item.after ONLY)
 const { item, itemIndex, changeItem, changePrice } = useCartItem();

--- a/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -1,0 +1,448 @@
+---
+name: sales-app-code-templates
+description: Code generation templates for Sales App extensions — simple, hook-based, API (no auth), IO Proxy (secure), Direct Auth (insecure), CSS module, and index.tsx with defineExtensions. Use when generating or scaffolding extension code.
+metadata:
+  version: "1.0"
+---
+
+# Code Templates and Patterns
+
+## Template Selection
+
+| Condition | Template |
+|-----------|----------|
+| No API + no hooks | Simple template |
+| No API + hooks needed | Hook template |
+| API + no authentication | API template |
+| API + VTEX IO proxy app | IO Proxy template (recommended) |
+| API + direct auth | Direct Auth template (insecure — warn user) |
+
+## Simple Extension (no hooks, no API)
+
+```typescript
+import React from 'react';
+import './${COMPONENT_NAME}.css';
+
+/**
+ * ${COMPONENT_NAME}
+ * ${DESCRIPTION}
+ *
+ * Extension Point: ${EXTENSION_POINT}
+ *
+ * IMPORTANT: This component MUST always return a JSX.Element, never null.
+ * The defineExtensions type (ExtensionPointComponent) does not accept null.
+ * If you need to conditionally hide content, return an empty fragment: <></>
+ */
+export function ${COMPONENT_NAME}(): JSX.Element {
+  return (
+    <div className="container">
+      <div className="content">
+        ${CONTENT}
+      </div>
+    </div>
+  );
+}
+```
+
+## Extension with Hooks
+
+```typescript
+import React from 'react';
+import { ${HOOKS_IMPORT} } from '@vtex/sales-app';
+import './${COMPONENT_NAME}.css';
+
+/**
+ * ${COMPONENT_NAME}
+ * ${DESCRIPTION}
+ *
+ * Extension Point: ${EXTENSION_POINT}
+ * Hooks: ${HOOKS_LIST}
+ */
+export function ${COMPONENT_NAME}(): JSX.Element {
+  ${HOOKS_USAGE}
+
+  return (
+    <div className="container">
+      <div className="content">
+        ${CONTENT}
+      </div>
+    </div>
+  );
+}
+```
+
+### Hook initialization patterns
+
+```typescript
+// useCart — access cart data and mutations
+const cart = useCart();
+// cart.items, cart.value, cart.totalizers, cart.clientProfileData, cart.addItem()
+
+// useCartItem — access individual cart item (cart.cart-item.after ONLY)
+const { item, itemIndex, changeItem, changePrice } = useCartItem();
+// ALWAYS check: if (!item) return (<></>);
+
+// useCurrentUser — access logged-in user (menu.drawer-content ONLY)
+const { name, email } = useCurrentUser();
+
+// useExtension — access account and extension point context (ALL extension points)
+const { account, extensionPoint } = useExtension();
+
+// usePDP — access product data (PDP extensions ONLY)
+const { productSku } = usePDP();
+// productSku.id, productSku.name, productSku.price, productSku.listPrice
+```
+
+## Extension with API (no auth)
+
+```typescript
+import React, { useState, useEffect } from 'react';
+import { ${HOOKS_IMPORT} } from '@vtex/sales-app';
+import './${COMPONENT_NAME}.css';
+
+interface ${COMPONENT_NAME}Data {
+  // Define the API response structure
+  ${DATA_INTERFACE}
+}
+
+export function ${COMPONENT_NAME}(): JSX.Element {
+  ${HOOKS_USAGE}
+  const [data, setData] = useState<${COMPONENT_NAME}Data | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const response = await fetch('${API_ENDPOINT}', {
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
+        });
+
+        if (!response.ok) throw new Error('Failed to fetch data');
+        const result = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [account]);
+
+  if (loading) {
+    return (
+      <div className="container">
+        <div className="loading">
+          <span className="spinner"></span>
+          <span>Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container">
+        <div className="error"><span>Error: {error}</span></div>
+      </div>
+    );
+  }
+
+  if (!data) return (<></>);
+
+  return (
+    <div className="container">
+      <div className="content">
+        ${CONTENT}
+      </div>
+    </div>
+  );
+}
+```
+
+## Extension with IO Proxy (recommended for authenticated APIs)
+
+The IO app handles the external API keys securely on the server side. The extension uses `credentials: 'include'` to forward session cookies.
+
+**Critical**: The API endpoint must be a **relative path** (e.g., `/_v/my-api/data`). **NEVER** use a full URL like `https://{account}.myvtex.com/...`. The Sales App internal proxy resolves the domain automatically.
+
+```typescript
+import React, { useState, useEffect } from 'react';
+import { ${HOOKS_IMPORT} } from '@vtex/sales-app';
+import './${COMPONENT_NAME}.css';
+
+interface ${COMPONENT_NAME}Data {
+  ${DATA_INTERFACE}
+}
+
+export function ${COMPONENT_NAME}(): JSX.Element {
+  ${HOOKS_USAGE}
+  const [data, setData] = useState<${COMPONENT_NAME}Data | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const response = await fetch('${API_ENDPOINT}', {
+          method: '${API_METHOD}',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          ${FETCH_BODY}
+        });
+
+        if (!response.ok) throw new Error('Failed to fetch data');
+        const result = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [account]);
+
+  if (loading) {
+    return (
+      <div className="container">
+        <div className="loading">
+          <span className="spinner"></span>
+          <span>Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container">
+        <div className="error"><span>Error: {error}</span></div>
+      </div>
+    );
+  }
+
+  if (!data) return (<></>);
+
+  return (
+    <div className="container">
+      <div className="content">
+        ${CONTENT}
+      </div>
+    </div>
+  );
+}
+```
+
+## Extension with Direct Auth (insecure — testing only)
+
+**⚠️ SECURITY WARNING**: This template passes authentication keys directly in request headers. The keys are visible to anyone inspecting the browser's network requests. Use a VTEX IO proxy app in production.
+
+```typescript
+import React, { useState, useEffect } from 'react';
+import { ${HOOKS_IMPORT} } from '@vtex/sales-app';
+import './${COMPONENT_NAME}.css';
+
+/**
+ * ⚠️ SECURITY WARNING: Authentication keys exposed in frontend code.
+ * Move to a VTEX IO proxy app for production use.
+ */
+
+interface ${COMPONENT_NAME}Data {
+  ${DATA_INTERFACE}
+}
+
+export function ${COMPONENT_NAME}(): JSX.Element {
+  ${HOOKS_USAGE}
+  const [data, setData] = useState<${COMPONENT_NAME}Data | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const response = await fetch('${API_ENDPOINT}', {
+          method: '${API_METHOD}',
+          headers: {
+            'Content-Type': 'application/json',
+            // ⚠️ INSECURE: Authentication key exposed in frontend code
+            '${AUTH_HEADER_NAME}': '${AUTH_HEADER_VALUE}',
+          },
+          ${FETCH_BODY}
+        });
+
+        if (!response.ok) throw new Error('Failed to fetch data');
+        const result = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [account]);
+
+  if (loading) {
+    return (
+      <div className="container">
+        <div className="loading">
+          <span className="spinner"></span>
+          <span>Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container">
+        <div className="error"><span>Error: {error}</span></div>
+      </div>
+    );
+  }
+
+  if (!data) return (<></>);
+
+  return (
+    <div className="container">
+      <div className="content">
+        ${CONTENT}
+      </div>
+    </div>
+  );
+}
+```
+
+## CSS Module
+
+All extensions use CSS modules with Admin UI design tokens.
+
+```css
+/**
+ * ${COMPONENT_NAME} Styles
+ * Design tokens follow Admin UI patterns.
+ */
+
+.container { padding: 16px; background-color: #ffffff; }
+.content { display: flex; flex-direction: column; gap: 12px; }
+.title { font-size: 16px; font-weight: 600; color: #1a1a1a; margin: 0; }
+.subtitle { font-size: 14px; color: #666666; margin: 0; }
+.text { font-size: 14px; color: #333333; line-height: 1.5; }
+
+/* Loading State */
+.loading {
+  display: flex; align-items: center; justify-content: center;
+  gap: 8px; padding: 24px; color: #666666;
+}
+.spinner {
+  width: 20px; height: 20px;
+  border: 2px solid #e0e0e0; border-top-color: #0066cc;
+  border-radius: 50%; animation: spin 1s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Error State */
+.error {
+  padding: 16px; background-color: #fff5f5;
+  border: 1px solid #ffcccc; border-radius: 8px;
+  color: #cc0000; font-size: 14px;
+}
+
+/* Button Styles */
+.button {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 10px 16px; font-size: 14px; font-weight: 500;
+  border: none; border-radius: 6px; cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+.buttonPrimary { background-color: #0066cc; color: #ffffff; }
+.buttonPrimary:hover { background-color: #0052a3; }
+.buttonSecondary { background-color: #f0f0f0; color: #333333; }
+.buttonSecondary:hover { background-color: #e0e0e0; }
+
+/* Card Styles */
+.card {
+  padding: 16px; background-color: #f9f9f9;
+  border-radius: 8px; border: 1px solid #e0e0e0;
+}
+
+/* Badge Styles */
+.badge {
+  display: inline-block; padding: 4px 8px;
+  font-size: 12px; font-weight: 500; border-radius: 4px;
+}
+.badgeSuccess { background-color: #e6f4ea; color: #137333; }
+.badgeWarning { background-color: #fef7e0; color: #b06000; }
+.badgeInfo { background-color: #e8f0fe; color: #1a73e8; }
+
+/* Input Styles */
+.input {
+  width: 100%; padding: 10px 12px; font-size: 14px;
+  border: 1px solid #d0d0d0; border-radius: 6px;
+  outline: none; transition: border-color 0.2s ease;
+}
+.input:focus { border-color: #0066cc; }
+
+/* Row/Flex Helpers */
+.row { display: flex; align-items: center; gap: 12px; }
+.spaceBetween { justify-content: space-between; }
+
+/* Price Display */
+.price { font-size: 18px; font-weight: 600; color: #1a1a1a; }
+.priceOld { font-size: 14px; color: #999999; text-decoration: line-through; }
+.priceDiscount { font-size: 14px; color: #137333; font-weight: 500; }
+```
+
+## index.tsx with defineExtensions
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+${COMPONENT_IMPORTS}
+
+/**
+ * Sales App Extensions Entry Point
+ *
+ * Connects extension components to their target extension points.
+ * Each extension point can only have one component assigned to it.
+ *
+ * Available extension points:
+ * - cart.cart-list.after
+ * - cart.cart-item.after
+ * - cart.order-summary.after
+ * - pdp.sidebar.before
+ * - pdp.sidebar.after
+ * - pdp.content.after
+ * - menu.item
+ * - menu.drawer-content
+ */
+export default defineExtensions({
+  ${EXTENSION_MAPPINGS}
+});
+```
+
+## Validation Rules
+
+After generating code, validate for these issues:
+
+1. **React import present** — `import React from 'react'` is required for JSX compilation
+2. **Component exported** — must have `export function`, `export const`, or `export default`
+3. **No null returns** — `return null` is not allowed; use `return (<></>)` instead
+4. **Hook imports** — all hooks must be imported from `@vtex/sales-app`
+5. **Optional property guards** — `manualPrice`, `productRefId`, `attachments` must have null checks
+6. **useCartItem item check** — `if (!item) return (<></>)` before accessing item properties
+7. **Hook/extension-point compatibility** — each hook is only valid in specific extension points
+8. **API call handling** — loading state and error handling must be present for any `fetch()` call
+9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
+10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`

--- a/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -101,13 +101,14 @@ import { ${HOOKS_IMPORT} } from '@vtex/sales-app';
 import './${COMPONENT_NAME}.css';
 
 interface ${COMPONENT_NAME}Data {
-  // Define the API response structure
+  // Generated from API documentation — see docs/<ExtensionName>.md for source
+  // Object fields → typed properties. Nested objects → separate interfaces. Optional fields → property?: Type
   ${DATA_INTERFACE}
 }
 
 export function ${COMPONENT_NAME}(): JSX.Element {
   ${HOOKS_USAGE}
-  const [data, setData] = useState<${COMPONENT_NAME}Data | null>(null);
+  const [data, setData] = useState<${COMPONENT_NAME}Data | null>(null)
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -177,6 +178,8 @@ import { ${HOOKS_IMPORT} } from '@vtex/sales-app';
 import './${COMPONENT_NAME}.css';
 
 interface ${COMPONENT_NAME}Data {
+  // Generated from API documentation — see docs/<ExtensionName>.md for source
+  // Object fields → typed properties. Nested objects → separate interfaces. Optional fields → property?: Type
   ${DATA_INTERFACE}
 }
 
@@ -257,6 +260,8 @@ import './${COMPONENT_NAME}.css';
  */
 
 interface ${COMPONENT_NAME}Data {
+  // Generated from API documentation — see docs/<ExtensionName>.md for source
+  // Object fields → typed properties. Nested objects → separate interfaces. Optional fields → property?: Type
   ${DATA_INTERFACE}
 }
 
@@ -446,3 +451,136 @@ After generating code, validate for these issues:
 8. **API call handling** — loading state and error handling must be present for any `fetch()` call
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
+
+## API Type Generation from Documentation
+
+When API documentation was ingested during Discovery (Step 1), generate TypeScript interfaces from the extracted response shapes. Apply these rules:
+
+### JSON to TypeScript conversion rules
+
+| JSON value | TypeScript type |
+|-----------|----------------|
+| `"string"` | `string` |
+| `123` | `number` |
+| `true` / `false` | `boolean` |
+| `null` or sometimes absent | `type \| null` or `property?: type` |
+| `{ }` (nested object) | Separate named `interface` |
+| `[ ]` (array of objects) | `InterfaceType[]` |
+| `[ ]` (array of primitives) | `string[]`, `number[]`, etc. |
+
+### Naming conventions
+
+- Top-level response type: `{ComponentName}Data` (replaces the `${DATA_INTERFACE}` placeholder)
+- Nested object type: `{ComponentName}{FieldName}` (e.g., `LoyaltyHistoryEntry`)
+- Request body type (POST/PUT): `{ComponentName}Request`
+- Keep names PascalCase and domain-specific
+
+### Example
+
+Given API response:
+
+```json
+{ "points": 100, "tier": "gold", "expiresAt": null, "history": [{ "date": "2026-01-01", "amount": 10 }] }
+```
+
+Generate:
+
+```typescript
+interface LoyaltyHistoryEntry {
+  date: string;
+  amount: number;
+}
+
+interface LoyaltyData {
+  points: number;
+  tier: string;
+  expiresAt: string | null;
+  history: LoyaltyHistoryEntry[];
+}
+```
+
+If a field is documented as optional (not always present), use `?`:
+
+```typescript
+interface ProductRecommendationData {
+  id: string;
+  name: string;
+  price: number;
+  imageUrl?: string;  // optional per API docs
+  badge?: string;     // optional per API docs
+}
+```
+
+### Multiple endpoints
+
+If the extension calls more than one endpoint, generate a separate interface per endpoint response. Prefix with the endpoint purpose: `{ComponentName}{Purpose}Data` (e.g., `LoyaltyBalanceData`, `LoyaltyRedemptionResponse`).
+
+## Custom Fetch Hook Pattern
+
+Use this pattern when the extension calls **2 or more endpoints** or when the fetch logic is complex (chained requests, pagination, polling).
+
+### Decision rule
+
+- **1 endpoint** → inline `useEffect` fetch inside the component (existing pattern).
+- **2+ endpoints** → extract into one or more custom hooks in `hooks/use{Purpose}.ts`.
+
+### Custom hook template
+
+```typescript
+import { useState, useEffect } from 'react';
+
+export function use${Purpose}(account: string) {
+  const [data, setData] = useState<${ResponseType} | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetch('${API_ENDPOINT}', {
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        });
+        if (!response.ok) throw new Error('Failed to fetch ${Purpose}');
+        const result: ${ResponseType} = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [account]);
+
+  return { data, loading, error };
+}
+```
+
+### Usage in component
+
+```typescript
+import { use${Purpose} } from './hooks/use${Purpose}';
+
+export function ${COMPONENT_NAME}(): JSX.Element {
+  const { account } = useExtension();
+  const { data: balance, loading: loadingBalance, error: errorBalance } = use${Purpose}(account);
+  const { data: history, loading: loadingHistory, error: errorHistory } = use${OtherPurpose}(account);
+
+  if (loadingBalance || loadingHistory) return <div className="loading">Loading...</div>;
+  if (errorBalance || errorHistory) return <div className="error">Error loading data</div>;
+  if (!balance || !history) return (<></>);
+
+  return (
+    <div className="container">
+      {/* render using balance and history */}
+    </div>
+  );
+}
+```
+
+### File placement
+
+Custom hooks go in `packages/sales-app/src/hooks/use{Purpose}.ts`. They must be TypeScript-only files (no JSX, no `.tsx` extension needed unless they return JSX).

--- a/tracks/sales-app/skills/sales-app-extensibility/references/discovery-and-use-cases.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/discovery-and-use-cases.md
@@ -1,0 +1,148 @@
+---
+name: sales-app-discovery-and-use-cases
+description: Discovery flow for identifying what Sales App extension to build, including use case detection keywords, targeted follow-up questions per use case, and API authentication strategy decision tree. Use during Step 1 (Discovery) of the workflow.
+metadata:
+  version: "1.0"
+---
+
+# Discovery Flow and Use Cases
+
+## Use Case Detection
+
+Detect the use case from keywords in the user's description:
+
+| Use Case | Keywords | Complexity | Requires API | Requires Hooks |
+|----------|----------|------------|-------------|----------------|
+| Static Information | message, warning, banner, badge, text, static, fixed | Simple | No | No |
+| Loyalty Program | loyalty, points, benefit, redeem, cashback, program | Medium | Yes | Yes |
+| Additional Services | warranty, insurance, installation, assembly, service, extra | Medium | Yes | Yes |
+| Product Recommendations | recommendation, suggestion, related, complementary, cross-sell, upsell | High | Yes | Yes |
+| Custom Discounts | discount, coupon, promotion, price, voucher | High | Yes | Yes |
+| User Profile Display | profile, user, seller, menu, drawer | Simple | No | Yes |
+
+## Discovery Questions by Use Case
+
+### Static Information
+
+1. **Content type**: Text message, Banner/Card, Badge/Tag, List of information, or Alert/Warning?
+2. **Location**: Which extension point?
+   - `cart.cart-list.after` — After the cart items list
+   - `cart.order-summary.after` — After the order summary
+   - `pdp.sidebar.before` — Before the PDP sidebar
+   - `pdp.sidebar.after` — After the PDP sidebar
+   - `pdp.content.after` — After the PDP content
+3. **Content**: What text/information to display?
+
+**Recommended extension points**: `cart.cart-list.after`, `cart.order-summary.after`, `pdp.sidebar.before`
+**Required hooks**: none
+**Template**: Simple
+
+### Loyalty Program
+
+1. **Data source**: Own external API, VTEX IO app, VTEX Master Data, Third-party API, or Not sure yet?
+2. **API endpoint**: Path (e.g., `/_v/my-loyalty/points`) — only if external data source
+3. **HTTP method**: GET, POST, PUT, or DELETE?
+4. **Request params**: Parameters, query strings, or request body to send
+5. **Response format**: JSON structure of the API response (required for component data mapping)
+6. **Features**: Display points balance, Show earnings with purchase, Allow points redemption, Display customer level
+7. **Location**: `cart.order-summary.after` or `menu.drawer-content`
+8. **Interaction**: View only or Interactive (redeem points, apply discounts)?
+
+**Recommended extension points**: `cart.order-summary.after`, `menu.drawer-content`
+**Required hooks**: useCart, useExtension, useCurrentUser
+**Template**: API (IO Proxy or Direct Auth)
+
+### Additional Services
+
+1. **Service types**: Extended warranty, Insurance, Installation, Assembly, Customization, Other
+2. **Data source**: External API, VTEX IO app, Fixed list in code, or VTEX Catalog?
+3. **API endpoint**: Path — only if external data source
+4. **HTTP method**: GET, POST, PUT, or DELETE?
+5. **Request params**: Parameters or request body
+6. **Response format**: JSON structure of the API response
+7. **Location**: `cart.cart-item.after` (per item) or `pdp.sidebar.after` (product page)
+8. **Pricing model**: Fixed price, Percentage of product, or Calculated by API?
+
+**Recommended extension points**: `cart.cart-item.after`, `pdp.sidebar.after`
+**Required hooks**: useCart, useCartItem, usePDP
+**Template**: Hook or API (depending on data source)
+
+### Product Recommendations
+
+1. **Recommendation type**: Frequently bought together, Accessories, Similar products, Upgrades
+2. **Data source**: Own API, VTEX Intelligent Search, Fixed rules, or Third-party API?
+3. **API endpoint**: Path — only if external data source
+4. **HTTP method**: GET, POST, PUT, or DELETE?
+5. **Request params**: Parameters or request body
+6. **Response format**: JSON structure of the API response
+7. **Location**: `cart.cart-list.after` or `pdp.content.after`
+8. **Quick add**: Can the seller quickly add recommended products to the cart?
+9. **Display count**: 3, 4, 6 products, or customizable?
+
+**Recommended extension points**: `cart.cart-list.after`, `pdp.content.after`
+**Required hooks**: useCart, usePDP, useExtension
+**Template**: API (IO Proxy or Direct Auth)
+
+### Custom Discounts
+
+1. **Discount types**: Discount coupon, Manual seller discount, Volume discount, Special promotion
+2. **Validation source**: Own promotions API, VTEX Promotions, or Fixed coupon list?
+3. **API endpoint**: Path for validation — only if external API
+4. **HTTP method**: GET, POST, PUT, or DELETE?
+5. **Request params**: Parameters or request body
+6. **Response format**: JSON structure of the API response
+7. **Discount limits**: No limit, Maximum percentage, Maximum value, or Depends on seller level?
+8. **Approval needed**: No, Yes above a certain value, or Always?
+
+**Recommended extension points**: `cart.order-summary.after`
+**Required hooks**: useCart, useCurrentUser, useExtension
+**Template**: API (IO Proxy or Direct Auth)
+
+### User Profile Display
+
+1. **Information to display**: Name, Email, Sales metrics, Goals, Quick settings
+2. **Metrics source** (if metrics selected): No metrics, Internal API, VTEX OMS, or Static data?
+
+**Recommended extension points**: `menu.drawer-content`
+**Required hooks**: useCurrentUser, useExtension
+**Template**: Hook (no API if only using useCurrentUser data)
+
+## API Authentication Decision Tree
+
+When the use case requires an external API:
+
+### Step 1: Confirm API details
+
+Collect: HTTP method, request parameters/body, and API response JSON structure.
+
+### Step 2: Does the API need authentication?
+
+- **No** → Use the basic API template. Done.
+- **Yes** → Continue to Step 3.
+
+### Step 3: Does the user have a VTEX IO proxy app?
+
+A VTEX IO proxy app acts as a middleware: the Sales App extension calls the IO app using `credentials: 'include'` to forward session cookies, and the IO app calls the external API with the secret keys on the server side. The keys never leave the server.
+
+- **Yes** → Collect the IO app endpoint path (relative, starting with `/`). Use IO Proxy template. Done.
+- **No** → Continue to Step 4.
+
+### Step 4: Implement IO proxy first, or continue with insecure direct auth?
+
+- **Implement IO proxy first** → Stop the Sales App extension workflow. The user should build the IO proxy app first and return later.
+- **Continue with insecure direct auth** → Continue to Step 5.
+
+### Step 5: Security warning and direct auth details
+
+**⚠️ WARNING**: Passing authentication keys directly in frontend code is **NOT secure**. The keys will be visible to anyone inspecting the browser. Confirm the user understands and accepts the risk.
+
+If confirmed, collect:
+- Auth header name (e.g., `x-api-key`, `Authorization`)
+- Auth header value (e.g., `Bearer your-token`, `your-api-key`)
+- Full API endpoint URL
+
+Use the Direct Auth template.
+
+### IO Proxy Critical Rule
+
+The `fetch` call in the extension must use **ONLY the relative path** (e.g., `/_v/my-api/endpoint`). **NEVER** prefix with `https://` or a domain like `{account}.myvtex.com`. The Sales App has an internal proxy that automatically resolves the domain.

--- a/tracks/sales-app/skills/sales-app-extensibility/references/discovery-and-use-cases.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/discovery-and-use-cases.md
@@ -39,11 +39,12 @@ Detect the use case from keywords in the user's description:
 
 ### Loyalty Program
 
+0. **API documentation** (optional, recommended): Do you have API documentation to share? URL, OpenAPI/Swagger JSON/YAML, Markdown file path, or paste the spec inline. If yes, skip questions 2–5 — the agent will extract endpoint, parameters, and response types automatically.
 1. **Data source**: Own external API, VTEX IO app, VTEX Master Data, Third-party API, or Not sure yet?
-2. **API endpoint**: Path (e.g., `/_v/my-loyalty/points`) — only if external data source
-3. **HTTP method**: GET, POST, PUT, or DELETE?
-4. **Request params**: Parameters, query strings, or request body to send
-5. **Response format**: JSON structure of the API response (required for component data mapping)
+2. **API endpoint**: Path (e.g., `/_v/my-loyalty/points`) — only if external data source and no docs provided
+3. **HTTP method**: GET, POST, PUT, or DELETE? — skip if API docs provided
+4. **Request params**: Parameters, query strings, or request body to send — skip if API docs provided
+5. **Response format**: JSON structure of the API response — skip if API docs provided
 6. **Features**: Display points balance, Show earnings with purchase, Allow points redemption, Display customer level
 7. **Location**: `cart.order-summary.after` or `menu.drawer-content`
 8. **Interaction**: View only or Interactive (redeem points, apply discounts)?
@@ -54,12 +55,13 @@ Detect the use case from keywords in the user's description:
 
 ### Additional Services
 
+0. **API documentation** (optional, recommended): Do you have API documentation to share? URL, OpenAPI/Swagger JSON/YAML, Markdown file path, or paste the spec inline. If yes, skip questions 3–6 — the agent will extract endpoint, parameters, and response types automatically.
 1. **Service types**: Extended warranty, Insurance, Installation, Assembly, Customization, Other
 2. **Data source**: External API, VTEX IO app, Fixed list in code, or VTEX Catalog?
-3. **API endpoint**: Path — only if external data source
-4. **HTTP method**: GET, POST, PUT, or DELETE?
-5. **Request params**: Parameters or request body
-6. **Response format**: JSON structure of the API response
+3. **API endpoint**: Path — only if external data source and no docs provided
+4. **HTTP method**: GET, POST, PUT, or DELETE? — skip if API docs provided
+5. **Request params**: Parameters or request body — skip if API docs provided
+6. **Response format**: JSON structure of the API response — skip if API docs provided
 7. **Location**: `cart.cart-item.after` (per item) or `pdp.sidebar.after` (product page)
 8. **Pricing model**: Fixed price, Percentage of product, or Calculated by API?
 
@@ -69,12 +71,13 @@ Detect the use case from keywords in the user's description:
 
 ### Product Recommendations
 
+0. **API documentation** (optional, recommended): Do you have API documentation to share? URL, OpenAPI/Swagger JSON/YAML, Markdown file path, or paste the spec inline. If yes, skip questions 3–6 — the agent will extract endpoint, parameters, and response types automatically.
 1. **Recommendation type**: Frequently bought together, Accessories, Similar products, Upgrades
 2. **Data source**: Own API, VTEX Intelligent Search, Fixed rules, or Third-party API?
-3. **API endpoint**: Path — only if external data source
-4. **HTTP method**: GET, POST, PUT, or DELETE?
-5. **Request params**: Parameters or request body
-6. **Response format**: JSON structure of the API response
+3. **API endpoint**: Path — only if external data source and no docs provided
+4. **HTTP method**: GET, POST, PUT, or DELETE? — skip if API docs provided
+5. **Request params**: Parameters or request body — skip if API docs provided
+6. **Response format**: JSON structure of the API response — skip if API docs provided
 7. **Location**: `cart.cart-list.after` or `pdp.content.after`
 8. **Quick add**: Can the seller quickly add recommended products to the cart?
 9. **Display count**: 3, 4, 6 products, or customizable?
@@ -85,12 +88,13 @@ Detect the use case from keywords in the user's description:
 
 ### Custom Discounts
 
+0. **API documentation** (optional, recommended): Do you have API documentation to share? URL, OpenAPI/Swagger JSON/YAML, Markdown file path, or paste the spec inline. If yes, skip questions 3–6 — the agent will extract endpoint, parameters, and response types automatically.
 1. **Discount types**: Discount coupon, Manual seller discount, Volume discount, Special promotion
 2. **Validation source**: Own promotions API, VTEX Promotions, or Fixed coupon list?
-3. **API endpoint**: Path for validation — only if external API
-4. **HTTP method**: GET, POST, PUT, or DELETE?
-5. **Request params**: Parameters or request body
-6. **Response format**: JSON structure of the API response
+3. **API endpoint**: Path for validation — only if external API and no docs provided
+4. **HTTP method**: GET, POST, PUT, or DELETE? — skip if API docs provided
+5. **Request params**: Parameters or request body — skip if API docs provided
+6. **Response format**: JSON structure of the API response — skip if API docs provided
 7. **Discount limits**: No limit, Maximum percentage, Maximum value, or Depends on seller level?
 8. **Approval needed**: No, Yes above a certain value, or Always?
 
@@ -111,9 +115,12 @@ Detect the use case from keywords in the user's description:
 
 When the use case requires an external API:
 
-### Step 1: Confirm API details
+### Step 1: Check for API documentation and confirm API details
 
-Collect: HTTP method, request parameters/body, and API response JSON structure.
+**First** — Ask: does the user have API documentation they can share?
+
+- **Yes** → Go to the [API Documentation Ingestion](#api-documentation-ingestion) section. Extract HTTP method, request parameters/body, and response JSON structure from the docs. Present the extracted details to the user for confirmation, then proceed to Step 2.
+- **No** → Collect manually: HTTP method, request parameters/body, and API response JSON structure. Proceed to Step 2.
 
 ### Step 2: Does the API need authentication?
 
@@ -146,3 +153,53 @@ Use the Direct Auth template.
 ### IO Proxy Critical Rule
 
 The `fetch` call in the extension must use **ONLY the relative path** (e.g., `/_v/my-api/endpoint`). **NEVER** prefix with `https://` or a domain like `{account}.myvtex.com`. The Sales App has an internal proxy that automatically resolves the domain.
+
+## API Documentation Ingestion
+
+When the user provides API documentation, follow these steps to extract structured information before generating code.
+
+### Supported input formats
+
+| Format | How to load | Notes |
+|--------|------------|-------|
+| URL | Use `fetch_webpage` to retrieve the page content | Works for REST API reference pages, Swagger UI, Redoc |
+| OpenAPI/Swagger JSON | Parse the JSON directly from user input or file content | Look for `paths`, `components/schemas` keys |
+| OpenAPI/Swagger YAML | Convert YAML mentally to JSON structure, then parse same as above | |
+| Markdown doc | Read sections for endpoint paths, method, headers, request/response examples | |
+| Inline text | Read the pasted content, identify patterns: `GET /path`, `POST /path`, JSON examples | |
+
+### Extraction checklist
+
+From any documentation format, extract and record:
+
+1. **Base URL** — the host/prefix (e.g., `https://api.example.com/v2`). For IO Proxy, this becomes irrelevant — only the path matters.
+2. **Endpoints** — for each endpoint: HTTP method, path, and purpose description.
+3. **Required headers** — `Content-Type`, `Authorization`, `x-api-key`, or others.
+4. **Query parameters** — name, type, required/optional.
+5. **Request body shape** — JSON structure with field names, types, and required/optional status.
+6. **Response shape** — JSON structure. If multiple status codes, capture the success response (200/201).
+7. **Error shapes** — if documented, capture 4xx/5xx response structures.
+
+### Extraction output (mental model)
+
+After extracting, summarize to the user in this format before proceeding to code generation:
+
+```
+Extracted API summary:
+- Endpoint: [METHOD] [path]
+- Auth: [None / IO Proxy at /_v/... / Direct with header X]
+- Request: { field: type, ... }
+- Response: { field: type, ... }
+- Optional fields: [list]
+
+Does this match what you expected?
+```
+
+Wait for user confirmation before proceeding to Step 2 (template selection) or code generation.
+
+### Multiple endpoints
+
+If the documentation describes multiple endpoints needed by the extension:
+- List all of them in the summary above
+- Note whether they can be called in parallel or must be sequential
+- This will determine whether a custom fetch hook is needed (see code templates reference)

--- a/tracks/sales-app/skills/sales-app-extensibility/references/extension-points-hooks-and-types.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/extension-points-hooks-and-types.md
@@ -1,0 +1,292 @@
+---
+name: sales-app-extension-points-hooks-types
+description: Complete reference for Sales App extension points, React hooks, and TypeScript types. Use when choosing where to render an extension, which hooks to use, or looking up type definitions for CartItem, ProductSku, Totalizers, and related types.
+metadata:
+  version: "1.0"
+---
+
+# Extension Points, Hooks, and Types
+
+## Extension Points
+
+Sales App has 8 extension points across 3 categories.
+
+### Cart Extension Points
+
+#### `cart.cart-list.after`
+
+- **Location**: Below the cart items list
+- **Layout Shift**: No
+- **Available Hooks**: useCart, useExtension
+- **Use Cases**: Loyalty points summary, promotional banners, gift options, shipping estimates
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+
+export default defineExtensions({
+  'cart.cart-list.after': MyExtension,
+});
+```
+
+#### `cart.cart-item.after`
+
+- **Location**: Below each individual cart item
+- **Layout Shift**: Yes — use loading states and skeletons
+- **Available Hooks**: useCart, useCartItem, useExtension
+- **Use Cases**: Warranty options, item-specific promotions, personalization, service attachments
+
+```typescript
+export default defineExtensions({
+  'cart.cart-item.after': ItemWarranty,
+});
+```
+
+#### `cart.order-summary.after`
+
+- **Location**: Below the order summary/totals
+- **Layout Shift**: Yes — use loading states and skeletons
+- **Available Hooks**: useCart, useExtension
+- **Use Cases**: Loyalty points redemption, additional fees/discounts, coupon input, installment options
+
+```typescript
+export default defineExtensions({
+  'cart.order-summary.after': LoyaltyPoints,
+});
+```
+
+### PDP Extension Points
+
+#### `pdp.sidebar.before`
+
+- **Location**: Above the sidebar content on the Product Detail Page
+- **Layout Shift**: Yes
+- **Available Hooks**: usePDP, useCart, useExtension
+- **Use Cases**: Product badges, stock alerts, promotional banners, seller information
+
+#### `pdp.sidebar.after`
+
+- **Location**: Below the sidebar content on the Product Detail Page
+- **Layout Shift**: Yes
+- **Available Hooks**: usePDP, useCart, useExtension
+- **Use Cases**: Warranty selection, related services, financing options, gift wrapping
+
+#### `pdp.content.after`
+
+- **Location**: Below the main content area on the Product Detail Page
+- **Layout Shift**: Yes
+- **Available Hooks**: usePDP, useCart, useExtension
+- **Use Cases**: Product recommendations, customer reviews, specifications, complementary products
+
+### Menu Extension Points
+
+#### `menu.item`
+
+- **Location**: Sales App main menu
+- **Layout Shift**: No
+- **Available Hooks**: useExtension
+- **Use Cases**: Custom navigation links, quick action buttons, menu notifications
+
+#### `menu.drawer-content`
+
+- **Location**: Sales App menu drawer
+- **Layout Shift**: No
+- **Available Hooks**: useCurrentUser, useExtension
+- **Use Cases**: User profile information, sales performance metrics, settings shortcuts, notifications
+
+## Hooks Reference
+
+All hooks are imported from `@vtex/sales-app`.
+
+### useCart
+
+Access cart data and perform mutations.
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+
+const cart = useCart();
+```
+
+**Available in**: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`
+
+**Returns**:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `orderFormId` | `string \| undefined` | Unique identifier of the current order form |
+| `value` | `number` | Total cart value in cents |
+| `items` | `CartItem[]` | Array of items in the cart |
+| `totalizers` | `Totalizers[]` | Array of totalizers (Items, Shipping, Discounts, Tax) |
+| `clientProfileData` | `ClientProfileData` | Client profile (email, document, phone) |
+| `addItem` | `(data: UseCartAddItemData) => Promise<void>` | Add an item to the cart |
+
+**Example — display total items**:
+
+```typescript
+const TotalItems = () => {
+  const cart = useCart();
+  return <div>Items: {cart.items.length}</div>;
+};
+```
+
+**Example — add item to cart**:
+
+```typescript
+const AddToCart = () => {
+  const cart = useCart();
+  const addItem = () => cart.addItem({
+    quantity: 1,
+    seller: '1',
+    id: '8392'
+  });
+  return <button onClick={addItem}>Add to cart</button>;
+};
+```
+
+### useCartItem
+
+Access individual cart item data. **Only available in `cart.cart-item.after`**.
+
+```typescript
+import { useCartItem } from '@vtex/sales-app';
+
+const { item, itemIndex, changeItem, changePrice } = useCartItem();
+// IMPORTANT: item may be undefined — always check first
+if (!item) return (<></>);
+```
+
+**Returns**:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `item` | `CartItem \| undefined` | The cart item data — **check for undefined** |
+| `itemIndex` | `number \| undefined` | Index of the item in the cart |
+| `changeItem` | `(data: UseCartItemChangeItemData) => Promise<void>` | Modify quantity or attachments |
+| `changePrice` | `(price: number) => Promise<void>` | Change item price (requires `allowManualPrice` in orderForm) |
+
+### useCurrentUser
+
+Access current authenticated user data. **Only available in `menu.drawer-content`**.
+
+```typescript
+import { useCurrentUser } from '@vtex/sales-app';
+
+const { name, email } = useCurrentUser();
+```
+
+**Returns**:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | `string` | Current user's name |
+| `email` | `string` | Current user's email |
+
+### useExtension
+
+Access account and extension point context. **Available in all extension points**.
+
+```typescript
+import { useExtension } from '@vtex/sales-app';
+
+const { account, extensionPoint } = useExtension();
+```
+
+**Returns**:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `account` | `string` | Current VTEX account name |
+| `extensionPoint` | `ExtensionPointsType` | Name of the extension point where the component is mounted |
+
+### usePDP
+
+Access Product Detail Page data. **Only available in PDP extensions**.
+
+```typescript
+import { usePDP } from '@vtex/sales-app';
+
+const { productSku } = usePDP();
+```
+
+**Returns**:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `productSku` | `ProductSku` | Current product SKU data |
+
+## TypeScript Types
+
+```typescript
+type CartItem = {
+  id: string;
+  name: string;
+  quantity: number;
+  seller: string;
+  sellingPrice: number;
+  listPrice: number;
+  manualPrice?: number;       // optional — guard before use
+  price: number;
+  imageUrl: string;
+  productRefId?: string;      // optional — guard before use
+  attachments?: Attachment[];  // optional — guard before use
+};
+
+type ClientProfileData = {
+  email: string | null;
+  document: string | null;
+  phone: string | null;
+};
+
+type ProductSku = {
+  id: string;
+  name: string;
+  quantity: number;
+  price: number;
+  listPrice: number;
+  sellingPrice?: number;
+};
+
+type Totalizers = {
+  id: string;    // Common IDs: "Items", "Shipping", "Discounts", "Tax"
+  name: string;
+  value: number; // in cents
+};
+
+type Attachment = {
+  name: string;
+  content: Record<string, string>;
+};
+
+type UseCartAddItemData = {
+  id: string;
+  quantity: number;
+  seller: string;
+  attachments?: Attachment[];
+};
+
+type UseCartItemChangeItemData = {
+  quantity?: number;
+  attachments?: Attachment[];
+};
+
+type ExtensionPointsType =
+  | 'cart.cart-list.after'
+  | 'cart.cart-item.after'
+  | 'cart.order-summary.after'
+  | 'pdp.sidebar.before'
+  | 'pdp.sidebar.after'
+  | 'pdp.content.after'
+  | 'menu.item'
+  | 'menu.drawer-content';
+```
+
+### Optional Properties Warning
+
+Three `CartItem` properties are optional and must be guarded:
+
+| Property | Type | Safe Access |
+|----------|------|-------------|
+| `manualPrice` | `number \| undefined` | `item.manualPrice ?? item.sellingPrice` |
+| `productRefId` | `string \| undefined` | `item.productRefId ?? 'N/A'` |
+| `attachments` | `Attachment[] \| undefined` | `item.attachments?.length ?? 0` |

--- a/tracks/sales-app/skills/sales-app-extensibility/references/extension-points-hooks-and-types.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/extension-points-hooks-and-types.md
@@ -119,7 +119,12 @@ const cart = useCart();
 | `items` | `CartItem[]` | Array of items in the cart |
 | `totalizers` | `Totalizers[]` | Array of totalizers (Items, Shipping, Discounts, Tax) |
 | `clientProfileData` | `ClientProfileData` | Client profile (email, document, phone) |
+| `giftCards` | `GiftCard[]` | Gift cards currently attached to the cart |
 | `addItem` | `(data: UseCartAddItemData) => Promise<void>` | Add an item to the cart |
+| `removeItem` | `(id: string, index: number) => Promise<void>` | Remove an item from the cart |
+| `addCoupon` | `(coupon: string) => Promise<void>` | Add a coupon to the cart |
+| `addGiftCard` | `(redemptionCodeOrGiftCard: string \| GiftCard, provider?: string) => Promise<void>` | Add a gift card to the cart payment data |
+| `sync` | `() => Promise<void>` | Sync the cart with the latest Order Form data |
 
 **Example — display total items**:
 
@@ -141,6 +146,19 @@ const AddToCart = () => {
     id: '8392'
   });
   return <button onClick={addItem}>Add to cart</button>;
+};
+```
+
+**Example — add gift card**:
+
+```typescript
+const AddGiftCard = () => {
+  const cart = useCart();
+  const add = async () => {
+    await cart.addGiftCard('ABC-123', 'my-giftcard-provider');
+    await cart.sync();
+  };
+  return <button onClick={add}>Add gift card</button>;
 };
 ```
 
@@ -256,6 +274,19 @@ type Totalizers = {
 type Attachment = {
   name: string;
   content: Record<string, string>;
+};
+
+type GiftCard = {
+  id: string;
+  redemptionCode?: string | null;
+  name: string;
+  caption: string;
+  value: number;
+  balance: number;
+  provider: string;
+  groupName?: string | null;
+  inUse: boolean;
+  isSpecialCard: boolean;
 };
 
 type UseCartAddItemData = {

--- a/tracks/sales-app/skills/sales-app-extensibility/references/local-dev-build-and-deploy.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/local-dev-build-and-deploy.md
@@ -1,0 +1,152 @@
+---
+name: sales-app-local-dev-build-deploy
+description: Commands and instructions for local development, building, and deploying Sales App extensions via FastStore WebOps. Use during Steps 4 and 5 of the workflow.
+metadata:
+  version: "1.0"
+---
+
+# Local Development, Build, and Deployment
+
+## Local Development (Step 4)
+
+### Start the dev server
+
+```bash
+# Verify dependencies are installed
+yarn install
+
+# Primary command — run at monorepo root
+yarn fsp dev {account_name}
+
+# Alternative with more control
+yarn sales-app dev {account_name} ./{account_name}/sales-app 3002
+
+# Show extension point placeholders (useful for finding where to render)
+yarn sales-app dev {account_name} ./{account_name}/sales-app 3002 --show-placeholders
+```
+
+### Test URLs
+
+| Page | URL |
+|------|-----|
+| Cart | `http://localhost:3002/sales-app/checkout/cart` |
+| PDP | `http://localhost:3002/sales-app/product/<product-id>` |
+| Base | `http://localhost:3002/sales-app` |
+
+### Development tips
+
+- Hot reload is active — code changes reflect automatically
+- Use `--show-placeholders` to see where extension points are located
+- Check the port configuration in `faststore.json` if there are conflicts
+
+### Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Port in use | Try a different port: 3003, 3004 |
+| Extension not visible | Check `index.tsx` and the configured extension point name |
+| Build error during dev | Run `yarn fsp build {account_name} sales-app` for detailed errors |
+| Module not found | Run `yarn install` to ensure dependencies are linked |
+
+## Build (Step 5a)
+
+### Build command
+
+```bash
+yarn fsp build {account_name} sales-app
+```
+
+### What the build checks
+
+1. **TypeScript** — types and syntax errors
+2. **Imports** — referenced modules and files exist
+3. **JSX** — correct React component syntax
+4. **CSS** — style files imported correctly
+5. **defineExtensions** — valid extension points configuration
+
+### Common build errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| TypeScript errors | Type mismatches, missing types | Check variable types and `@vtex/sales-app` imports |
+| Module not found | Wrong import path or missing file | Verify file exists at the imported path |
+| Hook errors | Hooks inside conditionals or loops | Move hook calls to the top level of the component |
+| CSS errors | Missing or misnamed CSS file | Check `.css` file exists and import path is correct |
+| defineExtensions errors | Invalid extension point or missing export | Verify extension point name and component export |
+
+### Build tip
+
+During development, `yarn fsp dev` already runs the build automatically. Use `yarn fsp build` when you want to validate before deploying.
+
+## Deployment (Step 5b)
+
+Deployment is automatic via **FastStore WebOps** when you push to the `main` branch.
+
+### Deployment steps
+
+```bash
+# 1. Verify local build passes
+yarn fsp build {account_name} sales-app
+
+# 2. Review changes
+git status
+
+# 3. Stage files
+git add .
+
+# 4. Create commit
+git commit -m "feat: add Sales App extension"
+
+# 5. Push to main
+git push origin main
+```
+
+After pushing:
+
+6. **Monitor deploy** — Access FastStore WebOps in VTEX Admin (`https://{account_name}.myvtex.com/admin/faststore-webops`)
+7. **Wait for propagation** — Deployment takes 5-10 minutes (includes CDN cache propagation)
+8. **Validate in production** — Access Sales App in production and verify the extension
+
+### Monitoring
+
+**FastStore WebOps**:
+- URL: VTEX Admin > FastStore > WebOps
+- Shows build and deployment status
+
+**GitHub Checks**:
+- Go to the GitHub repository
+- See the status icon (✔️, ❌, 🟡) next to each commit
+
+### Rollback
+
+If something goes wrong after deployment:
+
+```bash
+git revert HEAD
+git push origin main
+```
+
+### Troubleshooting deployment
+
+#### Build failed in WebOps
+
+1. Go to the GitHub repository
+2. Click the status icon next to the commit
+3. Select "Details" under "FastStore WebOps"
+4. Read the error logs
+5. Fix the issue locally
+6. Make a new commit and push
+
+#### Extension doesn't appear after deploy
+
+1. Check the extension point is correct in `index.tsx`
+2. Clear browser cache (Ctrl+Shift+R)
+3. Wait longer for propagation (up to 10 minutes)
+4. Verify you're accessing the correct account
+
+#### Runtime error in production
+
+1. Open the browser console (F12)
+2. Check for JavaScript errors
+3. If API error, verify URLs and authentication
+4. Fix locally, test, and redeploy

--- a/tracks/sales-app/skills/sales-app-extensibility/skill.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/skill.md
@@ -92,8 +92,9 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
 | 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
-| 4 | Local Testing | Provide dev commands and URLs |
-| 5 | Build & Deploy | Build command → deployment guide |
+| 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
+| 5 | Local Testing | Provide dev commands and URLs |
+| 6 | Build & Deploy | Build command → deployment guide |
 
 ### Extension point selection
 
@@ -358,9 +359,58 @@ Discovery → Generate code immediately.
 
 **Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
-**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
-**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS module file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+Template for the documentation file:
+
+````markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.module.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+````
+
+**Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 6** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
 ## Reference Files
 
@@ -385,6 +435,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
 
 ## Review checklist
 
@@ -401,6 +452,8 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
 - [ ] CSS file path matches component name?
+- [ ] Documentation generated at `docs/<ExtensionName>.md`?
+- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/tracks/sales-app/skills/sales-app-extensibility/skill.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/skill.md
@@ -1,6 +1,6 @@
 ---
 name: sales-app-extensibility
-description: Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns.
+description: Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 7-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, secure API integration patterns, and API documentation ingestion (OpenAPI, URLs, or inline specs) to generate typed integrations.
 metadata:
   track: sales-app
   tags:
@@ -124,6 +124,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 - API + no auth → **API template**
 - API + VTEX IO proxy → **IO proxy template** (recommended)
 - API + direct auth → **direct auth template** (insecure, warn user)
+- API doc provided → generate TypeScript interfaces from extracted response shapes; no API doc → use `${DATA_INTERFACE}` placeholder
 
 ### API authentication strategy
 
@@ -353,11 +354,11 @@ Discovery → Generate code immediately.
 
 **Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
 
-**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -368,6 +369,9 @@ Discovery → Generate code immediately.
 5. **Component structure** — description of the component tree, props, and state management.
 6. **Styling** — CSS module file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
 8. **How to test** — dev server command and URL to reach the extension.
 9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
 
@@ -421,7 +425,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
-| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 
 ## Common failure modes
 
@@ -436,6 +440,9 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Not presenting plan** — User may want a different approach. Always confirm.
 - **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
 - **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
+- **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
+- **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
 
 ## Review checklist
 
@@ -454,6 +461,8 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] CSS file path matches component name?
 - [ ] Documentation generated at `docs/<ExtensionName>.md`?
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/tracks/sales-app/skills/sales-app-extensibility/skill.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/skill.md
@@ -1,0 +1,417 @@
+---
+name: sales-app-extensibility
+description: Apply when building, customizing, or deploying extensions for VTEX Sales App. Covers the complete 6-step workflow from prerequisite checks through code generation to deployment, including extension points (cart, PDP, menu), React hooks (useCart, usePDP, useCartItem, useCurrentUser, useExtension), TypeScript types, and secure API integration patterns.
+metadata:
+  track: sales-app
+  tags:
+    - sales-app
+    - instore
+    - extensions
+    - defineExtensions
+    - useCart
+    - usePDP
+    - react
+    - faststore
+  globs:
+    - "packages/sales-app/**/*.tsx"
+    - "packages/sales-app/**/*.ts"
+    - "packages/sales-app/**/*.css"
+    - "packages/sales-app/src/index.tsx"
+  version: "1.0"
+  purpose: Guide the complete lifecycle of Sales App extension development from discovery through deployment
+  applies_to:
+    - creating Sales App extensions
+    - customizing cart, PDP, or menu in Sales App
+    - integrating APIs in Sales App extensions
+  excludes:
+    - regular FastStore storefront customization
+    - VTEX IO app development
+    - Sales App core development
+  decision_scope:
+    - extension-point-selection
+    - hook-selection
+    - api-auth-strategy
+    - template-selection
+  vtex_docs_verified: "2026-04-13"
+---
+
+# Sales App Extensibility
+
+## When this skill applies
+
+Use this skill when building, customizing, or deploying extensions for VTEX Sales App.
+
+- Adding features to the cart page (promotions, loyalty, services)
+- Adding features to the Product Detail Page (badges, recommendations, warranties)
+- Adding features to the menu (user profile, navigation, metrics)
+- Integrating external APIs into Sales App extensions
+- Generating, scaffolding, or validating extension code for Sales App
+
+Do not use this skill for:
+- Regular FastStore storefront customization (use `faststore-storefront`)
+- Building VTEX IO apps (use `vtex-io-*` skills)
+- Sales App core development or framework modifications
+
+### Prerequisite: FastStore project
+
+The project root must contain: `biome.json`, `faststore.json`, `package.json`, `tsconfig.json`, `turbo.json`.
+
+If any are missing, **STOP**. The user must install FastStore first:
+
+```bash
+npx @vtex/fsp-cli init
+# Prompt: "What is the application name?" → enter name or press Enter for default
+cd <application-name> && yarn
+```
+
+Documentation: https://beta.fast.store/getting-started
+
+### Prerequisite: Sales App module
+
+Inside the FastStore project, a Sales App workspace must exist (typically at `packages/sales-app`) with `src/`, `package.json`, and `tsconfig.json`. Check root `package.json` `"workspaces"` for a path containing `sales-app`. If missing, **STOP**:
+
+```bash
+yarn add @vtex/sales-app -D -W
+npx fsp create
+# Prompts: account name → "Sales App" → path (default or custom)
+# Then add the path to root package.json "workspaces" array
+yarn install
+```
+
+Documentation: https://beta.fast.store/sales-app/setting-up
+
+**Do NOT proceed to discovery or code generation until both prerequisites are confirmed.**
+
+## Decision rules
+
+Follow the mandatory 6-step workflow in order. Do not skip steps.
+
+| Step | Purpose | Gate |
+|------|---------|------|
+| 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
+| 1 | Discovery | Understand what the user wants to build |
+| 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
+| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 4 | Local Testing | Provide dev commands and URLs |
+| 5 | Build & Deploy | Build command → deployment guide |
+
+### Extension point selection
+
+| Extension Point | Category | Available Hooks | Layout Shift |
+|----------------|----------|----------------|--------------|
+| `cart.cart-list.after` | Cart | useCart, useExtension | No |
+| `cart.cart-item.after` | Cart | useCart, useCartItem, useExtension | Yes |
+| `cart.order-summary.after` | Cart | useCart, useExtension | Yes |
+| `pdp.sidebar.before` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.sidebar.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `pdp.content.after` | PDP | usePDP, useCart, useExtension | Yes |
+| `menu.item` | Menu | useExtension | No |
+| `menu.drawer-content` | Menu | useCurrentUser, useExtension | No |
+
+### Hook availability
+
+- **useCart** → all cart + PDP extensions
+- **useCartItem** → `cart.cart-item.after` only
+- **useCurrentUser** → `menu.drawer-content` only
+- **usePDP** → PDP extensions only
+- **useExtension** → all extension points
+
+### Template selection
+
+- No API + no hooks → **simple template**
+- No API + hooks → **hook template**
+- API + no auth → **API template**
+- API + VTEX IO proxy → **IO proxy template** (recommended)
+- API + direct auth → **direct auth template** (insecure, warn user)
+
+### API authentication strategy
+
+1. **Recommended: VTEX IO Proxy App** — IO app stores keys server-side. Extension uses `credentials: 'include'` with a **relative path** (`/_v/my-api/data`).
+2. **Insecure: Direct Auth** — Keys in frontend code, visible in browser. Testing/development only.
+
+## Hard constraints
+
+### Constraint: Component must return JSX.Element, never null
+
+`defineExtensions` expects `ExtensionPointComponent` which returns `Element`, not `Element | null`.
+
+**Why this matters**
+Returning `null` causes a TypeScript compilation error. The build will fail.
+
+**Detection**
+`return null` in any component registered with `defineExtensions`.
+
+**Correct**
+
+```typescript
+export function MyExtension(): JSX.Element {
+  if (!data) return (<></>);
+  return <div>{data.value}</div>;
+}
+```
+
+**Wrong**
+
+```typescript
+export function MyExtension(): JSX.Element | null {
+  if (!data) return null;
+  return <div>{data.value}</div>;
+}
+```
+
+### Constraint: Guard optional properties before use
+
+`CartItem.manualPrice` (number | undefined), `CartItem.productRefId` (string | undefined), `CartItem.attachments` (Attachment[] | undefined) must be guarded.
+
+**Why this matters**
+TypeScript strict mode rejects accessing possibly-undefined values.
+
+**Detection**
+`item.manualPrice`, `item.productRefId`, or `item.attachments` without `?.`, `??`, `&&`, or `!= null`.
+
+**Correct**
+
+```typescript
+const price = item.manualPrice ?? item.sellingPrice;
+const refId = item.productRefId ?? 'N/A';
+const count = item.attachments?.length ?? 0;
+```
+
+**Wrong**
+
+```typescript
+const price = item.manualPrice;
+const refId = item.productRefId.toUpperCase();
+const count = item.attachments.length;
+```
+
+### Constraint: useCartItem().item may be undefined
+
+`item` from `useCartItem()` is `CartItem | undefined`.
+
+**Why this matters**
+Accessing properties on `undefined` causes a runtime crash.
+
+**Detection**
+Destructured `item` from `useCartItem()` used without `if (!item)` guard.
+
+**Correct**
+
+```typescript
+const { item } = useCartItem();
+if (!item) return (<></>);
+return <div>{item.name}</div>;
+```
+
+**Wrong**
+
+```typescript
+const { item } = useCartItem();
+return <div>{item.name}</div>;
+```
+
+### Constraint: Never expose authentication keys in frontend code
+
+API keys in `fetch` headers are visible in the browser network tab.
+
+**Why this matters**
+Leaked keys compromise the external service.
+
+**Detection**
+Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
+
+**Correct**
+
+```typescript
+const response = await fetch('/_v/my-api/data', {
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+**Wrong**
+
+```typescript
+const response = await fetch('https://api.example.com/data', {
+  headers: { 'x-api-key': 'sk-secret-key-12345' },
+});
+```
+
+### Constraint: IO Proxy must use relative paths only
+
+The Sales App internal proxy resolves the domain automatically.
+
+**Why this matters**
+A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
+
+**Detection**
+`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
+
+**Correct**
+
+```typescript
+await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
+```
+
+**Wrong**
+
+```typescript
+await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
+```
+
+### Constraint: defineExtensions is required in index.tsx
+
+Entry point must use `defineExtensions` from `@vtex/sales-app`.
+
+**Why this matters**
+Without it, the build succeeds but no extensions render.
+
+**Detection**
+Missing `defineExtensions` import or call in `index.tsx`.
+
+**Correct**
+
+```typescript
+import { defineExtensions } from '@vtex/sales-app';
+import { MyExtension } from './components/MyExtension';
+export default defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+import { MyExtension } from './components/MyExtension';
+export default { 'cart.cart-list.after': MyExtension };
+```
+
+### Constraint: Extension point names must match exactly
+
+IDs are a fixed set. Non-existent names silently fail.
+
+**Why this matters**
+The extension renders nowhere. No build error — invisible at runtime.
+
+**Detection**
+Any name not in: `cart.cart-list.after`, `cart.cart-item.after`, `cart.order-summary.after`, `pdp.sidebar.before`, `pdp.sidebar.after`, `pdp.content.after`, `menu.item`, `menu.drawer-content`.
+
+**Correct**
+
+```typescript
+defineExtensions({ 'cart.cart-list.after': MyExtension });
+```
+
+**Wrong**
+
+```typescript
+defineExtensions({ 'cart.list.after': MyExtension });
+```
+
+### Constraint: Hooks must be used in compatible extension points
+
+Each hook has an `available_in` restriction.
+
+**Why this matters**
+Hook context is only mounted for specific extension points. Using elsewhere throws runtime errors.
+
+**Detection**
+`useCartItem` in PDP/menu. `useCurrentUser` in cart. `usePDP` in menu/cart-list.
+
+**Correct**
+
+```typescript
+// useCartItem in cart.cart-item.after ✓
+defineExtensions({ 'cart.cart-item.after': ItemWarranty });
+```
+
+**Wrong**
+
+```typescript
+// useCartItem in pdp.sidebar.after ✗ — will fail at runtime
+defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
+```
+
+### Constraint: Always present execution plan and wait for approval
+
+Do not generate code until the user confirms the plan.
+
+**Why this matters**
+Generating without agreement wastes effort and may produce the wrong extension.
+
+**Detection**
+Jumping from discovery to code generation without presenting a plan.
+
+**Correct**
+Discovery → Requirements → Present plan → **User approves** → Generate code.
+
+**Wrong**
+Discovery → Generate code immediately.
+
+## Preferred pattern
+
+### Workflow overview
+
+**Step 0** — Check FastStore + Sales App prerequisites. STOP if missing.
+
+**Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows.
+
+**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+
+**Step 4** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+**Step 5** — Build command and deployment guide. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
+
+## Reference Files
+
+Load these on demand based on what the task requires. Do not load all of them upfront.
+
+| File | Load when… |
+|------|-----------|
+| [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
+| [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 4–5 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+
+## Common failure modes
+
+- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
+- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
+- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
+- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
+- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
+- **Placing code outside packages/sales-app/src/** — Not included in build.
+- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
+- **Not presenting plan** — User may want a different approach. Always confirm.
+- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
+
+## Review checklist
+
+- [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
+- [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
+- [ ] Discovery completed and use case identified?
+- [ ] Execution plan approved by user?
+- [ ] Extension point is valid (from the 8-point reference)?
+- [ ] Hooks compatible with chosen extension point?
+- [ ] Component returns JSX.Element, never null?
+- [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
+- [ ] useCartItem().item checked for undefined?
+- [ ] No auth credentials exposed in frontend code?
+- [ ] IO Proxy uses relative path (/_v/...)?
+- [ ] defineExtensions configured in index.tsx?
+- [ ] CSS file path matches component name?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+## Related skills
+
+- `faststore-storefront` — storefront customization outside Sales App
+- `vtex-io-app-contract` — building VTEX IO proxy apps for secure API integration
+
+## Reference
+
+- Sales App setup: https://beta.fast.store/sales-app/setting-up
+- FastStore getting started: https://beta.fast.store/getting-started
+- VTEX Sales App documentation: https://help.vtex.com/en/tracks/instore-getting-started-and-setting-up
+- VTEX IO app development: https://developers.vtex.com/docs/guides/vtex-io-documentation-developing-an-app


### PR DESCRIPTION
## Description

This PR adds Sales App Extensibility Skill

---

## Contribution Checklist

Before submitting, please verify:

- [x] **Source files only**: Edited skill files in `tracks/{track}/skills/{name}/skill.md`, not in `skills/`, `exports/`, or `rules/` directories
- [x] **Correct file name**: Skill file is named `skill.md` (lowercase), not `SKILL.md` or other variants
- [x] **Frontmatter complete**: Includes `name`, `description`, and `metadata` with `track` and `tags` fields
- [x] **Validation passed**: Ran `bun run validate` and all hard checks pass
- [x] **Exports regenerated**: Ran `bun run export` and committed both source and generated files
- [x] **Skill name format**: Uses kebab-case and is unique across the repository
- [x] **Track directory correct**: Track name in frontmatter matches the directory structure

---

## Related Issues

<!-- Link to related issues if applicable -->
