### PR TITLE
refactor(payment): add cross-references to IO performance skill

### DIFF
--- a/exports/agents-md/payment/AGENTS.md
+++ b/exports/agents-md/payment/AGENTS.md
@@ -723,12 +723,14 @@ async function notifyGateway(callbackUrl: string, payload: object): Promise<void
 ## When this skill applies
 
 Use this skill when:
+
 - Implementing any PPP endpoint handler that processes payments, cancellations, captures, or refunds
 - Ensuring repeated Gateway calls with the same identifiers produce identical results without re-processing
 - Building a payment state machine to prevent invalid transitions (e.g., capturing a cancelled payment)
 - Handling the Gateway's 7-day retry window for `undefined` status payments
 
 Do not use this skill for:
+
 - PPP endpoint response shapes and HTTP methods — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Async callback URL notification logic — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -755,8 +757,12 @@ The VTEX Gateway retries Create Payment requests with `undefined` status for up 
 If the Create Payment handler does not check for an existing `paymentId` before processing, STOP. The handler must query the data store for the `paymentId` first.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // Check for existing payment — idempotency guard
@@ -792,8 +798,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // No idempotency check — every call hits the acquirer
@@ -828,8 +838,12 @@ The Gateway uses the response fields (`authorizationId`, `tid`, `nsu`, `status`)
 If the handler creates a new database record or generates new identifiers when it finds an existing `paymentId`, STOP. The handler must return the previously stored response verbatim.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -844,8 +858,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -855,7 +873,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     const newTid = generateNewTid();
     res.status(200).json({
       ...existing.response,
-      tid: newTid,  // Different from original — breaks reconciliation
+      tid: newTid, // Different from original — breaks reconciliation
       nsu: generateNewNsu(),
     });
     return;
@@ -876,8 +894,12 @@ Returning `approved` for an async method tells the Gateway the payment is confir
 If the Create Payment handler returns `status: "approved"` or `status: "denied"` for an asynchronous payment method (Boleto, Pix, bank transfer, redirect-based), STOP. Async methods must return `"undefined"` and use callbacks.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   const isAsyncMethod = ["BankInvoice", "Pix"].includes(paymentMethod);
@@ -893,7 +915,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
     res.status(200).json({
       paymentId,
-      status: "undefined",  // Correct for async
+      status: "undefined", // Correct for async
       authorizationId: pending.authorizationId ?? null,
       nsu: pending.nsu ?? null,
       tid: pending.tid ?? null,
@@ -902,7 +924,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer payment",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: 604800, // 7 days for async
       paymentUrl: pending.paymentUrl,
     });
     return;
@@ -914,8 +936,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod } = req.body;
 
   // WRONG: Approving a Pix payment synchronously
@@ -924,7 +950,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
   res.status(200).json({
     paymentId,
-    status: "approved",  // WRONG — Pix is async, should be "undefined"
+    status: "approved", // WRONG — Pix is async, should be "undefined"
     authorizationId: result.authorizationId ?? null,
     nsu: null,
     tid: null,
@@ -945,7 +971,13 @@ Payment state store with idempotency support:
 ```typescript
 interface PaymentRecord {
   paymentId: string;
-  status: "undefined" | "approved" | "denied" | "cancelled" | "settled" | "refunded";
+  status:
+    | "undefined"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "settled"
+    | "refunded";
   response: Record<string, unknown>;
   callbackUrl?: string;
   createdAt: Date;
@@ -966,7 +998,10 @@ Idempotent Create Payment with state machine:
 ```typescript
 const store = new PaymentStore();
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Idempotency check
@@ -996,8 +1031,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   };
 
   await store.save(paymentId, {
-    paymentId, status, response, callbackUrl,
-    createdAt: new Date(), updatedAt: new Date(),
+    paymentId,
+    status,
+    response,
+    callbackUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -1007,7 +1046,10 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 Idempotent Cancel with `requestId` guard and state validation:
 
 ```typescript
-async function cancelPaymentHandler(req: Request, res: Response): Promise<void> {
+async function cancelPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.params;
   const { requestId } = req.body;
 
@@ -1042,7 +1084,11 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 
   await store.updateStatus(paymentId, "cancelled");
   await store.saveOperation(requestId, {
-    requestId, paymentId, operation: "cancel", response, createdAt: new Date(),
+    requestId,
+    paymentId,
+    operation: "cancel",
+    response,
+    createdAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -2317,11 +2363,13 @@ Replace all example vendor names, endpoints, and credentials with values for you
 ## When this skill applies
 
 Use this skill when:
+
 - Building a new payment connector middleware that integrates a PSP with the VTEX Payment Gateway
 - Implementing, debugging, or extending any of the 9 PPP endpoints
 - Preparing a connector for VTEX Payment Provider Test Suite homologation
 
 Do not use this skill for:
+
 - Idempotency and duplicate prevention logic — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows and callback URLs — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy card handling — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -2348,6 +2396,7 @@ The VTEX Payment Provider Test Suite validates every endpoint during homologatio
 If the connector router/handler file does not define handlers for all 6 payment-flow paths, STOP and add the missing endpoints before proceeding.
 
 **Correct**
+
 ```typescript
 import { Router } from "express";
 
@@ -2359,12 +2408,16 @@ router.post("/payments", createPaymentHandler);
 router.post("/payments/:paymentId/cancellations", cancelPaymentHandler);
 router.post("/payments/:paymentId/settlements", capturePaymentHandler);
 router.post("/payments/:paymentId/refunds", refundPaymentHandler);
-router.post("/payments/:paymentId/inbound-request/:action", inboundRequestHandler);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  inboundRequestHandler,
+);
 
 export default router;
 ```
 
 **Wrong**
+
 ```typescript
 import { Router } from "express";
 
@@ -2390,6 +2443,7 @@ The Gateway parses these fields programmatically. Missing fields cause deseriali
 If a response object is missing any of the required fields for its endpoint, STOP and add the missing fields.
 
 **Correct**
+
 ```typescript
 interface CreatePaymentResponse {
   paymentId: string;
@@ -2406,8 +2460,12 @@ interface CreatePaymentResponse {
   paymentUrl?: string;
 }
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId, value, currency, paymentMethod, card, callbackUrl } = req.body;
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { paymentId, value, currency, paymentMethod, card, callbackUrl } =
+    req.body;
 
   const result = await processPaymentWithAcquirer(req.body);
 
@@ -2420,9 +2478,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     acquirer: "MyAcquirer",
     code: result.code ?? null,
     message: result.message ?? null,
-    delayToAutoSettle: 21600,    // 6 hours in seconds
+    delayToAutoSettle: 21600, // 6 hours in seconds
     delayToAutoSettleAfterAntifraud: 1800, // 30 minutes in seconds
-    delayToCancel: 21600,         // 6 hours in seconds
+    delayToCancel: 21600, // 6 hours in seconds
   };
 
   res.status(200).json(response);
@@ -2430,9 +2488,13 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
 // Missing required fields — Gateway will reject this response
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const result = await processPaymentWithAcquirer(req.body);
 
   // Missing: authorizationId, nsu, tid, acquirer, code, message,
@@ -2455,6 +2517,7 @@ The Gateway reads the manifest to determine which payment methods are available.
 If the manifest handler returns an empty `paymentMethods` array or hardcodes methods the provider does not actually support, STOP and fix the manifest.
 
 **Correct**
+
 ```typescript
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
   const manifest = {
@@ -2472,6 +2535,7 @@ async function manifestHandler(_req: Request, res: Response): Promise<void> {
 ```
 
 **Wrong**
+
 ```typescript
 // Empty manifest — no payment methods will appear in the Admin
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
@@ -2614,62 +2678,74 @@ router.post("/payments", async (req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-router.post("/payments/:paymentId/cancellations", async (req: Request, res: Response) => {
-  const { paymentId } = req.params;
-  const { requestId } = req.body;
-  const result = await cancelWithAcquirer(paymentId);
+router.post(
+  "/payments/:paymentId/cancellations",
+  async (req: Request, res: Response) => {
+    const { paymentId } = req.params;
+    const { requestId } = req.body;
+    const result = await cancelWithAcquirer(paymentId);
 
-  res.status(200).json({
-    paymentId,
-    cancellationId: result.cancellationId ?? null,
-    code: result.code ?? null,
-    message: result.message ?? "Successfully cancelled",
-    requestId,
-  });
-});
+    res.status(200).json({
+      paymentId,
+      cancellationId: result.cancellationId ?? null,
+      code: result.code ?? null,
+      message: result.message ?? "Successfully cancelled",
+      requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/settlements", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await captureWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/settlements",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await captureWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    settleId: result.settleId ?? null,
-    value: result.capturedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      settleId: result.settleId ?? null,
+      value: result.capturedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/refunds", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await refundWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/refunds",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await refundWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    refundId: result.refundId ?? null,
-    value: result.refundedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      refundId: result.refundId ?? null,
+      value: result.refundedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/inbound-request/:action", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await handleInbound(body);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await handleInbound(body);
 
-  res.status(200).json({
-    requestId: body.requestId,
-    paymentId: body.paymentId,
-    responseData: {
-      statusCode: 200,
-      contentType: "application/json",
-      content: JSON.stringify(result),
-    },
-  });
-});
+    res.status(200).json({
+      requestId: body.requestId,
+      paymentId: body.paymentId,
+      responseData: {
+        statusCode: 200,
+        contentType: "application/json",
+        content: JSON.stringify(result),
+      },
+    });
+  },
+);
 
 export default router;
 ```
@@ -2682,29 +2758,40 @@ import { Router, Request, Response } from "express";
 const configRouter = Router();
 
 // 1. POST /authorization/token
-configRouter.post("/authorization/token", async (req: Request, res: Response) => {
-  const { applicationId, returnUrl } = req.body;
-  const token = await generateAuthorizationToken(applicationId, returnUrl);
-  res.status(200).json({ applicationId, token });
-});
+configRouter.post(
+  "/authorization/token",
+  async (req: Request, res: Response) => {
+    const { applicationId, returnUrl } = req.body;
+    const token = await generateAuthorizationToken(applicationId, returnUrl);
+    res.status(200).json({ applicationId, token });
+  },
+);
 
 // 2. GET /authorization/redirect
-configRouter.get("/authorization/redirect", async (req: Request, res: Response) => {
-  const { token } = req.query;
-  const providerLoginUrl = buildProviderLoginUrl(token as string);
-  res.redirect(302, providerLoginUrl);
-});
+configRouter.get(
+  "/authorization/redirect",
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
+    const providerLoginUrl = buildProviderLoginUrl(token as string);
+    res.redirect(302, providerLoginUrl);
+  },
+);
 
 // 3. GET /authorization/credentials
-configRouter.get("/authorization/credentials", async (req: Request, res: Response) => {
-  const { authorizationCode } = req.query;
-  const credentials = await exchangeCodeForCredentials(authorizationCode as string);
-  res.status(200).json({
-    applicationId: "vtex",
-    appKey: credentials.appKey,
-    appToken: credentials.appToken,
-  });
-});
+configRouter.get(
+  "/authorization/credentials",
+  async (req: Request, res: Response) => {
+    const { authorizationCode } = req.query;
+    const credentials = await exchangeCodeForCredentials(
+      authorizationCode as string,
+    );
+    res.status(200).json({
+      applicationId: "vtex",
+      appKey: credentials.appKey,
+      appToken: credentials.appToken,
+    });
+  },
+);
 
 export default configRouter;
 ```

--- a/exports/claude/payment-payment-idempotency.md
+++ b/exports/claude/payment-payment-idempotency.md
@@ -5,12 +5,14 @@ This skill provides guidance for AI agents working with VTEX Payment Connector D
 ## When this skill applies
 
 Use this skill when:
+
 - Implementing any PPP endpoint handler that processes payments, cancellations, captures, or refunds
 - Ensuring repeated Gateway calls with the same identifiers produce identical results without re-processing
 - Building a payment state machine to prevent invalid transitions (e.g., capturing a cancelled payment)
 - Handling the Gateway's 7-day retry window for `undefined` status payments
 
 Do not use this skill for:
+
 - PPP endpoint response shapes and HTTP methods — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Async callback URL notification logic — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -37,8 +39,12 @@ The VTEX Gateway retries Create Payment requests with `undefined` status for up 
 If the Create Payment handler does not check for an existing `paymentId` before processing, STOP. The handler must query the data store for the `paymentId` first.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // Check for existing payment — idempotency guard
@@ -74,8 +80,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // No idempotency check — every call hits the acquirer
@@ -110,8 +120,12 @@ The Gateway uses the response fields (`authorizationId`, `tid`, `nsu`, `status`)
 If the handler creates a new database record or generates new identifiers when it finds an existing `paymentId`, STOP. The handler must return the previously stored response verbatim.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -126,8 +140,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -137,7 +155,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     const newTid = generateNewTid();
     res.status(200).json({
       ...existing.response,
-      tid: newTid,  // Different from original — breaks reconciliation
+      tid: newTid, // Different from original — breaks reconciliation
       nsu: generateNewNsu(),
     });
     return;
@@ -158,8 +176,12 @@ Returning `approved` for an async method tells the Gateway the payment is confir
 If the Create Payment handler returns `status: "approved"` or `status: "denied"` for an asynchronous payment method (Boleto, Pix, bank transfer, redirect-based), STOP. Async methods must return `"undefined"` and use callbacks.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   const isAsyncMethod = ["BankInvoice", "Pix"].includes(paymentMethod);
@@ -175,7 +197,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
     res.status(200).json({
       paymentId,
-      status: "undefined",  // Correct for async
+      status: "undefined", // Correct for async
       authorizationId: pending.authorizationId ?? null,
       nsu: pending.nsu ?? null,
       tid: pending.tid ?? null,
@@ -184,7 +206,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer payment",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: 604800, // 7 days for async
       paymentUrl: pending.paymentUrl,
     });
     return;
@@ -196,8 +218,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod } = req.body;
 
   // WRONG: Approving a Pix payment synchronously
@@ -206,7 +232,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
   res.status(200).json({
     paymentId,
-    status: "approved",  // WRONG — Pix is async, should be "undefined"
+    status: "approved", // WRONG — Pix is async, should be "undefined"
     authorizationId: result.authorizationId ?? null,
     nsu: null,
     tid: null,
@@ -227,7 +253,13 @@ Payment state store with idempotency support:
 ```typescript
 interface PaymentRecord {
   paymentId: string;
-  status: "undefined" | "approved" | "denied" | "cancelled" | "settled" | "refunded";
+  status:
+    | "undefined"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "settled"
+    | "refunded";
   response: Record<string, unknown>;
   callbackUrl?: string;
   createdAt: Date;
@@ -248,7 +280,10 @@ Idempotent Create Payment with state machine:
 ```typescript
 const store = new PaymentStore();
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Idempotency check
@@ -278,8 +313,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   };
 
   await store.save(paymentId, {
-    paymentId, status, response, callbackUrl,
-    createdAt: new Date(), updatedAt: new Date(),
+    paymentId,
+    status,
+    response,
+    callbackUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -289,7 +328,10 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 Idempotent Cancel with `requestId` guard and state validation:
 
 ```typescript
-async function cancelPaymentHandler(req: Request, res: Response): Promise<void> {
+async function cancelPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.params;
   const { requestId } = req.body;
 
@@ -324,7 +366,11 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 
   await store.updateStatus(paymentId, "cancelled");
   await store.saveOperation(requestId, {
-    requestId, paymentId, operation: "cancel", response, createdAt: new Date(),
+    requestId,
+    paymentId,
+    operation: "cancel",
+    response,
+    createdAt: new Date(),
   });
 
   res.status(200).json(response);

--- a/exports/claude/payment-payment-provider-protocol.md
+++ b/exports/claude/payment-payment-provider-protocol.md
@@ -5,11 +5,13 @@ This skill provides guidance for AI agents working with VTEX Payment Connector D
 ## When this skill applies
 
 Use this skill when:
+
 - Building a new payment connector middleware that integrates a PSP with the VTEX Payment Gateway
 - Implementing, debugging, or extending any of the 9 PPP endpoints
 - Preparing a connector for VTEX Payment Provider Test Suite homologation
 
 Do not use this skill for:
+
 - Idempotency and duplicate prevention logic — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows and callback URLs — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy card handling — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -36,6 +38,7 @@ The VTEX Payment Provider Test Suite validates every endpoint during homologatio
 If the connector router/handler file does not define handlers for all 6 payment-flow paths, STOP and add the missing endpoints before proceeding.
 
 **Correct**
+
 ```typescript
 import { Router } from "express";
 
@@ -47,12 +50,16 @@ router.post("/payments", createPaymentHandler);
 router.post("/payments/:paymentId/cancellations", cancelPaymentHandler);
 router.post("/payments/:paymentId/settlements", capturePaymentHandler);
 router.post("/payments/:paymentId/refunds", refundPaymentHandler);
-router.post("/payments/:paymentId/inbound-request/:action", inboundRequestHandler);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  inboundRequestHandler,
+);
 
 export default router;
 ```
 
 **Wrong**
+
 ```typescript
 import { Router } from "express";
 
@@ -78,6 +85,7 @@ The Gateway parses these fields programmatically. Missing fields cause deseriali
 If a response object is missing any of the required fields for its endpoint, STOP and add the missing fields.
 
 **Correct**
+
 ```typescript
 interface CreatePaymentResponse {
   paymentId: string;
@@ -94,8 +102,12 @@ interface CreatePaymentResponse {
   paymentUrl?: string;
 }
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId, value, currency, paymentMethod, card, callbackUrl } = req.body;
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { paymentId, value, currency, paymentMethod, card, callbackUrl } =
+    req.body;
 
   const result = await processPaymentWithAcquirer(req.body);
 
@@ -108,9 +120,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     acquirer: "MyAcquirer",
     code: result.code ?? null,
     message: result.message ?? null,
-    delayToAutoSettle: 21600,    // 6 hours in seconds
+    delayToAutoSettle: 21600, // 6 hours in seconds
     delayToAutoSettleAfterAntifraud: 1800, // 30 minutes in seconds
-    delayToCancel: 21600,         // 6 hours in seconds
+    delayToCancel: 21600, // 6 hours in seconds
   };
 
   res.status(200).json(response);
@@ -118,9 +130,13 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
 // Missing required fields — Gateway will reject this response
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const result = await processPaymentWithAcquirer(req.body);
 
   // Missing: authorizationId, nsu, tid, acquirer, code, message,
@@ -143,6 +159,7 @@ The Gateway reads the manifest to determine which payment methods are available.
 If the manifest handler returns an empty `paymentMethods` array or hardcodes methods the provider does not actually support, STOP and fix the manifest.
 
 **Correct**
+
 ```typescript
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
   const manifest = {
@@ -160,6 +177,7 @@ async function manifestHandler(_req: Request, res: Response): Promise<void> {
 ```
 
 **Wrong**
+
 ```typescript
 // Empty manifest — no payment methods will appear in the Admin
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
@@ -302,62 +320,74 @@ router.post("/payments", async (req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-router.post("/payments/:paymentId/cancellations", async (req: Request, res: Response) => {
-  const { paymentId } = req.params;
-  const { requestId } = req.body;
-  const result = await cancelWithAcquirer(paymentId);
+router.post(
+  "/payments/:paymentId/cancellations",
+  async (req: Request, res: Response) => {
+    const { paymentId } = req.params;
+    const { requestId } = req.body;
+    const result = await cancelWithAcquirer(paymentId);
 
-  res.status(200).json({
-    paymentId,
-    cancellationId: result.cancellationId ?? null,
-    code: result.code ?? null,
-    message: result.message ?? "Successfully cancelled",
-    requestId,
-  });
-});
+    res.status(200).json({
+      paymentId,
+      cancellationId: result.cancellationId ?? null,
+      code: result.code ?? null,
+      message: result.message ?? "Successfully cancelled",
+      requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/settlements", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await captureWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/settlements",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await captureWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    settleId: result.settleId ?? null,
-    value: result.capturedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      settleId: result.settleId ?? null,
+      value: result.capturedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/refunds", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await refundWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/refunds",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await refundWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    refundId: result.refundId ?? null,
-    value: result.refundedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      refundId: result.refundId ?? null,
+      value: result.refundedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/inbound-request/:action", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await handleInbound(body);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await handleInbound(body);
 
-  res.status(200).json({
-    requestId: body.requestId,
-    paymentId: body.paymentId,
-    responseData: {
-      statusCode: 200,
-      contentType: "application/json",
-      content: JSON.stringify(result),
-    },
-  });
-});
+    res.status(200).json({
+      requestId: body.requestId,
+      paymentId: body.paymentId,
+      responseData: {
+        statusCode: 200,
+        contentType: "application/json",
+        content: JSON.stringify(result),
+      },
+    });
+  },
+);
 
 export default router;
 ```
@@ -370,29 +400,40 @@ import { Router, Request, Response } from "express";
 const configRouter = Router();
 
 // 1. POST /authorization/token
-configRouter.post("/authorization/token", async (req: Request, res: Response) => {
-  const { applicationId, returnUrl } = req.body;
-  const token = await generateAuthorizationToken(applicationId, returnUrl);
-  res.status(200).json({ applicationId, token });
-});
+configRouter.post(
+  "/authorization/token",
+  async (req: Request, res: Response) => {
+    const { applicationId, returnUrl } = req.body;
+    const token = await generateAuthorizationToken(applicationId, returnUrl);
+    res.status(200).json({ applicationId, token });
+  },
+);
 
 // 2. GET /authorization/redirect
-configRouter.get("/authorization/redirect", async (req: Request, res: Response) => {
-  const { token } = req.query;
-  const providerLoginUrl = buildProviderLoginUrl(token as string);
-  res.redirect(302, providerLoginUrl);
-});
+configRouter.get(
+  "/authorization/redirect",
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
+    const providerLoginUrl = buildProviderLoginUrl(token as string);
+    res.redirect(302, providerLoginUrl);
+  },
+);
 
 // 3. GET /authorization/credentials
-configRouter.get("/authorization/credentials", async (req: Request, res: Response) => {
-  const { authorizationCode } = req.query;
-  const credentials = await exchangeCodeForCredentials(authorizationCode as string);
-  res.status(200).json({
-    applicationId: "vtex",
-    appKey: credentials.appKey,
-    appToken: credentials.appToken,
-  });
-});
+configRouter.get(
+  "/authorization/credentials",
+  async (req: Request, res: Response) => {
+    const { authorizationCode } = req.query;
+    const credentials = await exchangeCodeForCredentials(
+      authorizationCode as string,
+    );
+    res.status(200).json({
+      applicationId: "vtex",
+      appKey: credentials.appKey,
+      appToken: credentials.appToken,
+    });
+  },
+);
 
 export default configRouter;
 ```

--- a/exports/claude/payment.md
+++ b/exports/claude/payment.md
@@ -714,12 +714,14 @@ This skill provides guidance for AI agents working with VTEX Payment Connector D
 ## When this skill applies
 
 Use this skill when:
+
 - Implementing any PPP endpoint handler that processes payments, cancellations, captures, or refunds
 - Ensuring repeated Gateway calls with the same identifiers produce identical results without re-processing
 - Building a payment state machine to prevent invalid transitions (e.g., capturing a cancelled payment)
 - Handling the Gateway's 7-day retry window for `undefined` status payments
 
 Do not use this skill for:
+
 - PPP endpoint response shapes and HTTP methods — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Async callback URL notification logic — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -746,8 +748,12 @@ The VTEX Gateway retries Create Payment requests with `undefined` status for up 
 If the Create Payment handler does not check for an existing `paymentId` before processing, STOP. The handler must query the data store for the `paymentId` first.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // Check for existing payment — idempotency guard
@@ -783,8 +789,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // No idempotency check — every call hits the acquirer
@@ -819,8 +829,12 @@ The Gateway uses the response fields (`authorizationId`, `tid`, `nsu`, `status`)
 If the handler creates a new database record or generates new identifiers when it finds an existing `paymentId`, STOP. The handler must return the previously stored response verbatim.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -835,8 +849,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -846,7 +864,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     const newTid = generateNewTid();
     res.status(200).json({
       ...existing.response,
-      tid: newTid,  // Different from original — breaks reconciliation
+      tid: newTid, // Different from original — breaks reconciliation
       nsu: generateNewNsu(),
     });
     return;
@@ -867,8 +885,12 @@ Returning `approved` for an async method tells the Gateway the payment is confir
 If the Create Payment handler returns `status: "approved"` or `status: "denied"` for an asynchronous payment method (Boleto, Pix, bank transfer, redirect-based), STOP. Async methods must return `"undefined"` and use callbacks.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   const isAsyncMethod = ["BankInvoice", "Pix"].includes(paymentMethod);
@@ -884,7 +906,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
     res.status(200).json({
       paymentId,
-      status: "undefined",  // Correct for async
+      status: "undefined", // Correct for async
       authorizationId: pending.authorizationId ?? null,
       nsu: pending.nsu ?? null,
       tid: pending.tid ?? null,
@@ -893,7 +915,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer payment",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: 604800, // 7 days for async
       paymentUrl: pending.paymentUrl,
     });
     return;
@@ -905,8 +927,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod } = req.body;
 
   // WRONG: Approving a Pix payment synchronously
@@ -915,7 +941,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
   res.status(200).json({
     paymentId,
-    status: "approved",  // WRONG — Pix is async, should be "undefined"
+    status: "approved", // WRONG — Pix is async, should be "undefined"
     authorizationId: result.authorizationId ?? null,
     nsu: null,
     tid: null,
@@ -936,7 +962,13 @@ Payment state store with idempotency support:
 ```typescript
 interface PaymentRecord {
   paymentId: string;
-  status: "undefined" | "approved" | "denied" | "cancelled" | "settled" | "refunded";
+  status:
+    | "undefined"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "settled"
+    | "refunded";
   response: Record<string, unknown>;
   callbackUrl?: string;
   createdAt: Date;
@@ -957,7 +989,10 @@ Idempotent Create Payment with state machine:
 ```typescript
 const store = new PaymentStore();
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Idempotency check
@@ -987,8 +1022,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   };
 
   await store.save(paymentId, {
-    paymentId, status, response, callbackUrl,
-    createdAt: new Date(), updatedAt: new Date(),
+    paymentId,
+    status,
+    response,
+    callbackUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -998,7 +1037,10 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 Idempotent Cancel with `requestId` guard and state validation:
 
 ```typescript
-async function cancelPaymentHandler(req: Request, res: Response): Promise<void> {
+async function cancelPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.params;
   const { requestId } = req.body;
 
@@ -1033,7 +1075,11 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 
   await store.updateStatus(paymentId, "cancelled");
   await store.saveOperation(requestId, {
-    requestId, paymentId, operation: "cancel", response, createdAt: new Date(),
+    requestId,
+    paymentId,
+    operation: "cancel",
+    response,
+    createdAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -2302,11 +2348,13 @@ This skill provides guidance for AI agents working with VTEX Payment Connector D
 ## When this skill applies
 
 Use this skill when:
+
 - Building a new payment connector middleware that integrates a PSP with the VTEX Payment Gateway
 - Implementing, debugging, or extending any of the 9 PPP endpoints
 - Preparing a connector for VTEX Payment Provider Test Suite homologation
 
 Do not use this skill for:
+
 - Idempotency and duplicate prevention logic — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows and callback URLs — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy card handling — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -2333,6 +2381,7 @@ The VTEX Payment Provider Test Suite validates every endpoint during homologatio
 If the connector router/handler file does not define handlers for all 6 payment-flow paths, STOP and add the missing endpoints before proceeding.
 
 **Correct**
+
 ```typescript
 import { Router } from "express";
 
@@ -2344,12 +2393,16 @@ router.post("/payments", createPaymentHandler);
 router.post("/payments/:paymentId/cancellations", cancelPaymentHandler);
 router.post("/payments/:paymentId/settlements", capturePaymentHandler);
 router.post("/payments/:paymentId/refunds", refundPaymentHandler);
-router.post("/payments/:paymentId/inbound-request/:action", inboundRequestHandler);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  inboundRequestHandler,
+);
 
 export default router;
 ```
 
 **Wrong**
+
 ```typescript
 import { Router } from "express";
 
@@ -2375,6 +2428,7 @@ The Gateway parses these fields programmatically. Missing fields cause deseriali
 If a response object is missing any of the required fields for its endpoint, STOP and add the missing fields.
 
 **Correct**
+
 ```typescript
 interface CreatePaymentResponse {
   paymentId: string;
@@ -2391,8 +2445,12 @@ interface CreatePaymentResponse {
   paymentUrl?: string;
 }
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId, value, currency, paymentMethod, card, callbackUrl } = req.body;
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { paymentId, value, currency, paymentMethod, card, callbackUrl } =
+    req.body;
 
   const result = await processPaymentWithAcquirer(req.body);
 
@@ -2405,9 +2463,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     acquirer: "MyAcquirer",
     code: result.code ?? null,
     message: result.message ?? null,
-    delayToAutoSettle: 21600,    // 6 hours in seconds
+    delayToAutoSettle: 21600, // 6 hours in seconds
     delayToAutoSettleAfterAntifraud: 1800, // 30 minutes in seconds
-    delayToCancel: 21600,         // 6 hours in seconds
+    delayToCancel: 21600, // 6 hours in seconds
   };
 
   res.status(200).json(response);
@@ -2415,9 +2473,13 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
 // Missing required fields — Gateway will reject this response
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const result = await processPaymentWithAcquirer(req.body);
 
   // Missing: authorizationId, nsu, tid, acquirer, code, message,
@@ -2440,6 +2502,7 @@ The Gateway reads the manifest to determine which payment methods are available.
 If the manifest handler returns an empty `paymentMethods` array or hardcodes methods the provider does not actually support, STOP and fix the manifest.
 
 **Correct**
+
 ```typescript
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
   const manifest = {
@@ -2457,6 +2520,7 @@ async function manifestHandler(_req: Request, res: Response): Promise<void> {
 ```
 
 **Wrong**
+
 ```typescript
 // Empty manifest — no payment methods will appear in the Admin
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
@@ -2599,62 +2663,74 @@ router.post("/payments", async (req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-router.post("/payments/:paymentId/cancellations", async (req: Request, res: Response) => {
-  const { paymentId } = req.params;
-  const { requestId } = req.body;
-  const result = await cancelWithAcquirer(paymentId);
+router.post(
+  "/payments/:paymentId/cancellations",
+  async (req: Request, res: Response) => {
+    const { paymentId } = req.params;
+    const { requestId } = req.body;
+    const result = await cancelWithAcquirer(paymentId);
 
-  res.status(200).json({
-    paymentId,
-    cancellationId: result.cancellationId ?? null,
-    code: result.code ?? null,
-    message: result.message ?? "Successfully cancelled",
-    requestId,
-  });
-});
+    res.status(200).json({
+      paymentId,
+      cancellationId: result.cancellationId ?? null,
+      code: result.code ?? null,
+      message: result.message ?? "Successfully cancelled",
+      requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/settlements", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await captureWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/settlements",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await captureWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    settleId: result.settleId ?? null,
-    value: result.capturedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      settleId: result.settleId ?? null,
+      value: result.capturedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/refunds", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await refundWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/refunds",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await refundWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    refundId: result.refundId ?? null,
-    value: result.refundedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      refundId: result.refundId ?? null,
+      value: result.refundedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/inbound-request/:action", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await handleInbound(body);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await handleInbound(body);
 
-  res.status(200).json({
-    requestId: body.requestId,
-    paymentId: body.paymentId,
-    responseData: {
-      statusCode: 200,
-      contentType: "application/json",
-      content: JSON.stringify(result),
-    },
-  });
-});
+    res.status(200).json({
+      requestId: body.requestId,
+      paymentId: body.paymentId,
+      responseData: {
+        statusCode: 200,
+        contentType: "application/json",
+        content: JSON.stringify(result),
+      },
+    });
+  },
+);
 
 export default router;
 ```
@@ -2667,29 +2743,40 @@ import { Router, Request, Response } from "express";
 const configRouter = Router();
 
 // 1. POST /authorization/token
-configRouter.post("/authorization/token", async (req: Request, res: Response) => {
-  const { applicationId, returnUrl } = req.body;
-  const token = await generateAuthorizationToken(applicationId, returnUrl);
-  res.status(200).json({ applicationId, token });
-});
+configRouter.post(
+  "/authorization/token",
+  async (req: Request, res: Response) => {
+    const { applicationId, returnUrl } = req.body;
+    const token = await generateAuthorizationToken(applicationId, returnUrl);
+    res.status(200).json({ applicationId, token });
+  },
+);
 
 // 2. GET /authorization/redirect
-configRouter.get("/authorization/redirect", async (req: Request, res: Response) => {
-  const { token } = req.query;
-  const providerLoginUrl = buildProviderLoginUrl(token as string);
-  res.redirect(302, providerLoginUrl);
-});
+configRouter.get(
+  "/authorization/redirect",
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
+    const providerLoginUrl = buildProviderLoginUrl(token as string);
+    res.redirect(302, providerLoginUrl);
+  },
+);
 
 // 3. GET /authorization/credentials
-configRouter.get("/authorization/credentials", async (req: Request, res: Response) => {
-  const { authorizationCode } = req.query;
-  const credentials = await exchangeCodeForCredentials(authorizationCode as string);
-  res.status(200).json({
-    applicationId: "vtex",
-    appKey: credentials.appKey,
-    appToken: credentials.appToken,
-  });
-});
+configRouter.get(
+  "/authorization/credentials",
+  async (req: Request, res: Response) => {
+    const { authorizationCode } = req.query;
+    const credentials = await exchangeCodeForCredentials(
+      authorizationCode as string,
+    );
+    res.status(200).json({
+      applicationId: "vtex",
+      appKey: credentials.appKey,
+      appToken: credentials.appToken,
+    });
+  },
+);
 
 export default configRouter;
 ```

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -6520,12 +6520,14 @@ async function notifyGateway(callbackUrl: string, payload: object): Promise<void
 ## When this skill applies
 
 Use this skill when:
+
 - Implementing any PPP endpoint handler that processes payments, cancellations, captures, or refunds
 - Ensuring repeated Gateway calls with the same identifiers produce identical results without re-processing
 - Building a payment state machine to prevent invalid transitions (e.g., capturing a cancelled payment)
 - Handling the Gateway's 7-day retry window for `undefined` status payments
 
 Do not use this skill for:
+
 - PPP endpoint response shapes and HTTP methods — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Async callback URL notification logic — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -6552,8 +6554,12 @@ The VTEX Gateway retries Create Payment requests with `undefined` status for up 
 If the Create Payment handler does not check for an existing `paymentId` before processing, STOP. The handler must query the data store for the `paymentId` first.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // Check for existing payment — idempotency guard
@@ -6589,8 +6595,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // No idempotency check — every call hits the acquirer
@@ -6625,8 +6635,12 @@ The Gateway uses the response fields (`authorizationId`, `tid`, `nsu`, `status`)
 If the handler creates a new database record or generates new identifiers when it finds an existing `paymentId`, STOP. The handler must return the previously stored response verbatim.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -6641,8 +6655,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -6652,7 +6670,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     const newTid = generateNewTid();
     res.status(200).json({
       ...existing.response,
-      tid: newTid,  // Different from original — breaks reconciliation
+      tid: newTid, // Different from original — breaks reconciliation
       nsu: generateNewNsu(),
     });
     return;
@@ -6673,8 +6691,12 @@ Returning `approved` for an async method tells the Gateway the payment is confir
 If the Create Payment handler returns `status: "approved"` or `status: "denied"` for an asynchronous payment method (Boleto, Pix, bank transfer, redirect-based), STOP. Async methods must return `"undefined"` and use callbacks.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   const isAsyncMethod = ["BankInvoice", "Pix"].includes(paymentMethod);
@@ -6690,7 +6712,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
     res.status(200).json({
       paymentId,
-      status: "undefined",  // Correct for async
+      status: "undefined", // Correct for async
       authorizationId: pending.authorizationId ?? null,
       nsu: pending.nsu ?? null,
       tid: pending.tid ?? null,
@@ -6699,7 +6721,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer payment",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: 604800, // 7 days for async
       paymentUrl: pending.paymentUrl,
     });
     return;
@@ -6711,8 +6733,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod } = req.body;
 
   // WRONG: Approving a Pix payment synchronously
@@ -6721,7 +6747,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
   res.status(200).json({
     paymentId,
-    status: "approved",  // WRONG — Pix is async, should be "undefined"
+    status: "approved", // WRONG — Pix is async, should be "undefined"
     authorizationId: result.authorizationId ?? null,
     nsu: null,
     tid: null,
@@ -6742,7 +6768,13 @@ Payment state store with idempotency support:
 ```typescript
 interface PaymentRecord {
   paymentId: string;
-  status: "undefined" | "approved" | "denied" | "cancelled" | "settled" | "refunded";
+  status:
+    | "undefined"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "settled"
+    | "refunded";
   response: Record<string, unknown>;
   callbackUrl?: string;
   createdAt: Date;
@@ -6763,7 +6795,10 @@ Idempotent Create Payment with state machine:
 ```typescript
 const store = new PaymentStore();
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Idempotency check
@@ -6793,8 +6828,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   };
 
   await store.save(paymentId, {
-    paymentId, status, response, callbackUrl,
-    createdAt: new Date(), updatedAt: new Date(),
+    paymentId,
+    status,
+    response,
+    callbackUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -6804,7 +6843,10 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 Idempotent Cancel with `requestId` guard and state validation:
 
 ```typescript
-async function cancelPaymentHandler(req: Request, res: Response): Promise<void> {
+async function cancelPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.params;
   const { requestId } = req.body;
 
@@ -6839,7 +6881,11 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 
   await store.updateStatus(paymentId, "cancelled");
   await store.saveOperation(requestId, {
-    requestId, paymentId, operation: "cancel", response, createdAt: new Date(),
+    requestId,
+    paymentId,
+    operation: "cancel",
+    response,
+    createdAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -8102,11 +8148,13 @@ Replace all example vendor names, endpoints, and credentials with values for you
 ## When this skill applies
 
 Use this skill when:
+
 - Building a new payment connector middleware that integrates a PSP with the VTEX Payment Gateway
 - Implementing, debugging, or extending any of the 9 PPP endpoints
 - Preparing a connector for VTEX Payment Provider Test Suite homologation
 
 Do not use this skill for:
+
 - Idempotency and duplicate prevention logic — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows and callback URLs — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy card handling — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -8133,6 +8181,7 @@ The VTEX Payment Provider Test Suite validates every endpoint during homologatio
 If the connector router/handler file does not define handlers for all 6 payment-flow paths, STOP and add the missing endpoints before proceeding.
 
 **Correct**
+
 ```typescript
 import { Router } from "express";
 
@@ -8144,12 +8193,16 @@ router.post("/payments", createPaymentHandler);
 router.post("/payments/:paymentId/cancellations", cancelPaymentHandler);
 router.post("/payments/:paymentId/settlements", capturePaymentHandler);
 router.post("/payments/:paymentId/refunds", refundPaymentHandler);
-router.post("/payments/:paymentId/inbound-request/:action", inboundRequestHandler);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  inboundRequestHandler,
+);
 
 export default router;
 ```
 
 **Wrong**
+
 ```typescript
 import { Router } from "express";
 
@@ -8175,6 +8228,7 @@ The Gateway parses these fields programmatically. Missing fields cause deseriali
 If a response object is missing any of the required fields for its endpoint, STOP and add the missing fields.
 
 **Correct**
+
 ```typescript
 interface CreatePaymentResponse {
   paymentId: string;
@@ -8191,8 +8245,12 @@ interface CreatePaymentResponse {
   paymentUrl?: string;
 }
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId, value, currency, paymentMethod, card, callbackUrl } = req.body;
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { paymentId, value, currency, paymentMethod, card, callbackUrl } =
+    req.body;
 
   const result = await processPaymentWithAcquirer(req.body);
 
@@ -8205,9 +8263,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     acquirer: "MyAcquirer",
     code: result.code ?? null,
     message: result.message ?? null,
-    delayToAutoSettle: 21600,    // 6 hours in seconds
+    delayToAutoSettle: 21600, // 6 hours in seconds
     delayToAutoSettleAfterAntifraud: 1800, // 30 minutes in seconds
-    delayToCancel: 21600,         // 6 hours in seconds
+    delayToCancel: 21600, // 6 hours in seconds
   };
 
   res.status(200).json(response);
@@ -8215,9 +8273,13 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
 // Missing required fields — Gateway will reject this response
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const result = await processPaymentWithAcquirer(req.body);
 
   // Missing: authorizationId, nsu, tid, acquirer, code, message,
@@ -8240,6 +8302,7 @@ The Gateway reads the manifest to determine which payment methods are available.
 If the manifest handler returns an empty `paymentMethods` array or hardcodes methods the provider does not actually support, STOP and fix the manifest.
 
 **Correct**
+
 ```typescript
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
   const manifest = {
@@ -8257,6 +8320,7 @@ async function manifestHandler(_req: Request, res: Response): Promise<void> {
 ```
 
 **Wrong**
+
 ```typescript
 // Empty manifest — no payment methods will appear in the Admin
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
@@ -8399,62 +8463,74 @@ router.post("/payments", async (req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-router.post("/payments/:paymentId/cancellations", async (req: Request, res: Response) => {
-  const { paymentId } = req.params;
-  const { requestId } = req.body;
-  const result = await cancelWithAcquirer(paymentId);
+router.post(
+  "/payments/:paymentId/cancellations",
+  async (req: Request, res: Response) => {
+    const { paymentId } = req.params;
+    const { requestId } = req.body;
+    const result = await cancelWithAcquirer(paymentId);
 
-  res.status(200).json({
-    paymentId,
-    cancellationId: result.cancellationId ?? null,
-    code: result.code ?? null,
-    message: result.message ?? "Successfully cancelled",
-    requestId,
-  });
-});
+    res.status(200).json({
+      paymentId,
+      cancellationId: result.cancellationId ?? null,
+      code: result.code ?? null,
+      message: result.message ?? "Successfully cancelled",
+      requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/settlements", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await captureWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/settlements",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await captureWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    settleId: result.settleId ?? null,
-    value: result.capturedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      settleId: result.settleId ?? null,
+      value: result.capturedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/refunds", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await refundWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/refunds",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await refundWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    refundId: result.refundId ?? null,
-    value: result.refundedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      refundId: result.refundId ?? null,
+      value: result.refundedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/inbound-request/:action", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await handleInbound(body);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await handleInbound(body);
 
-  res.status(200).json({
-    requestId: body.requestId,
-    paymentId: body.paymentId,
-    responseData: {
-      statusCode: 200,
-      contentType: "application/json",
-      content: JSON.stringify(result),
-    },
-  });
-});
+    res.status(200).json({
+      requestId: body.requestId,
+      paymentId: body.paymentId,
+      responseData: {
+        statusCode: 200,
+        contentType: "application/json",
+        content: JSON.stringify(result),
+      },
+    });
+  },
+);
 
 export default router;
 ```
@@ -8467,29 +8543,40 @@ import { Router, Request, Response } from "express";
 const configRouter = Router();
 
 // 1. POST /authorization/token
-configRouter.post("/authorization/token", async (req: Request, res: Response) => {
-  const { applicationId, returnUrl } = req.body;
-  const token = await generateAuthorizationToken(applicationId, returnUrl);
-  res.status(200).json({ applicationId, token });
-});
+configRouter.post(
+  "/authorization/token",
+  async (req: Request, res: Response) => {
+    const { applicationId, returnUrl } = req.body;
+    const token = await generateAuthorizationToken(applicationId, returnUrl);
+    res.status(200).json({ applicationId, token });
+  },
+);
 
 // 2. GET /authorization/redirect
-configRouter.get("/authorization/redirect", async (req: Request, res: Response) => {
-  const { token } = req.query;
-  const providerLoginUrl = buildProviderLoginUrl(token as string);
-  res.redirect(302, providerLoginUrl);
-});
+configRouter.get(
+  "/authorization/redirect",
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
+    const providerLoginUrl = buildProviderLoginUrl(token as string);
+    res.redirect(302, providerLoginUrl);
+  },
+);
 
 // 3. GET /authorization/credentials
-configRouter.get("/authorization/credentials", async (req: Request, res: Response) => {
-  const { authorizationCode } = req.query;
-  const credentials = await exchangeCodeForCredentials(authorizationCode as string);
-  res.status(200).json({
-    applicationId: "vtex",
-    appKey: credentials.appKey,
-    appToken: credentials.appToken,
-  });
-});
+configRouter.get(
+  "/authorization/credentials",
+  async (req: Request, res: Response) => {
+    const { authorizationCode } = req.query;
+    const credentials = await exchangeCodeForCredentials(
+      authorizationCode as string,
+    );
+    res.status(200).json({
+      applicationId: "vtex",
+      appKey: credentials.appKey,
+      appToken: credentials.appToken,
+    });
+  },
+);
 
 export default configRouter;
 ```

--- a/exports/copilot/payment.md
+++ b/exports/copilot/payment.md
@@ -712,12 +712,14 @@ async function notifyGateway(callbackUrl: string, payload: object): Promise<void
 ## When this skill applies
 
 Use this skill when:
+
 - Implementing any PPP endpoint handler that processes payments, cancellations, captures, or refunds
 - Ensuring repeated Gateway calls with the same identifiers produce identical results without re-processing
 - Building a payment state machine to prevent invalid transitions (e.g., capturing a cancelled payment)
 - Handling the Gateway's 7-day retry window for `undefined` status payments
 
 Do not use this skill for:
+
 - PPP endpoint response shapes and HTTP methods — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Async callback URL notification logic — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -744,8 +746,12 @@ The VTEX Gateway retries Create Payment requests with `undefined` status for up 
 If the Create Payment handler does not check for an existing `paymentId` before processing, STOP. The handler must query the data store for the `paymentId` first.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // Check for existing payment — idempotency guard
@@ -781,8 +787,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // No idempotency check — every call hits the acquirer
@@ -817,8 +827,12 @@ The Gateway uses the response fields (`authorizationId`, `tid`, `nsu`, `status`)
 If the handler creates a new database record or generates new identifiers when it finds an existing `paymentId`, STOP. The handler must return the previously stored response verbatim.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -833,8 +847,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -844,7 +862,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     const newTid = generateNewTid();
     res.status(200).json({
       ...existing.response,
-      tid: newTid,  // Different from original — breaks reconciliation
+      tid: newTid, // Different from original — breaks reconciliation
       nsu: generateNewNsu(),
     });
     return;
@@ -865,8 +883,12 @@ Returning `approved` for an async method tells the Gateway the payment is confir
 If the Create Payment handler returns `status: "approved"` or `status: "denied"` for an asynchronous payment method (Boleto, Pix, bank transfer, redirect-based), STOP. Async methods must return `"undefined"` and use callbacks.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   const isAsyncMethod = ["BankInvoice", "Pix"].includes(paymentMethod);
@@ -882,7 +904,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
     res.status(200).json({
       paymentId,
-      status: "undefined",  // Correct for async
+      status: "undefined", // Correct for async
       authorizationId: pending.authorizationId ?? null,
       nsu: pending.nsu ?? null,
       tid: pending.tid ?? null,
@@ -891,7 +913,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer payment",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: 604800, // 7 days for async
       paymentUrl: pending.paymentUrl,
     });
     return;
@@ -903,8 +925,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod } = req.body;
 
   // WRONG: Approving a Pix payment synchronously
@@ -913,7 +939,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
   res.status(200).json({
     paymentId,
-    status: "approved",  // WRONG — Pix is async, should be "undefined"
+    status: "approved", // WRONG — Pix is async, should be "undefined"
     authorizationId: result.authorizationId ?? null,
     nsu: null,
     tid: null,
@@ -934,7 +960,13 @@ Payment state store with idempotency support:
 ```typescript
 interface PaymentRecord {
   paymentId: string;
-  status: "undefined" | "approved" | "denied" | "cancelled" | "settled" | "refunded";
+  status:
+    | "undefined"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "settled"
+    | "refunded";
   response: Record<string, unknown>;
   callbackUrl?: string;
   createdAt: Date;
@@ -955,7 +987,10 @@ Idempotent Create Payment with state machine:
 ```typescript
 const store = new PaymentStore();
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Idempotency check
@@ -985,8 +1020,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   };
 
   await store.save(paymentId, {
-    paymentId, status, response, callbackUrl,
-    createdAt: new Date(), updatedAt: new Date(),
+    paymentId,
+    status,
+    response,
+    callbackUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -996,7 +1035,10 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 Idempotent Cancel with `requestId` guard and state validation:
 
 ```typescript
-async function cancelPaymentHandler(req: Request, res: Response): Promise<void> {
+async function cancelPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.params;
   const { requestId } = req.body;
 
@@ -1031,7 +1073,11 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 
   await store.updateStatus(paymentId, "cancelled");
   await store.saveOperation(requestId, {
-    requestId, paymentId, operation: "cancel", response, createdAt: new Date(),
+    requestId,
+    paymentId,
+    operation: "cancel",
+    response,
+    createdAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -2294,11 +2340,13 @@ Replace all example vendor names, endpoints, and credentials with values for you
 ## When this skill applies
 
 Use this skill when:
+
 - Building a new payment connector middleware that integrates a PSP with the VTEX Payment Gateway
 - Implementing, debugging, or extending any of the 9 PPP endpoints
 - Preparing a connector for VTEX Payment Provider Test Suite homologation
 
 Do not use this skill for:
+
 - Idempotency and duplicate prevention logic — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows and callback URLs — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy card handling — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -2325,6 +2373,7 @@ The VTEX Payment Provider Test Suite validates every endpoint during homologatio
 If the connector router/handler file does not define handlers for all 6 payment-flow paths, STOP and add the missing endpoints before proceeding.
 
 **Correct**
+
 ```typescript
 import { Router } from "express";
 
@@ -2336,12 +2385,16 @@ router.post("/payments", createPaymentHandler);
 router.post("/payments/:paymentId/cancellations", cancelPaymentHandler);
 router.post("/payments/:paymentId/settlements", capturePaymentHandler);
 router.post("/payments/:paymentId/refunds", refundPaymentHandler);
-router.post("/payments/:paymentId/inbound-request/:action", inboundRequestHandler);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  inboundRequestHandler,
+);
 
 export default router;
 ```
 
 **Wrong**
+
 ```typescript
 import { Router } from "express";
 
@@ -2367,6 +2420,7 @@ The Gateway parses these fields programmatically. Missing fields cause deseriali
 If a response object is missing any of the required fields for its endpoint, STOP and add the missing fields.
 
 **Correct**
+
 ```typescript
 interface CreatePaymentResponse {
   paymentId: string;
@@ -2383,8 +2437,12 @@ interface CreatePaymentResponse {
   paymentUrl?: string;
 }
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId, value, currency, paymentMethod, card, callbackUrl } = req.body;
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { paymentId, value, currency, paymentMethod, card, callbackUrl } =
+    req.body;
 
   const result = await processPaymentWithAcquirer(req.body);
 
@@ -2397,9 +2455,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     acquirer: "MyAcquirer",
     code: result.code ?? null,
     message: result.message ?? null,
-    delayToAutoSettle: 21600,    // 6 hours in seconds
+    delayToAutoSettle: 21600, // 6 hours in seconds
     delayToAutoSettleAfterAntifraud: 1800, // 30 minutes in seconds
-    delayToCancel: 21600,         // 6 hours in seconds
+    delayToCancel: 21600, // 6 hours in seconds
   };
 
   res.status(200).json(response);
@@ -2407,9 +2465,13 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
 // Missing required fields — Gateway will reject this response
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const result = await processPaymentWithAcquirer(req.body);
 
   // Missing: authorizationId, nsu, tid, acquirer, code, message,
@@ -2432,6 +2494,7 @@ The Gateway reads the manifest to determine which payment methods are available.
 If the manifest handler returns an empty `paymentMethods` array or hardcodes methods the provider does not actually support, STOP and fix the manifest.
 
 **Correct**
+
 ```typescript
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
   const manifest = {
@@ -2449,6 +2512,7 @@ async function manifestHandler(_req: Request, res: Response): Promise<void> {
 ```
 
 **Wrong**
+
 ```typescript
 // Empty manifest — no payment methods will appear in the Admin
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
@@ -2591,62 +2655,74 @@ router.post("/payments", async (req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-router.post("/payments/:paymentId/cancellations", async (req: Request, res: Response) => {
-  const { paymentId } = req.params;
-  const { requestId } = req.body;
-  const result = await cancelWithAcquirer(paymentId);
+router.post(
+  "/payments/:paymentId/cancellations",
+  async (req: Request, res: Response) => {
+    const { paymentId } = req.params;
+    const { requestId } = req.body;
+    const result = await cancelWithAcquirer(paymentId);
 
-  res.status(200).json({
-    paymentId,
-    cancellationId: result.cancellationId ?? null,
-    code: result.code ?? null,
-    message: result.message ?? "Successfully cancelled",
-    requestId,
-  });
-});
+    res.status(200).json({
+      paymentId,
+      cancellationId: result.cancellationId ?? null,
+      code: result.code ?? null,
+      message: result.message ?? "Successfully cancelled",
+      requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/settlements", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await captureWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/settlements",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await captureWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    settleId: result.settleId ?? null,
-    value: result.capturedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      settleId: result.settleId ?? null,
+      value: result.capturedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/refunds", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await refundWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/refunds",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await refundWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    refundId: result.refundId ?? null,
-    value: result.refundedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      refundId: result.refundId ?? null,
+      value: result.refundedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/inbound-request/:action", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await handleInbound(body);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await handleInbound(body);
 
-  res.status(200).json({
-    requestId: body.requestId,
-    paymentId: body.paymentId,
-    responseData: {
-      statusCode: 200,
-      contentType: "application/json",
-      content: JSON.stringify(result),
-    },
-  });
-});
+    res.status(200).json({
+      requestId: body.requestId,
+      paymentId: body.paymentId,
+      responseData: {
+        statusCode: 200,
+        contentType: "application/json",
+        content: JSON.stringify(result),
+      },
+    });
+  },
+);
 
 export default router;
 ```
@@ -2659,29 +2735,40 @@ import { Router, Request, Response } from "express";
 const configRouter = Router();
 
 // 1. POST /authorization/token
-configRouter.post("/authorization/token", async (req: Request, res: Response) => {
-  const { applicationId, returnUrl } = req.body;
-  const token = await generateAuthorizationToken(applicationId, returnUrl);
-  res.status(200).json({ applicationId, token });
-});
+configRouter.post(
+  "/authorization/token",
+  async (req: Request, res: Response) => {
+    const { applicationId, returnUrl } = req.body;
+    const token = await generateAuthorizationToken(applicationId, returnUrl);
+    res.status(200).json({ applicationId, token });
+  },
+);
 
 // 2. GET /authorization/redirect
-configRouter.get("/authorization/redirect", async (req: Request, res: Response) => {
-  const { token } = req.query;
-  const providerLoginUrl = buildProviderLoginUrl(token as string);
-  res.redirect(302, providerLoginUrl);
-});
+configRouter.get(
+  "/authorization/redirect",
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
+    const providerLoginUrl = buildProviderLoginUrl(token as string);
+    res.redirect(302, providerLoginUrl);
+  },
+);
 
 // 3. GET /authorization/credentials
-configRouter.get("/authorization/credentials", async (req: Request, res: Response) => {
-  const { authorizationCode } = req.query;
-  const credentials = await exchangeCodeForCredentials(authorizationCode as string);
-  res.status(200).json({
-    applicationId: "vtex",
-    appKey: credentials.appKey,
-    appToken: credentials.appToken,
-  });
-});
+configRouter.get(
+  "/authorization/credentials",
+  async (req: Request, res: Response) => {
+    const { authorizationCode } = req.query;
+    const credentials = await exchangeCodeForCredentials(
+      authorizationCode as string,
+    );
+    res.status(200).json({
+      applicationId: "vtex",
+      appKey: credentials.appKey,
+      appToken: credentials.appToken,
+    });
+  },
+);
 
 export default configRouter;
 ```

--- a/exports/cursor/payment-all.mdc
+++ b/exports/cursor/payment-all.mdc
@@ -716,12 +716,14 @@ async function notifyGateway(callbackUrl: string, payload: object): Promise<void
 ## When this skill applies
 
 Use this skill when:
+
 - Implementing any PPP endpoint handler that processes payments, cancellations, captures, or refunds
 - Ensuring repeated Gateway calls with the same identifiers produce identical results without re-processing
 - Building a payment state machine to prevent invalid transitions (e.g., capturing a cancelled payment)
 - Handling the Gateway's 7-day retry window for `undefined` status payments
 
 Do not use this skill for:
+
 - PPP endpoint response shapes and HTTP methods — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Async callback URL notification logic — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -748,8 +750,12 @@ The VTEX Gateway retries Create Payment requests with `undefined` status for up 
 If the Create Payment handler does not check for an existing `paymentId` before processing, STOP. The handler must query the data store for the `paymentId` first.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // Check for existing payment — idempotency guard
@@ -785,8 +791,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // No idempotency check — every call hits the acquirer
@@ -821,8 +831,12 @@ The Gateway uses the response fields (`authorizationId`, `tid`, `nsu`, `status`)
 If the handler creates a new database record or generates new identifiers when it finds an existing `paymentId`, STOP. The handler must return the previously stored response verbatim.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -837,8 +851,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -848,7 +866,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     const newTid = generateNewTid();
     res.status(200).json({
       ...existing.response,
-      tid: newTid,  // Different from original — breaks reconciliation
+      tid: newTid, // Different from original — breaks reconciliation
       nsu: generateNewNsu(),
     });
     return;
@@ -869,8 +887,12 @@ Returning `approved` for an async method tells the Gateway the payment is confir
 If the Create Payment handler returns `status: "approved"` or `status: "denied"` for an asynchronous payment method (Boleto, Pix, bank transfer, redirect-based), STOP. Async methods must return `"undefined"` and use callbacks.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   const isAsyncMethod = ["BankInvoice", "Pix"].includes(paymentMethod);
@@ -886,7 +908,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
     res.status(200).json({
       paymentId,
-      status: "undefined",  // Correct for async
+      status: "undefined", // Correct for async
       authorizationId: pending.authorizationId ?? null,
       nsu: pending.nsu ?? null,
       tid: pending.tid ?? null,
@@ -895,7 +917,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer payment",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: 604800, // 7 days for async
       paymentUrl: pending.paymentUrl,
     });
     return;
@@ -907,8 +929,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod } = req.body;
 
   // WRONG: Approving a Pix payment synchronously
@@ -917,7 +943,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
   res.status(200).json({
     paymentId,
-    status: "approved",  // WRONG — Pix is async, should be "undefined"
+    status: "approved", // WRONG — Pix is async, should be "undefined"
     authorizationId: result.authorizationId ?? null,
     nsu: null,
     tid: null,
@@ -938,7 +964,13 @@ Payment state store with idempotency support:
 ```typescript
 interface PaymentRecord {
   paymentId: string;
-  status: "undefined" | "approved" | "denied" | "cancelled" | "settled" | "refunded";
+  status:
+    | "undefined"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "settled"
+    | "refunded";
   response: Record<string, unknown>;
   callbackUrl?: string;
   createdAt: Date;
@@ -959,7 +991,10 @@ Idempotent Create Payment with state machine:
 ```typescript
 const store = new PaymentStore();
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Idempotency check
@@ -989,8 +1024,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   };
 
   await store.save(paymentId, {
-    paymentId, status, response, callbackUrl,
-    createdAt: new Date(), updatedAt: new Date(),
+    paymentId,
+    status,
+    response,
+    callbackUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -1000,7 +1039,10 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 Idempotent Cancel with `requestId` guard and state validation:
 
 ```typescript
-async function cancelPaymentHandler(req: Request, res: Response): Promise<void> {
+async function cancelPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.params;
   const { requestId } = req.body;
 
@@ -1035,7 +1077,11 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 
   await store.updateStatus(paymentId, "cancelled");
   await store.saveOperation(requestId, {
-    requestId, paymentId, operation: "cancel", response, createdAt: new Date(),
+    requestId,
+    paymentId,
+    operation: "cancel",
+    response,
+    createdAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -2298,11 +2344,13 @@ Replace all example vendor names, endpoints, and credentials with values for you
 ## When this skill applies
 
 Use this skill when:
+
 - Building a new payment connector middleware that integrates a PSP with the VTEX Payment Gateway
 - Implementing, debugging, or extending any of the 9 PPP endpoints
 - Preparing a connector for VTEX Payment Provider Test Suite homologation
 
 Do not use this skill for:
+
 - Idempotency and duplicate prevention logic — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows and callback URLs — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy card handling — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -2329,6 +2377,7 @@ The VTEX Payment Provider Test Suite validates every endpoint during homologatio
 If the connector router/handler file does not define handlers for all 6 payment-flow paths, STOP and add the missing endpoints before proceeding.
 
 **Correct**
+
 ```typescript
 import { Router } from "express";
 
@@ -2340,12 +2389,16 @@ router.post("/payments", createPaymentHandler);
 router.post("/payments/:paymentId/cancellations", cancelPaymentHandler);
 router.post("/payments/:paymentId/settlements", capturePaymentHandler);
 router.post("/payments/:paymentId/refunds", refundPaymentHandler);
-router.post("/payments/:paymentId/inbound-request/:action", inboundRequestHandler);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  inboundRequestHandler,
+);
 
 export default router;
 ```
 
 **Wrong**
+
 ```typescript
 import { Router } from "express";
 
@@ -2371,6 +2424,7 @@ The Gateway parses these fields programmatically. Missing fields cause deseriali
 If a response object is missing any of the required fields for its endpoint, STOP and add the missing fields.
 
 **Correct**
+
 ```typescript
 interface CreatePaymentResponse {
   paymentId: string;
@@ -2387,8 +2441,12 @@ interface CreatePaymentResponse {
   paymentUrl?: string;
 }
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId, value, currency, paymentMethod, card, callbackUrl } = req.body;
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { paymentId, value, currency, paymentMethod, card, callbackUrl } =
+    req.body;
 
   const result = await processPaymentWithAcquirer(req.body);
 
@@ -2401,9 +2459,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     acquirer: "MyAcquirer",
     code: result.code ?? null,
     message: result.message ?? null,
-    delayToAutoSettle: 21600,    // 6 hours in seconds
+    delayToAutoSettle: 21600, // 6 hours in seconds
     delayToAutoSettleAfterAntifraud: 1800, // 30 minutes in seconds
-    delayToCancel: 21600,         // 6 hours in seconds
+    delayToCancel: 21600, // 6 hours in seconds
   };
 
   res.status(200).json(response);
@@ -2411,9 +2469,13 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
 // Missing required fields — Gateway will reject this response
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const result = await processPaymentWithAcquirer(req.body);
 
   // Missing: authorizationId, nsu, tid, acquirer, code, message,
@@ -2436,6 +2498,7 @@ The Gateway reads the manifest to determine which payment methods are available.
 If the manifest handler returns an empty `paymentMethods` array or hardcodes methods the provider does not actually support, STOP and fix the manifest.
 
 **Correct**
+
 ```typescript
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
   const manifest = {
@@ -2453,6 +2516,7 @@ async function manifestHandler(_req: Request, res: Response): Promise<void> {
 ```
 
 **Wrong**
+
 ```typescript
 // Empty manifest — no payment methods will appear in the Admin
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
@@ -2595,62 +2659,74 @@ router.post("/payments", async (req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-router.post("/payments/:paymentId/cancellations", async (req: Request, res: Response) => {
-  const { paymentId } = req.params;
-  const { requestId } = req.body;
-  const result = await cancelWithAcquirer(paymentId);
+router.post(
+  "/payments/:paymentId/cancellations",
+  async (req: Request, res: Response) => {
+    const { paymentId } = req.params;
+    const { requestId } = req.body;
+    const result = await cancelWithAcquirer(paymentId);
 
-  res.status(200).json({
-    paymentId,
-    cancellationId: result.cancellationId ?? null,
-    code: result.code ?? null,
-    message: result.message ?? "Successfully cancelled",
-    requestId,
-  });
-});
+    res.status(200).json({
+      paymentId,
+      cancellationId: result.cancellationId ?? null,
+      code: result.code ?? null,
+      message: result.message ?? "Successfully cancelled",
+      requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/settlements", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await captureWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/settlements",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await captureWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    settleId: result.settleId ?? null,
-    value: result.capturedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      settleId: result.settleId ?? null,
+      value: result.capturedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/refunds", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await refundWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/refunds",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await refundWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    refundId: result.refundId ?? null,
-    value: result.refundedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      refundId: result.refundId ?? null,
+      value: result.refundedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/inbound-request/:action", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await handleInbound(body);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await handleInbound(body);
 
-  res.status(200).json({
-    requestId: body.requestId,
-    paymentId: body.paymentId,
-    responseData: {
-      statusCode: 200,
-      contentType: "application/json",
-      content: JSON.stringify(result),
-    },
-  });
-});
+    res.status(200).json({
+      requestId: body.requestId,
+      paymentId: body.paymentId,
+      responseData: {
+        statusCode: 200,
+        contentType: "application/json",
+        content: JSON.stringify(result),
+      },
+    });
+  },
+);
 
 export default router;
 ```
@@ -2663,29 +2739,40 @@ import { Router, Request, Response } from "express";
 const configRouter = Router();
 
 // 1. POST /authorization/token
-configRouter.post("/authorization/token", async (req: Request, res: Response) => {
-  const { applicationId, returnUrl } = req.body;
-  const token = await generateAuthorizationToken(applicationId, returnUrl);
-  res.status(200).json({ applicationId, token });
-});
+configRouter.post(
+  "/authorization/token",
+  async (req: Request, res: Response) => {
+    const { applicationId, returnUrl } = req.body;
+    const token = await generateAuthorizationToken(applicationId, returnUrl);
+    res.status(200).json({ applicationId, token });
+  },
+);
 
 // 2. GET /authorization/redirect
-configRouter.get("/authorization/redirect", async (req: Request, res: Response) => {
-  const { token } = req.query;
-  const providerLoginUrl = buildProviderLoginUrl(token as string);
-  res.redirect(302, providerLoginUrl);
-});
+configRouter.get(
+  "/authorization/redirect",
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
+    const providerLoginUrl = buildProviderLoginUrl(token as string);
+    res.redirect(302, providerLoginUrl);
+  },
+);
 
 // 3. GET /authorization/credentials
-configRouter.get("/authorization/credentials", async (req: Request, res: Response) => {
-  const { authorizationCode } = req.query;
-  const credentials = await exchangeCodeForCredentials(authorizationCode as string);
-  res.status(200).json({
-    applicationId: "vtex",
-    appKey: credentials.appKey,
-    appToken: credentials.appToken,
-  });
-});
+configRouter.get(
+  "/authorization/credentials",
+  async (req: Request, res: Response) => {
+    const { authorizationCode } = req.query;
+    const credentials = await exchangeCodeForCredentials(
+      authorizationCode as string,
+    );
+    res.status(200).json({
+      applicationId: "vtex",
+      appKey: credentials.appKey,
+      appToken: credentials.appToken,
+    });
+  },
+);
 
 export default configRouter;
 ```

--- a/exports/cursor/payment-payment-idempotency.mdc
+++ b/exports/cursor/payment-payment-idempotency.mdc
@@ -9,12 +9,14 @@ alwaysApply: false
 ## When this skill applies
 
 Use this skill when:
+
 - Implementing any PPP endpoint handler that processes payments, cancellations, captures, or refunds
 - Ensuring repeated Gateway calls with the same identifiers produce identical results without re-processing
 - Building a payment state machine to prevent invalid transitions (e.g., capturing a cancelled payment)
 - Handling the Gateway's 7-day retry window for `undefined` status payments
 
 Do not use this skill for:
+
 - PPP endpoint response shapes and HTTP methods — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Async callback URL notification logic — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -41,8 +43,12 @@ The VTEX Gateway retries Create Payment requests with `undefined` status for up 
 If the Create Payment handler does not check for an existing `paymentId` before processing, STOP. The handler must query the data store for the `paymentId` first.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // Check for existing payment — idempotency guard
@@ -78,8 +84,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // No idempotency check — every call hits the acquirer
@@ -114,8 +124,12 @@ The Gateway uses the response fields (`authorizationId`, `tid`, `nsu`, `status`)
 If the handler creates a new database record or generates new identifiers when it finds an existing `paymentId`, STOP. The handler must return the previously stored response verbatim.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -130,8 +144,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -141,7 +159,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     const newTid = generateNewTid();
     res.status(200).json({
       ...existing.response,
-      tid: newTid,  // Different from original — breaks reconciliation
+      tid: newTid, // Different from original — breaks reconciliation
       nsu: generateNewNsu(),
     });
     return;
@@ -162,8 +180,12 @@ Returning `approved` for an async method tells the Gateway the payment is confir
 If the Create Payment handler returns `status: "approved"` or `status: "denied"` for an asynchronous payment method (Boleto, Pix, bank transfer, redirect-based), STOP. Async methods must return `"undefined"` and use callbacks.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   const isAsyncMethod = ["BankInvoice", "Pix"].includes(paymentMethod);
@@ -179,7 +201,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
     res.status(200).json({
       paymentId,
-      status: "undefined",  // Correct for async
+      status: "undefined", // Correct for async
       authorizationId: pending.authorizationId ?? null,
       nsu: pending.nsu ?? null,
       tid: pending.tid ?? null,
@@ -188,7 +210,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer payment",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: 604800, // 7 days for async
       paymentUrl: pending.paymentUrl,
     });
     return;
@@ -200,8 +222,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod } = req.body;
 
   // WRONG: Approving a Pix payment synchronously
@@ -210,7 +236,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
   res.status(200).json({
     paymentId,
-    status: "approved",  // WRONG — Pix is async, should be "undefined"
+    status: "approved", // WRONG — Pix is async, should be "undefined"
     authorizationId: result.authorizationId ?? null,
     nsu: null,
     tid: null,
@@ -231,7 +257,13 @@ Payment state store with idempotency support:
 ```typescript
 interface PaymentRecord {
   paymentId: string;
-  status: "undefined" | "approved" | "denied" | "cancelled" | "settled" | "refunded";
+  status:
+    | "undefined"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "settled"
+    | "refunded";
   response: Record<string, unknown>;
   callbackUrl?: string;
   createdAt: Date;
@@ -252,7 +284,10 @@ Idempotent Create Payment with state machine:
 ```typescript
 const store = new PaymentStore();
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Idempotency check
@@ -282,8 +317,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   };
 
   await store.save(paymentId, {
-    paymentId, status, response, callbackUrl,
-    createdAt: new Date(), updatedAt: new Date(),
+    paymentId,
+    status,
+    response,
+    callbackUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -293,7 +332,10 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 Idempotent Cancel with `requestId` guard and state validation:
 
 ```typescript
-async function cancelPaymentHandler(req: Request, res: Response): Promise<void> {
+async function cancelPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.params;
   const { requestId } = req.body;
 
@@ -328,7 +370,11 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 
   await store.updateStatus(paymentId, "cancelled");
   await store.saveOperation(requestId, {
-    requestId, paymentId, operation: "cancel", response, createdAt: new Date(),
+    requestId,
+    paymentId,
+    operation: "cancel",
+    response,
+    createdAt: new Date(),
   });
 
   res.status(200).json(response);

--- a/exports/cursor/payment-payment-provider-protocol.mdc
+++ b/exports/cursor/payment-payment-provider-protocol.mdc
@@ -9,11 +9,13 @@ alwaysApply: false
 ## When this skill applies
 
 Use this skill when:
+
 - Building a new payment connector middleware that integrates a PSP with the VTEX Payment Gateway
 - Implementing, debugging, or extending any of the 9 PPP endpoints
 - Preparing a connector for VTEX Payment Provider Test Suite homologation
 
 Do not use this skill for:
+
 - Idempotency and duplicate prevention logic — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows and callback URLs — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy card handling — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -40,6 +42,7 @@ The VTEX Payment Provider Test Suite validates every endpoint during homologatio
 If the connector router/handler file does not define handlers for all 6 payment-flow paths, STOP and add the missing endpoints before proceeding.
 
 **Correct**
+
 ```typescript
 import { Router } from "express";
 
@@ -51,12 +54,16 @@ router.post("/payments", createPaymentHandler);
 router.post("/payments/:paymentId/cancellations", cancelPaymentHandler);
 router.post("/payments/:paymentId/settlements", capturePaymentHandler);
 router.post("/payments/:paymentId/refunds", refundPaymentHandler);
-router.post("/payments/:paymentId/inbound-request/:action", inboundRequestHandler);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  inboundRequestHandler,
+);
 
 export default router;
 ```
 
 **Wrong**
+
 ```typescript
 import { Router } from "express";
 
@@ -82,6 +89,7 @@ The Gateway parses these fields programmatically. Missing fields cause deseriali
 If a response object is missing any of the required fields for its endpoint, STOP and add the missing fields.
 
 **Correct**
+
 ```typescript
 interface CreatePaymentResponse {
   paymentId: string;
@@ -98,8 +106,12 @@ interface CreatePaymentResponse {
   paymentUrl?: string;
 }
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId, value, currency, paymentMethod, card, callbackUrl } = req.body;
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { paymentId, value, currency, paymentMethod, card, callbackUrl } =
+    req.body;
 
   const result = await processPaymentWithAcquirer(req.body);
 
@@ -112,9 +124,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     acquirer: "MyAcquirer",
     code: result.code ?? null,
     message: result.message ?? null,
-    delayToAutoSettle: 21600,    // 6 hours in seconds
+    delayToAutoSettle: 21600, // 6 hours in seconds
     delayToAutoSettleAfterAntifraud: 1800, // 30 minutes in seconds
-    delayToCancel: 21600,         // 6 hours in seconds
+    delayToCancel: 21600, // 6 hours in seconds
   };
 
   res.status(200).json(response);
@@ -122,9 +134,13 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
 // Missing required fields — Gateway will reject this response
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const result = await processPaymentWithAcquirer(req.body);
 
   // Missing: authorizationId, nsu, tid, acquirer, code, message,
@@ -147,6 +163,7 @@ The Gateway reads the manifest to determine which payment methods are available.
 If the manifest handler returns an empty `paymentMethods` array or hardcodes methods the provider does not actually support, STOP and fix the manifest.
 
 **Correct**
+
 ```typescript
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
   const manifest = {
@@ -164,6 +181,7 @@ async function manifestHandler(_req: Request, res: Response): Promise<void> {
 ```
 
 **Wrong**
+
 ```typescript
 // Empty manifest — no payment methods will appear in the Admin
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
@@ -306,62 +324,74 @@ router.post("/payments", async (req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-router.post("/payments/:paymentId/cancellations", async (req: Request, res: Response) => {
-  const { paymentId } = req.params;
-  const { requestId } = req.body;
-  const result = await cancelWithAcquirer(paymentId);
+router.post(
+  "/payments/:paymentId/cancellations",
+  async (req: Request, res: Response) => {
+    const { paymentId } = req.params;
+    const { requestId } = req.body;
+    const result = await cancelWithAcquirer(paymentId);
 
-  res.status(200).json({
-    paymentId,
-    cancellationId: result.cancellationId ?? null,
-    code: result.code ?? null,
-    message: result.message ?? "Successfully cancelled",
-    requestId,
-  });
-});
+    res.status(200).json({
+      paymentId,
+      cancellationId: result.cancellationId ?? null,
+      code: result.code ?? null,
+      message: result.message ?? "Successfully cancelled",
+      requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/settlements", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await captureWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/settlements",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await captureWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    settleId: result.settleId ?? null,
-    value: result.capturedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      settleId: result.settleId ?? null,
+      value: result.capturedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/refunds", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await refundWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/refunds",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await refundWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    refundId: result.refundId ?? null,
-    value: result.refundedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      refundId: result.refundId ?? null,
+      value: result.refundedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/inbound-request/:action", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await handleInbound(body);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await handleInbound(body);
 
-  res.status(200).json({
-    requestId: body.requestId,
-    paymentId: body.paymentId,
-    responseData: {
-      statusCode: 200,
-      contentType: "application/json",
-      content: JSON.stringify(result),
-    },
-  });
-});
+    res.status(200).json({
+      requestId: body.requestId,
+      paymentId: body.paymentId,
+      responseData: {
+        statusCode: 200,
+        contentType: "application/json",
+        content: JSON.stringify(result),
+      },
+    });
+  },
+);
 
 export default router;
 ```
@@ -374,29 +404,40 @@ import { Router, Request, Response } from "express";
 const configRouter = Router();
 
 // 1. POST /authorization/token
-configRouter.post("/authorization/token", async (req: Request, res: Response) => {
-  const { applicationId, returnUrl } = req.body;
-  const token = await generateAuthorizationToken(applicationId, returnUrl);
-  res.status(200).json({ applicationId, token });
-});
+configRouter.post(
+  "/authorization/token",
+  async (req: Request, res: Response) => {
+    const { applicationId, returnUrl } = req.body;
+    const token = await generateAuthorizationToken(applicationId, returnUrl);
+    res.status(200).json({ applicationId, token });
+  },
+);
 
 // 2. GET /authorization/redirect
-configRouter.get("/authorization/redirect", async (req: Request, res: Response) => {
-  const { token } = req.query;
-  const providerLoginUrl = buildProviderLoginUrl(token as string);
-  res.redirect(302, providerLoginUrl);
-});
+configRouter.get(
+  "/authorization/redirect",
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
+    const providerLoginUrl = buildProviderLoginUrl(token as string);
+    res.redirect(302, providerLoginUrl);
+  },
+);
 
 // 3. GET /authorization/credentials
-configRouter.get("/authorization/credentials", async (req: Request, res: Response) => {
-  const { authorizationCode } = req.query;
-  const credentials = await exchangeCodeForCredentials(authorizationCode as string);
-  res.status(200).json({
-    applicationId: "vtex",
-    appKey: credentials.appKey,
-    appToken: credentials.appToken,
-  });
-});
+configRouter.get(
+  "/authorization/credentials",
+  async (req: Request, res: Response) => {
+    const { authorizationCode } = req.query;
+    const credentials = await exchangeCodeForCredentials(
+      authorizationCode as string,
+    );
+    res.status(200).json({
+      applicationId: "vtex",
+      appKey: credentials.appKey,
+      appToken: credentials.appToken,
+    });
+  },
+);
 
 export default configRouter;
 ```

--- a/exports/kiro/steering/payment-all.md
+++ b/exports/kiro/steering/payment-all.md
@@ -712,12 +712,14 @@ async function notifyGateway(callbackUrl: string, payload: object): Promise<void
 ## When this skill applies
 
 Use this skill when:
+
 - Implementing any PPP endpoint handler that processes payments, cancellations, captures, or refunds
 - Ensuring repeated Gateway calls with the same identifiers produce identical results without re-processing
 - Building a payment state machine to prevent invalid transitions (e.g., capturing a cancelled payment)
 - Handling the Gateway's 7-day retry window for `undefined` status payments
 
 Do not use this skill for:
+
 - PPP endpoint response shapes and HTTP methods — use [`payment-provider-protocol`](payment-payment-provider-protocol.md)
 - Async callback URL notification logic — use [`payment-async-flow`](payment-payment-async-flow.md)
 - PCI compliance and Secure Proxy — use [`payment-pci-security`](payment-payment-pci-security.md)
@@ -744,8 +746,12 @@ The VTEX Gateway retries Create Payment requests with `undefined` status for up 
 If the Create Payment handler does not check for an existing `paymentId` before processing, STOP. The handler must query the data store for the `paymentId` first.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // Check for existing payment — idempotency guard
@@ -781,8 +787,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // No idempotency check — every call hits the acquirer
@@ -817,8 +827,12 @@ The Gateway uses the response fields (`authorizationId`, `tid`, `nsu`, `status`)
 If the handler creates a new database record or generates new identifiers when it finds an existing `paymentId`, STOP. The handler must return the previously stored response verbatim.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -833,8 +847,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -844,7 +862,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     const newTid = generateNewTid();
     res.status(200).json({
       ...existing.response,
-      tid: newTid,  // Different from original — breaks reconciliation
+      tid: newTid, // Different from original — breaks reconciliation
       nsu: generateNewNsu(),
     });
     return;
@@ -865,8 +883,12 @@ Returning `approved` for an async method tells the Gateway the payment is confir
 If the Create Payment handler returns `status: "approved"` or `status: "denied"` for an asynchronous payment method (Boleto, Pix, bank transfer, redirect-based), STOP. Async methods must return `"undefined"` and use callbacks.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   const isAsyncMethod = ["BankInvoice", "Pix"].includes(paymentMethod);
@@ -882,7 +904,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
     res.status(200).json({
       paymentId,
-      status: "undefined",  // Correct for async
+      status: "undefined", // Correct for async
       authorizationId: pending.authorizationId ?? null,
       nsu: pending.nsu ?? null,
       tid: pending.tid ?? null,
@@ -891,7 +913,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer payment",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: 604800, // 7 days for async
       paymentUrl: pending.paymentUrl,
     });
     return;
@@ -903,8 +925,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod } = req.body;
 
   // WRONG: Approving a Pix payment synchronously
@@ -913,7 +939,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
   res.status(200).json({
     paymentId,
-    status: "approved",  // WRONG — Pix is async, should be "undefined"
+    status: "approved", // WRONG — Pix is async, should be "undefined"
     authorizationId: result.authorizationId ?? null,
     nsu: null,
     tid: null,
@@ -934,7 +960,13 @@ Payment state store with idempotency support:
 ```typescript
 interface PaymentRecord {
   paymentId: string;
-  status: "undefined" | "approved" | "denied" | "cancelled" | "settled" | "refunded";
+  status:
+    | "undefined"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "settled"
+    | "refunded";
   response: Record<string, unknown>;
   callbackUrl?: string;
   createdAt: Date;
@@ -955,7 +987,10 @@ Idempotent Create Payment with state machine:
 ```typescript
 const store = new PaymentStore();
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Idempotency check
@@ -985,8 +1020,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   };
 
   await store.save(paymentId, {
-    paymentId, status, response, callbackUrl,
-    createdAt: new Date(), updatedAt: new Date(),
+    paymentId,
+    status,
+    response,
+    callbackUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -996,7 +1035,10 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 Idempotent Cancel with `requestId` guard and state validation:
 
 ```typescript
-async function cancelPaymentHandler(req: Request, res: Response): Promise<void> {
+async function cancelPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.params;
   const { requestId } = req.body;
 
@@ -1031,7 +1073,11 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 
   await store.updateStatus(paymentId, "cancelled");
   await store.saveOperation(requestId, {
-    requestId, paymentId, operation: "cancel", response, createdAt: new Date(),
+    requestId,
+    paymentId,
+    operation: "cancel",
+    response,
+    createdAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -2294,11 +2340,13 @@ Replace all example vendor names, endpoints, and credentials with values for you
 ## When this skill applies
 
 Use this skill when:
+
 - Building a new payment connector middleware that integrates a PSP with the VTEX Payment Gateway
 - Implementing, debugging, or extending any of the 9 PPP endpoints
 - Preparing a connector for VTEX Payment Provider Test Suite homologation
 
 Do not use this skill for:
+
 - Idempotency and duplicate prevention logic — use [`payment-idempotency`](payment-payment-idempotency.md)
 - Async payment flows and callback URLs — use [`payment-async-flow`](payment-payment-async-flow.md)
 - PCI compliance and Secure Proxy card handling — use [`payment-pci-security`](payment-payment-pci-security.md)
@@ -2325,6 +2373,7 @@ The VTEX Payment Provider Test Suite validates every endpoint during homologatio
 If the connector router/handler file does not define handlers for all 6 payment-flow paths, STOP and add the missing endpoints before proceeding.
 
 **Correct**
+
 ```typescript
 import { Router } from "express";
 
@@ -2336,12 +2385,16 @@ router.post("/payments", createPaymentHandler);
 router.post("/payments/:paymentId/cancellations", cancelPaymentHandler);
 router.post("/payments/:paymentId/settlements", capturePaymentHandler);
 router.post("/payments/:paymentId/refunds", refundPaymentHandler);
-router.post("/payments/:paymentId/inbound-request/:action", inboundRequestHandler);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  inboundRequestHandler,
+);
 
 export default router;
 ```
 
 **Wrong**
+
 ```typescript
 import { Router } from "express";
 
@@ -2367,6 +2420,7 @@ The Gateway parses these fields programmatically. Missing fields cause deseriali
 If a response object is missing any of the required fields for its endpoint, STOP and add the missing fields.
 
 **Correct**
+
 ```typescript
 interface CreatePaymentResponse {
   paymentId: string;
@@ -2383,8 +2437,12 @@ interface CreatePaymentResponse {
   paymentUrl?: string;
 }
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId, value, currency, paymentMethod, card, callbackUrl } = req.body;
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { paymentId, value, currency, paymentMethod, card, callbackUrl } =
+    req.body;
 
   const result = await processPaymentWithAcquirer(req.body);
 
@@ -2397,9 +2455,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     acquirer: "MyAcquirer",
     code: result.code ?? null,
     message: result.message ?? null,
-    delayToAutoSettle: 21600,    // 6 hours in seconds
+    delayToAutoSettle: 21600, // 6 hours in seconds
     delayToAutoSettleAfterAntifraud: 1800, // 30 minutes in seconds
-    delayToCancel: 21600,         // 6 hours in seconds
+    delayToCancel: 21600, // 6 hours in seconds
   };
 
   res.status(200).json(response);
@@ -2407,9 +2465,13 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
 // Missing required fields — Gateway will reject this response
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const result = await processPaymentWithAcquirer(req.body);
 
   // Missing: authorizationId, nsu, tid, acquirer, code, message,
@@ -2432,6 +2494,7 @@ The Gateway reads the manifest to determine which payment methods are available.
 If the manifest handler returns an empty `paymentMethods` array or hardcodes methods the provider does not actually support, STOP and fix the manifest.
 
 **Correct**
+
 ```typescript
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
   const manifest = {
@@ -2449,6 +2512,7 @@ async function manifestHandler(_req: Request, res: Response): Promise<void> {
 ```
 
 **Wrong**
+
 ```typescript
 // Empty manifest — no payment methods will appear in the Admin
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
@@ -2591,62 +2655,74 @@ router.post("/payments", async (req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-router.post("/payments/:paymentId/cancellations", async (req: Request, res: Response) => {
-  const { paymentId } = req.params;
-  const { requestId } = req.body;
-  const result = await cancelWithAcquirer(paymentId);
+router.post(
+  "/payments/:paymentId/cancellations",
+  async (req: Request, res: Response) => {
+    const { paymentId } = req.params;
+    const { requestId } = req.body;
+    const result = await cancelWithAcquirer(paymentId);
 
-  res.status(200).json({
-    paymentId,
-    cancellationId: result.cancellationId ?? null,
-    code: result.code ?? null,
-    message: result.message ?? "Successfully cancelled",
-    requestId,
-  });
-});
+    res.status(200).json({
+      paymentId,
+      cancellationId: result.cancellationId ?? null,
+      code: result.code ?? null,
+      message: result.message ?? "Successfully cancelled",
+      requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/settlements", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await captureWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/settlements",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await captureWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    settleId: result.settleId ?? null,
-    value: result.capturedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      settleId: result.settleId ?? null,
+      value: result.capturedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/refunds", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await refundWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/refunds",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await refundWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    refundId: result.refundId ?? null,
-    value: result.refundedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      refundId: result.refundId ?? null,
+      value: result.refundedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/inbound-request/:action", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await handleInbound(body);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await handleInbound(body);
 
-  res.status(200).json({
-    requestId: body.requestId,
-    paymentId: body.paymentId,
-    responseData: {
-      statusCode: 200,
-      contentType: "application/json",
-      content: JSON.stringify(result),
-    },
-  });
-});
+    res.status(200).json({
+      requestId: body.requestId,
+      paymentId: body.paymentId,
+      responseData: {
+        statusCode: 200,
+        contentType: "application/json",
+        content: JSON.stringify(result),
+      },
+    });
+  },
+);
 
 export default router;
 ```
@@ -2659,29 +2735,40 @@ import { Router, Request, Response } from "express";
 const configRouter = Router();
 
 // 1. POST /authorization/token
-configRouter.post("/authorization/token", async (req: Request, res: Response) => {
-  const { applicationId, returnUrl } = req.body;
-  const token = await generateAuthorizationToken(applicationId, returnUrl);
-  res.status(200).json({ applicationId, token });
-});
+configRouter.post(
+  "/authorization/token",
+  async (req: Request, res: Response) => {
+    const { applicationId, returnUrl } = req.body;
+    const token = await generateAuthorizationToken(applicationId, returnUrl);
+    res.status(200).json({ applicationId, token });
+  },
+);
 
 // 2. GET /authorization/redirect
-configRouter.get("/authorization/redirect", async (req: Request, res: Response) => {
-  const { token } = req.query;
-  const providerLoginUrl = buildProviderLoginUrl(token as string);
-  res.redirect(302, providerLoginUrl);
-});
+configRouter.get(
+  "/authorization/redirect",
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
+    const providerLoginUrl = buildProviderLoginUrl(token as string);
+    res.redirect(302, providerLoginUrl);
+  },
+);
 
 // 3. GET /authorization/credentials
-configRouter.get("/authorization/credentials", async (req: Request, res: Response) => {
-  const { authorizationCode } = req.query;
-  const credentials = await exchangeCodeForCredentials(authorizationCode as string);
-  res.status(200).json({
-    applicationId: "vtex",
-    appKey: credentials.appKey,
-    appToken: credentials.appToken,
-  });
-});
+configRouter.get(
+  "/authorization/credentials",
+  async (req: Request, res: Response) => {
+    const { authorizationCode } = req.query;
+    const credentials = await exchangeCodeForCredentials(
+      authorizationCode as string,
+    );
+    res.status(200).json({
+      applicationId: "vtex",
+      appKey: credentials.appKey,
+      appToken: credentials.appToken,
+    });
+  },
+);
 
 export default configRouter;
 ```

--- a/exports/kiro/steering/payment-payment-idempotency.md
+++ b/exports/kiro/steering/payment-payment-idempotency.md
@@ -7,12 +7,14 @@ Apply when implementing idempotency logic in payment connector code or handling 
 ## When this skill applies
 
 Use this skill when:
+
 - Implementing any PPP endpoint handler that processes payments, cancellations, captures, or refunds
 - Ensuring repeated Gateway calls with the same identifiers produce identical results without re-processing
 - Building a payment state machine to prevent invalid transitions (e.g., capturing a cancelled payment)
 - Handling the Gateway's 7-day retry window for `undefined` status payments
 
 Do not use this skill for:
+
 - PPP endpoint response shapes and HTTP methods — use [`payment-provider-protocol`](payment-payment-provider-protocol.md)
 - Async callback URL notification logic — use [`payment-async-flow`](payment-payment-async-flow.md)
 - PCI compliance and Secure Proxy — use [`payment-pci-security`](payment-payment-pci-security.md)
@@ -39,8 +41,12 @@ The VTEX Gateway retries Create Payment requests with `undefined` status for up 
 If the Create Payment handler does not check for an existing `paymentId` before processing, STOP. The handler must query the data store for the `paymentId` first.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // Check for existing payment — idempotency guard
@@ -76,8 +82,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // No idempotency check — every call hits the acquirer
@@ -112,8 +122,12 @@ The Gateway uses the response fields (`authorizationId`, `tid`, `nsu`, `status`)
 If the handler creates a new database record or generates new identifiers when it finds an existing `paymentId`, STOP. The handler must return the previously stored response verbatim.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -128,8 +142,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -139,7 +157,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     const newTid = generateNewTid();
     res.status(200).json({
       ...existing.response,
-      tid: newTid,  // Different from original — breaks reconciliation
+      tid: newTid, // Different from original — breaks reconciliation
       nsu: generateNewNsu(),
     });
     return;
@@ -160,8 +178,12 @@ Returning `approved` for an async method tells the Gateway the payment is confir
 If the Create Payment handler returns `status: "approved"` or `status: "denied"` for an asynchronous payment method (Boleto, Pix, bank transfer, redirect-based), STOP. Async methods must return `"undefined"` and use callbacks.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   const isAsyncMethod = ["BankInvoice", "Pix"].includes(paymentMethod);
@@ -177,7 +199,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
     res.status(200).json({
       paymentId,
-      status: "undefined",  // Correct for async
+      status: "undefined", // Correct for async
       authorizationId: pending.authorizationId ?? null,
       nsu: pending.nsu ?? null,
       tid: pending.tid ?? null,
@@ -186,7 +208,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer payment",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: 604800, // 7 days for async
       paymentUrl: pending.paymentUrl,
     });
     return;
@@ -198,8 +220,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod } = req.body;
 
   // WRONG: Approving a Pix payment synchronously
@@ -208,7 +234,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
   res.status(200).json({
     paymentId,
-    status: "approved",  // WRONG — Pix is async, should be "undefined"
+    status: "approved", // WRONG — Pix is async, should be "undefined"
     authorizationId: result.authorizationId ?? null,
     nsu: null,
     tid: null,
@@ -229,7 +255,13 @@ Payment state store with idempotency support:
 ```typescript
 interface PaymentRecord {
   paymentId: string;
-  status: "undefined" | "approved" | "denied" | "cancelled" | "settled" | "refunded";
+  status:
+    | "undefined"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "settled"
+    | "refunded";
   response: Record<string, unknown>;
   callbackUrl?: string;
   createdAt: Date;
@@ -250,7 +282,10 @@ Idempotent Create Payment with state machine:
 ```typescript
 const store = new PaymentStore();
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Idempotency check
@@ -280,8 +315,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   };
 
   await store.save(paymentId, {
-    paymentId, status, response, callbackUrl,
-    createdAt: new Date(), updatedAt: new Date(),
+    paymentId,
+    status,
+    response,
+    callbackUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -291,7 +330,10 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 Idempotent Cancel with `requestId` guard and state validation:
 
 ```typescript
-async function cancelPaymentHandler(req: Request, res: Response): Promise<void> {
+async function cancelPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.params;
   const { requestId } = req.body;
 
@@ -326,7 +368,11 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 
   await store.updateStatus(paymentId, "cancelled");
   await store.saveOperation(requestId, {
-    requestId, paymentId, operation: "cancel", response, createdAt: new Date(),
+    requestId,
+    paymentId,
+    operation: "cancel",
+    response,
+    createdAt: new Date(),
   });
 
   res.status(200).json(response);

--- a/exports/kiro/steering/payment-payment-provider-protocol.md
+++ b/exports/kiro/steering/payment-payment-provider-protocol.md
@@ -7,11 +7,13 @@ Apply when implementing a VTEX Payment Provider Protocol (PPP) connector or work
 ## When this skill applies
 
 Use this skill when:
+
 - Building a new payment connector middleware that integrates a PSP with the VTEX Payment Gateway
 - Implementing, debugging, or extending any of the 9 PPP endpoints
 - Preparing a connector for VTEX Payment Provider Test Suite homologation
 
 Do not use this skill for:
+
 - Idempotency and duplicate prevention logic — use [`payment-idempotency`](payment-payment-idempotency.md)
 - Async payment flows and callback URLs — use [`payment-async-flow`](payment-payment-async-flow.md)
 - PCI compliance and Secure Proxy card handling — use [`payment-pci-security`](payment-payment-pci-security.md)
@@ -38,6 +40,7 @@ The VTEX Payment Provider Test Suite validates every endpoint during homologatio
 If the connector router/handler file does not define handlers for all 6 payment-flow paths, STOP and add the missing endpoints before proceeding.
 
 **Correct**
+
 ```typescript
 import { Router } from "express";
 
@@ -49,12 +52,16 @@ router.post("/payments", createPaymentHandler);
 router.post("/payments/:paymentId/cancellations", cancelPaymentHandler);
 router.post("/payments/:paymentId/settlements", capturePaymentHandler);
 router.post("/payments/:paymentId/refunds", refundPaymentHandler);
-router.post("/payments/:paymentId/inbound-request/:action", inboundRequestHandler);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  inboundRequestHandler,
+);
 
 export default router;
 ```
 
 **Wrong**
+
 ```typescript
 import { Router } from "express";
 
@@ -80,6 +87,7 @@ The Gateway parses these fields programmatically. Missing fields cause deseriali
 If a response object is missing any of the required fields for its endpoint, STOP and add the missing fields.
 
 **Correct**
+
 ```typescript
 interface CreatePaymentResponse {
   paymentId: string;
@@ -96,8 +104,12 @@ interface CreatePaymentResponse {
   paymentUrl?: string;
 }
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId, value, currency, paymentMethod, card, callbackUrl } = req.body;
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { paymentId, value, currency, paymentMethod, card, callbackUrl } =
+    req.body;
 
   const result = await processPaymentWithAcquirer(req.body);
 
@@ -110,9 +122,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     acquirer: "MyAcquirer",
     code: result.code ?? null,
     message: result.message ?? null,
-    delayToAutoSettle: 21600,    // 6 hours in seconds
+    delayToAutoSettle: 21600, // 6 hours in seconds
     delayToAutoSettleAfterAntifraud: 1800, // 30 minutes in seconds
-    delayToCancel: 21600,         // 6 hours in seconds
+    delayToCancel: 21600, // 6 hours in seconds
   };
 
   res.status(200).json(response);
@@ -120,9 +132,13 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
 // Missing required fields — Gateway will reject this response
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const result = await processPaymentWithAcquirer(req.body);
 
   // Missing: authorizationId, nsu, tid, acquirer, code, message,
@@ -145,6 +161,7 @@ The Gateway reads the manifest to determine which payment methods are available.
 If the manifest handler returns an empty `paymentMethods` array or hardcodes methods the provider does not actually support, STOP and fix the manifest.
 
 **Correct**
+
 ```typescript
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
   const manifest = {
@@ -162,6 +179,7 @@ async function manifestHandler(_req: Request, res: Response): Promise<void> {
 ```
 
 **Wrong**
+
 ```typescript
 // Empty manifest — no payment methods will appear in the Admin
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
@@ -304,62 +322,74 @@ router.post("/payments", async (req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-router.post("/payments/:paymentId/cancellations", async (req: Request, res: Response) => {
-  const { paymentId } = req.params;
-  const { requestId } = req.body;
-  const result = await cancelWithAcquirer(paymentId);
+router.post(
+  "/payments/:paymentId/cancellations",
+  async (req: Request, res: Response) => {
+    const { paymentId } = req.params;
+    const { requestId } = req.body;
+    const result = await cancelWithAcquirer(paymentId);
 
-  res.status(200).json({
-    paymentId,
-    cancellationId: result.cancellationId ?? null,
-    code: result.code ?? null,
-    message: result.message ?? "Successfully cancelled",
-    requestId,
-  });
-});
+    res.status(200).json({
+      paymentId,
+      cancellationId: result.cancellationId ?? null,
+      code: result.code ?? null,
+      message: result.message ?? "Successfully cancelled",
+      requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/settlements", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await captureWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/settlements",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await captureWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    settleId: result.settleId ?? null,
-    value: result.capturedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      settleId: result.settleId ?? null,
+      value: result.capturedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/refunds", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await refundWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/refunds",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await refundWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    refundId: result.refundId ?? null,
-    value: result.refundedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      refundId: result.refundId ?? null,
+      value: result.refundedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/inbound-request/:action", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await handleInbound(body);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await handleInbound(body);
 
-  res.status(200).json({
-    requestId: body.requestId,
-    paymentId: body.paymentId,
-    responseData: {
-      statusCode: 200,
-      contentType: "application/json",
-      content: JSON.stringify(result),
-    },
-  });
-});
+    res.status(200).json({
+      requestId: body.requestId,
+      paymentId: body.paymentId,
+      responseData: {
+        statusCode: 200,
+        contentType: "application/json",
+        content: JSON.stringify(result),
+      },
+    });
+  },
+);
 
 export default router;
 ```
@@ -372,29 +402,40 @@ import { Router, Request, Response } from "express";
 const configRouter = Router();
 
 // 1. POST /authorization/token
-configRouter.post("/authorization/token", async (req: Request, res: Response) => {
-  const { applicationId, returnUrl } = req.body;
-  const token = await generateAuthorizationToken(applicationId, returnUrl);
-  res.status(200).json({ applicationId, token });
-});
+configRouter.post(
+  "/authorization/token",
+  async (req: Request, res: Response) => {
+    const { applicationId, returnUrl } = req.body;
+    const token = await generateAuthorizationToken(applicationId, returnUrl);
+    res.status(200).json({ applicationId, token });
+  },
+);
 
 // 2. GET /authorization/redirect
-configRouter.get("/authorization/redirect", async (req: Request, res: Response) => {
-  const { token } = req.query;
-  const providerLoginUrl = buildProviderLoginUrl(token as string);
-  res.redirect(302, providerLoginUrl);
-});
+configRouter.get(
+  "/authorization/redirect",
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
+    const providerLoginUrl = buildProviderLoginUrl(token as string);
+    res.redirect(302, providerLoginUrl);
+  },
+);
 
 // 3. GET /authorization/credentials
-configRouter.get("/authorization/credentials", async (req: Request, res: Response) => {
-  const { authorizationCode } = req.query;
-  const credentials = await exchangeCodeForCredentials(authorizationCode as string);
-  res.status(200).json({
-    applicationId: "vtex",
-    appKey: credentials.appKey,
-    appToken: credentials.appToken,
-  });
-});
+configRouter.get(
+  "/authorization/credentials",
+  async (req: Request, res: Response) => {
+    const { authorizationCode } = req.query;
+    const credentials = await exchangeCodeForCredentials(
+      authorizationCode as string,
+    );
+    res.status(200).json({
+      applicationId: "vtex",
+      appKey: credentials.appKey,
+      appToken: credentials.appToken,
+    });
+  },
+);
 
 export default configRouter;
 ```

--- a/exports/opencode/payment-idempotency/SKILL.md
+++ b/exports/opencode/payment-idempotency/SKILL.md
@@ -8,12 +8,14 @@ description: "Apply when implementing idempotency logic in payment connector cod
 ## When this skill applies
 
 Use this skill when:
+
 - Implementing any PPP endpoint handler that processes payments, cancellations, captures, or refunds
 - Ensuring repeated Gateway calls with the same identifiers produce identical results without re-processing
 - Building a payment state machine to prevent invalid transitions (e.g., capturing a cancelled payment)
 - Handling the Gateway's 7-day retry window for `undefined` status payments
 
 Do not use this skill for:
+
 - PPP endpoint response shapes and HTTP methods — use [`payment-provider-protocol`](../payment-provider-protocol/SKILL.md)
 - Async callback URL notification logic — use [`payment-async-flow`](../payment-async-flow/SKILL.md)
 - PCI compliance and Secure Proxy — use [`payment-pci-security`](../payment-pci-security/SKILL.md)
@@ -40,8 +42,12 @@ The VTEX Gateway retries Create Payment requests with `undefined` status for up 
 If the Create Payment handler does not check for an existing `paymentId` before processing, STOP. The handler must query the data store for the `paymentId` first.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // Check for existing payment — idempotency guard
@@ -77,8 +83,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // No idempotency check — every call hits the acquirer
@@ -113,8 +123,12 @@ The Gateway uses the response fields (`authorizationId`, `tid`, `nsu`, `status`)
 If the handler creates a new database record or generates new identifiers when it finds an existing `paymentId`, STOP. The handler must return the previously stored response verbatim.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -129,8 +143,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -140,7 +158,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     const newTid = generateNewTid();
     res.status(200).json({
       ...existing.response,
-      tid: newTid,  // Different from original — breaks reconciliation
+      tid: newTid, // Different from original — breaks reconciliation
       nsu: generateNewNsu(),
     });
     return;
@@ -161,8 +179,12 @@ Returning `approved` for an async method tells the Gateway the payment is confir
 If the Create Payment handler returns `status: "approved"` or `status: "denied"` for an asynchronous payment method (Boleto, Pix, bank transfer, redirect-based), STOP. Async methods must return `"undefined"` and use callbacks.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   const isAsyncMethod = ["BankInvoice", "Pix"].includes(paymentMethod);
@@ -178,7 +200,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
     res.status(200).json({
       paymentId,
-      status: "undefined",  // Correct for async
+      status: "undefined", // Correct for async
       authorizationId: pending.authorizationId ?? null,
       nsu: pending.nsu ?? null,
       tid: pending.tid ?? null,
@@ -187,7 +209,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer payment",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: 604800, // 7 days for async
       paymentUrl: pending.paymentUrl,
     });
     return;
@@ -199,8 +221,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod } = req.body;
 
   // WRONG: Approving a Pix payment synchronously
@@ -209,7 +235,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
   res.status(200).json({
     paymentId,
-    status: "approved",  // WRONG — Pix is async, should be "undefined"
+    status: "approved", // WRONG — Pix is async, should be "undefined"
     authorizationId: result.authorizationId ?? null,
     nsu: null,
     tid: null,
@@ -230,7 +256,13 @@ Payment state store with idempotency support:
 ```typescript
 interface PaymentRecord {
   paymentId: string;
-  status: "undefined" | "approved" | "denied" | "cancelled" | "settled" | "refunded";
+  status:
+    | "undefined"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "settled"
+    | "refunded";
   response: Record<string, unknown>;
   callbackUrl?: string;
   createdAt: Date;
@@ -251,7 +283,10 @@ Idempotent Create Payment with state machine:
 ```typescript
 const store = new PaymentStore();
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Idempotency check
@@ -281,8 +316,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   };
 
   await store.save(paymentId, {
-    paymentId, status, response, callbackUrl,
-    createdAt: new Date(), updatedAt: new Date(),
+    paymentId,
+    status,
+    response,
+    callbackUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -292,7 +331,10 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 Idempotent Cancel with `requestId` guard and state validation:
 
 ```typescript
-async function cancelPaymentHandler(req: Request, res: Response): Promise<void> {
+async function cancelPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.params;
   const { requestId } = req.body;
 
@@ -327,7 +369,11 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 
   await store.updateStatus(paymentId, "cancelled");
   await store.saveOperation(requestId, {
-    requestId, paymentId, operation: "cancel", response, createdAt: new Date(),
+    requestId,
+    paymentId,
+    operation: "cancel",
+    response,
+    createdAt: new Date(),
   });
 
   res.status(200).json(response);

--- a/exports/opencode/payment-provider-protocol/SKILL.md
+++ b/exports/opencode/payment-provider-protocol/SKILL.md
@@ -8,11 +8,13 @@ description: "Apply when implementing a VTEX Payment Provider Protocol (PPP) con
 ## When this skill applies
 
 Use this skill when:
+
 - Building a new payment connector middleware that integrates a PSP with the VTEX Payment Gateway
 - Implementing, debugging, or extending any of the 9 PPP endpoints
 - Preparing a connector for VTEX Payment Provider Test Suite homologation
 
 Do not use this skill for:
+
 - Idempotency and duplicate prevention logic — use [`payment-idempotency`](../payment-idempotency/SKILL.md)
 - Async payment flows and callback URLs — use [`payment-async-flow`](../payment-async-flow/SKILL.md)
 - PCI compliance and Secure Proxy card handling — use [`payment-pci-security`](../payment-pci-security/SKILL.md)
@@ -39,6 +41,7 @@ The VTEX Payment Provider Test Suite validates every endpoint during homologatio
 If the connector router/handler file does not define handlers for all 6 payment-flow paths, STOP and add the missing endpoints before proceeding.
 
 **Correct**
+
 ```typescript
 import { Router } from "express";
 
@@ -50,12 +53,16 @@ router.post("/payments", createPaymentHandler);
 router.post("/payments/:paymentId/cancellations", cancelPaymentHandler);
 router.post("/payments/:paymentId/settlements", capturePaymentHandler);
 router.post("/payments/:paymentId/refunds", refundPaymentHandler);
-router.post("/payments/:paymentId/inbound-request/:action", inboundRequestHandler);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  inboundRequestHandler,
+);
 
 export default router;
 ```
 
 **Wrong**
+
 ```typescript
 import { Router } from "express";
 
@@ -81,6 +88,7 @@ The Gateway parses these fields programmatically. Missing fields cause deseriali
 If a response object is missing any of the required fields for its endpoint, STOP and add the missing fields.
 
 **Correct**
+
 ```typescript
 interface CreatePaymentResponse {
   paymentId: string;
@@ -97,8 +105,12 @@ interface CreatePaymentResponse {
   paymentUrl?: string;
 }
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId, value, currency, paymentMethod, card, callbackUrl } = req.body;
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { paymentId, value, currency, paymentMethod, card, callbackUrl } =
+    req.body;
 
   const result = await processPaymentWithAcquirer(req.body);
 
@@ -111,9 +123,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     acquirer: "MyAcquirer",
     code: result.code ?? null,
     message: result.message ?? null,
-    delayToAutoSettle: 21600,    // 6 hours in seconds
+    delayToAutoSettle: 21600, // 6 hours in seconds
     delayToAutoSettleAfterAntifraud: 1800, // 30 minutes in seconds
-    delayToCancel: 21600,         // 6 hours in seconds
+    delayToCancel: 21600, // 6 hours in seconds
   };
 
   res.status(200).json(response);
@@ -121,9 +133,13 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
 // Missing required fields — Gateway will reject this response
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const result = await processPaymentWithAcquirer(req.body);
 
   // Missing: authorizationId, nsu, tid, acquirer, code, message,
@@ -146,6 +162,7 @@ The Gateway reads the manifest to determine which payment methods are available.
 If the manifest handler returns an empty `paymentMethods` array or hardcodes methods the provider does not actually support, STOP and fix the manifest.
 
 **Correct**
+
 ```typescript
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
   const manifest = {
@@ -163,6 +180,7 @@ async function manifestHandler(_req: Request, res: Response): Promise<void> {
 ```
 
 **Wrong**
+
 ```typescript
 // Empty manifest — no payment methods will appear in the Admin
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
@@ -305,62 +323,74 @@ router.post("/payments", async (req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-router.post("/payments/:paymentId/cancellations", async (req: Request, res: Response) => {
-  const { paymentId } = req.params;
-  const { requestId } = req.body;
-  const result = await cancelWithAcquirer(paymentId);
+router.post(
+  "/payments/:paymentId/cancellations",
+  async (req: Request, res: Response) => {
+    const { paymentId } = req.params;
+    const { requestId } = req.body;
+    const result = await cancelWithAcquirer(paymentId);
 
-  res.status(200).json({
-    paymentId,
-    cancellationId: result.cancellationId ?? null,
-    code: result.code ?? null,
-    message: result.message ?? "Successfully cancelled",
-    requestId,
-  });
-});
+    res.status(200).json({
+      paymentId,
+      cancellationId: result.cancellationId ?? null,
+      code: result.code ?? null,
+      message: result.message ?? "Successfully cancelled",
+      requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/settlements", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await captureWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/settlements",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await captureWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    settleId: result.settleId ?? null,
-    value: result.capturedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      settleId: result.settleId ?? null,
+      value: result.capturedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/refunds", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await refundWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/refunds",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await refundWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    refundId: result.refundId ?? null,
-    value: result.refundedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      refundId: result.refundId ?? null,
+      value: result.refundedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/inbound-request/:action", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await handleInbound(body);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await handleInbound(body);
 
-  res.status(200).json({
-    requestId: body.requestId,
-    paymentId: body.paymentId,
-    responseData: {
-      statusCode: 200,
-      contentType: "application/json",
-      content: JSON.stringify(result),
-    },
-  });
-});
+    res.status(200).json({
+      requestId: body.requestId,
+      paymentId: body.paymentId,
+      responseData: {
+        statusCode: 200,
+        contentType: "application/json",
+        content: JSON.stringify(result),
+      },
+    });
+  },
+);
 
 export default router;
 ```
@@ -373,29 +403,40 @@ import { Router, Request, Response } from "express";
 const configRouter = Router();
 
 // 1. POST /authorization/token
-configRouter.post("/authorization/token", async (req: Request, res: Response) => {
-  const { applicationId, returnUrl } = req.body;
-  const token = await generateAuthorizationToken(applicationId, returnUrl);
-  res.status(200).json({ applicationId, token });
-});
+configRouter.post(
+  "/authorization/token",
+  async (req: Request, res: Response) => {
+    const { applicationId, returnUrl } = req.body;
+    const token = await generateAuthorizationToken(applicationId, returnUrl);
+    res.status(200).json({ applicationId, token });
+  },
+);
 
 // 2. GET /authorization/redirect
-configRouter.get("/authorization/redirect", async (req: Request, res: Response) => {
-  const { token } = req.query;
-  const providerLoginUrl = buildProviderLoginUrl(token as string);
-  res.redirect(302, providerLoginUrl);
-});
+configRouter.get(
+  "/authorization/redirect",
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
+    const providerLoginUrl = buildProviderLoginUrl(token as string);
+    res.redirect(302, providerLoginUrl);
+  },
+);
 
 // 3. GET /authorization/credentials
-configRouter.get("/authorization/credentials", async (req: Request, res: Response) => {
-  const { authorizationCode } = req.query;
-  const credentials = await exchangeCodeForCredentials(authorizationCode as string);
-  res.status(200).json({
-    applicationId: "vtex",
-    appKey: credentials.appKey,
-    appToken: credentials.appToken,
-  });
-});
+configRouter.get(
+  "/authorization/credentials",
+  async (req: Request, res: Response) => {
+    const { authorizationCode } = req.query;
+    const credentials = await exchangeCodeForCredentials(
+      authorizationCode as string,
+    );
+    res.status(200).json({
+      applicationId: "vtex",
+      appKey: credentials.appKey,
+      appToken: credentials.appToken,
+    });
+  },
+);
 
 export default configRouter;
 ```

--- a/tracks/payment/skills/payment-idempotency/skill.md
+++ b/tracks/payment/skills/payment-idempotency/skill.md
@@ -39,12 +39,14 @@ metadata:
 ## When this skill applies
 
 Use this skill when:
+
 - Implementing any PPP endpoint handler that processes payments, cancellations, captures, or refunds
 - Ensuring repeated Gateway calls with the same identifiers produce identical results without re-processing
 - Building a payment state machine to prevent invalid transitions (e.g., capturing a cancelled payment)
 - Handling the Gateway's 7-day retry window for `undefined` status payments
 
 Do not use this skill for:
+
 - PPP endpoint response shapes and HTTP methods — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Async callback URL notification logic — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -71,8 +73,12 @@ The VTEX Gateway retries Create Payment requests with `undefined` status for up 
 If the Create Payment handler does not check for an existing `paymentId` before processing, STOP. The handler must query the data store for the `paymentId` first.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // Check for existing payment — idempotency guard
@@ -108,8 +114,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   // No idempotency check — every call hits the acquirer
@@ -144,8 +154,12 @@ The Gateway uses the response fields (`authorizationId`, `tid`, `nsu`, `status`)
 If the handler creates a new database record or generates new identifiers when it finds an existing `paymentId`, STOP. The handler must return the previously stored response verbatim.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -160,8 +174,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.body;
 
   const existing = await paymentStore.findByPaymentId(paymentId);
@@ -171,7 +189,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     const newTid = generateNewTid();
     res.status(200).json({
       ...existing.response,
-      tid: newTid,  // Different from original — breaks reconciliation
+      tid: newTid, // Different from original — breaks reconciliation
       nsu: generateNewNsu(),
     });
     return;
@@ -192,8 +210,12 @@ Returning `approved` for an async method tells the Gateway the payment is confir
 If the Create Payment handler returns `status: "approved"` or `status: "denied"` for an asynchronous payment method (Boleto, Pix, bank transfer, redirect-based), STOP. Async methods must return `"undefined"` and use callbacks.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   const isAsyncMethod = ["BankInvoice", "Pix"].includes(paymentMethod);
@@ -209,7 +231,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
     res.status(200).json({
       paymentId,
-      status: "undefined",  // Correct for async
+      status: "undefined", // Correct for async
       authorizationId: pending.authorizationId ?? null,
       nsu: pending.nsu ?? null,
       tid: pending.tid ?? null,
@@ -218,7 +240,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       message: "Awaiting customer payment",
       delayToAutoSettle: 21600,
       delayToAutoSettleAfterAntifraud: 1800,
-      delayToCancel: 604800,  // 7 days for async
+      delayToCancel: 604800, // 7 days for async
       paymentUrl: pending.paymentUrl,
     });
     return;
@@ -230,8 +252,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod } = req.body;
 
   // WRONG: Approving a Pix payment synchronously
@@ -240,7 +266,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 
   res.status(200).json({
     paymentId,
-    status: "approved",  // WRONG — Pix is async, should be "undefined"
+    status: "approved", // WRONG — Pix is async, should be "undefined"
     authorizationId: result.authorizationId ?? null,
     nsu: null,
     tid: null,
@@ -261,7 +287,13 @@ Payment state store with idempotency support:
 ```typescript
 interface PaymentRecord {
   paymentId: string;
-  status: "undefined" | "approved" | "denied" | "cancelled" | "settled" | "refunded";
+  status:
+    | "undefined"
+    | "approved"
+    | "denied"
+    | "cancelled"
+    | "settled"
+    | "refunded";
   response: Record<string, unknown>;
   callbackUrl?: string;
   createdAt: Date;
@@ -282,7 +314,10 @@ Idempotent Create Payment with state machine:
 ```typescript
 const store = new PaymentStore();
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, paymentMethod, callbackUrl } = req.body;
 
   // Idempotency check
@@ -312,8 +347,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
   };
 
   await store.save(paymentId, {
-    paymentId, status, response, callbackUrl,
-    createdAt: new Date(), updatedAt: new Date(),
+    paymentId,
+    status,
+    response,
+    callbackUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   });
 
   res.status(200).json(response);
@@ -323,7 +362,10 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 Idempotent Cancel with `requestId` guard and state validation:
 
 ```typescript
-async function cancelPaymentHandler(req: Request, res: Response): Promise<void> {
+async function cancelPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId } = req.params;
   const { requestId } = req.body;
 
@@ -358,7 +400,11 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 
   await store.updateStatus(paymentId, "cancelled");
   await store.saveOperation(requestId, {
-    requestId, paymentId, operation: "cancel", response, createdAt: new Date(),
+    requestId,
+    paymentId,
+    operation: "cancel",
+    response,
+    createdAt: new Date(),
   });
 
   res.status(200).json(response);

--- a/tracks/payment/skills/payment-provider-protocol/skill.md
+++ b/tracks/payment/skills/payment-provider-protocol/skill.md
@@ -40,11 +40,13 @@ metadata:
 ## When this skill applies
 
 Use this skill when:
+
 - Building a new payment connector middleware that integrates a PSP with the VTEX Payment Gateway
 - Implementing, debugging, or extending any of the 9 PPP endpoints
 - Preparing a connector for VTEX Payment Provider Test Suite homologation
 
 Do not use this skill for:
+
 - Idempotency and duplicate prevention logic — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows and callback URLs — use [`payment-async-flow`](../payment-async-flow/skill.md)
 - PCI compliance and Secure Proxy card handling — use [`payment-pci-security`](../payment-pci-security/skill.md)
@@ -71,6 +73,7 @@ The VTEX Payment Provider Test Suite validates every endpoint during homologatio
 If the connector router/handler file does not define handlers for all 6 payment-flow paths, STOP and add the missing endpoints before proceeding.
 
 **Correct**
+
 ```typescript
 import { Router } from "express";
 
@@ -82,12 +85,16 @@ router.post("/payments", createPaymentHandler);
 router.post("/payments/:paymentId/cancellations", cancelPaymentHandler);
 router.post("/payments/:paymentId/settlements", capturePaymentHandler);
 router.post("/payments/:paymentId/refunds", refundPaymentHandler);
-router.post("/payments/:paymentId/inbound-request/:action", inboundRequestHandler);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  inboundRequestHandler,
+);
 
 export default router;
 ```
 
 **Wrong**
+
 ```typescript
 import { Router } from "express";
 
@@ -113,6 +120,7 @@ The Gateway parses these fields programmatically. Missing fields cause deseriali
 If a response object is missing any of the required fields for its endpoint, STOP and add the missing fields.
 
 **Correct**
+
 ```typescript
 interface CreatePaymentResponse {
   paymentId: string;
@@ -129,8 +137,12 @@ interface CreatePaymentResponse {
   paymentUrl?: string;
 }
 
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
-  const { paymentId, value, currency, paymentMethod, card, callbackUrl } = req.body;
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { paymentId, value, currency, paymentMethod, card, callbackUrl } =
+    req.body;
 
   const result = await processPaymentWithAcquirer(req.body);
 
@@ -143,9 +155,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     acquirer: "MyAcquirer",
     code: result.code ?? null,
     message: result.message ?? null,
-    delayToAutoSettle: 21600,    // 6 hours in seconds
+    delayToAutoSettle: 21600, // 6 hours in seconds
     delayToAutoSettleAfterAntifraud: 1800, // 30 minutes in seconds
-    delayToCancel: 21600,         // 6 hours in seconds
+    delayToCancel: 21600, // 6 hours in seconds
   };
 
   res.status(200).json(response);
@@ -153,9 +165,13 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
 // Missing required fields — Gateway will reject this response
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const result = await processPaymentWithAcquirer(req.body);
 
   // Missing: authorizationId, nsu, tid, acquirer, code, message,
@@ -178,6 +194,7 @@ The Gateway reads the manifest to determine which payment methods are available.
 If the manifest handler returns an empty `paymentMethods` array or hardcodes methods the provider does not actually support, STOP and fix the manifest.
 
 **Correct**
+
 ```typescript
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
   const manifest = {
@@ -195,6 +212,7 @@ async function manifestHandler(_req: Request, res: Response): Promise<void> {
 ```
 
 **Wrong**
+
 ```typescript
 // Empty manifest — no payment methods will appear in the Admin
 async function manifestHandler(_req: Request, res: Response): Promise<void> {
@@ -337,62 +355,74 @@ router.post("/payments", async (req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-router.post("/payments/:paymentId/cancellations", async (req: Request, res: Response) => {
-  const { paymentId } = req.params;
-  const { requestId } = req.body;
-  const result = await cancelWithAcquirer(paymentId);
+router.post(
+  "/payments/:paymentId/cancellations",
+  async (req: Request, res: Response) => {
+    const { paymentId } = req.params;
+    const { requestId } = req.body;
+    const result = await cancelWithAcquirer(paymentId);
 
-  res.status(200).json({
-    paymentId,
-    cancellationId: result.cancellationId ?? null,
-    code: result.code ?? null,
-    message: result.message ?? "Successfully cancelled",
-    requestId,
-  });
-});
+    res.status(200).json({
+      paymentId,
+      cancellationId: result.cancellationId ?? null,
+      code: result.code ?? null,
+      message: result.message ?? "Successfully cancelled",
+      requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/settlements", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await captureWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/settlements",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await captureWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    settleId: result.settleId ?? null,
-    value: result.capturedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      settleId: result.settleId ?? null,
+      value: result.capturedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/refunds", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await refundWithAcquirer(body.paymentId, body.value);
+router.post(
+  "/payments/:paymentId/refunds",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await refundWithAcquirer(body.paymentId, body.value);
 
-  res.status(200).json({
-    paymentId: body.paymentId,
-    refundId: result.refundId ?? null,
-    value: result.refundedValue ?? body.value,
-    code: result.code ?? null,
-    message: result.message ?? null,
-    requestId: body.requestId,
-  });
-});
+    res.status(200).json({
+      paymentId: body.paymentId,
+      refundId: result.refundId ?? null,
+      value: result.refundedValue ?? body.value,
+      code: result.code ?? null,
+      message: result.message ?? null,
+      requestId: body.requestId,
+    });
+  },
+);
 
-router.post("/payments/:paymentId/inbound-request/:action", async (req: Request, res: Response) => {
-  const body = req.body;
-  const result = await handleInbound(body);
+router.post(
+  "/payments/:paymentId/inbound-request/:action",
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const result = await handleInbound(body);
 
-  res.status(200).json({
-    requestId: body.requestId,
-    paymentId: body.paymentId,
-    responseData: {
-      statusCode: 200,
-      contentType: "application/json",
-      content: JSON.stringify(result),
-    },
-  });
-});
+    res.status(200).json({
+      requestId: body.requestId,
+      paymentId: body.paymentId,
+      responseData: {
+        statusCode: 200,
+        contentType: "application/json",
+        content: JSON.stringify(result),
+      },
+    });
+  },
+);
 
 export default router;
 ```
@@ -405,29 +435,40 @@ import { Router, Request, Response } from "express";
 const configRouter = Router();
 
 // 1. POST /authorization/token
-configRouter.post("/authorization/token", async (req: Request, res: Response) => {
-  const { applicationId, returnUrl } = req.body;
-  const token = await generateAuthorizationToken(applicationId, returnUrl);
-  res.status(200).json({ applicationId, token });
-});
+configRouter.post(
+  "/authorization/token",
+  async (req: Request, res: Response) => {
+    const { applicationId, returnUrl } = req.body;
+    const token = await generateAuthorizationToken(applicationId, returnUrl);
+    res.status(200).json({ applicationId, token });
+  },
+);
 
 // 2. GET /authorization/redirect
-configRouter.get("/authorization/redirect", async (req: Request, res: Response) => {
-  const { token } = req.query;
-  const providerLoginUrl = buildProviderLoginUrl(token as string);
-  res.redirect(302, providerLoginUrl);
-});
+configRouter.get(
+  "/authorization/redirect",
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
+    const providerLoginUrl = buildProviderLoginUrl(token as string);
+    res.redirect(302, providerLoginUrl);
+  },
+);
 
 // 3. GET /authorization/credentials
-configRouter.get("/authorization/credentials", async (req: Request, res: Response) => {
-  const { authorizationCode } = req.query;
-  const credentials = await exchangeCodeForCredentials(authorizationCode as string);
-  res.status(200).json({
-    applicationId: "vtex",
-    appKey: credentials.appKey,
-    appToken: credentials.appToken,
-  });
-});
+configRouter.get(
+  "/authorization/credentials",
+  async (req: Request, res: Response) => {
+    const { authorizationCode } = req.query;
+    const credentials = await exchangeCodeForCredentials(
+      authorizationCode as string,
+    );
+    res.status(200).json({
+      applicationId: "vtex",
+      appKey: credentials.appKey,
+      appToken: credentials.appToken,
+    });
+  },
+);
 
 export default configRouter;
 ```


### PR DESCRIPTION
## Summary

- **`payment-idempotency`**: Added cross-reference to `vtex-io-application-performance` for VBase write correctness (awaiting writes in critical paths), per-client timeout/retry config, and caching rules for IO-based connectors.
- **`payment-provider-protocol`**: Added cross-reference to `vtex-io-application-performance` for per-client timeout/retry tuning, VBase correctness constraints, and structured logging for IO-based payment connectors.

These cross-references help payment connector developers find the relevant IO performance guidance (e.g. always await VBase writes in financial flows, use acquirer idempotency keys).

## Test plan

- [ ] `bun run validate` passes (38 passed, 1 pre-existing warning)
- [ ] `bun run export` generates all platforms successfully
- [ ] Cross-reference companion links resolve correctly