### PR TITLE
docs: add public documentation sync checklist for PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,6 +29,8 @@ Examples of pages that commonly mirror this repository (non-exhaustive):
 
 Search `developers.vtex.com` and `help.vtex.com` for any other page that references the affected tracks, skills, install commands, or repo URL — there may be more than the examples above.
 
+> **Tip:** if you have the `vtex-docs` MCP configured (or any AI assistant with the VTEX Developer MCP), ask it to run `search_documentation` for the changed concepts and `fetch_document` on the hits — it covers both `developers.vtex.com` and `help.vtex.com` in a single pass. AI agents working on this repo are already instructed to do this automatically (see [`AGENTS.md`](../AGENTS.md#use-the-vtex-docs-mcp-for-discovery-and-diffing)).
+
 Pick one:
 
 - [ ] **No public docs change needed** — this PR only affects internal content (skill body edits, validator tweaks, refactors, CI, etc.)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,21 +20,23 @@ Before submitting, please verify:
 
 ## Public Documentation Sync
 
-VTEX Skills and the VTEX Developer MCP are documented on the public developer portal. When this PR changes user-facing behavior (new/removed skills, renamed tracks, install commands, supported platforms, CLI flags, repository URL, etc.), the public docs may need to be updated in lockstep.
+VTEX Skills, the VTEX Developer MCP, and other AI-assisted development tooling are documented across the public developer portal (`developers.vtex.com`) and help center (`help.vtex.com`). When this PR changes user-facing behavior (new/removed skills, renamed tracks, install commands, supported platforms, CLI flags, repository URL, etc.), any related public page may need to be updated in lockstep.
 
-Check the pages that mirror this repository:
+Examples of pages that commonly mirror this repository (non-exhaustive):
 
 - [VTEX Skills guide](https://developers.vtex.com/docs/guides/vtex-skills)
 - [Release notes — VTEX Developer MCP and Skills](https://developers.vtex.com/updates/release-notes/2026-04-09-vtex-developer-mcp-and-skills)
 
+Search `developers.vtex.com` and `help.vtex.com` for any other page that references the affected tracks, skills, install commands, or repo URL — there may be more than the examples above.
+
 Pick one:
 
 - [ ] **No public docs change needed** — this PR only affects internal content (skill body edits, validator tweaks, refactors, CI, etc.)
-- [ ] **Public docs update required** — describe what needs to change and link the follow-up (issue, PR in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content), or ticket) below:
+- [ ] **Public docs update required** — list every page that needs to change and link the follow-up (issue, PR in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content), or ticket) below:
 
 <!--
 Example:
-- Adds a new track `architecture` → update the "Tracks and skills" table on the VTEX Skills guide.
+- Adds a new track `architecture` → update the "Tracks and skills" table on the VTEX Skills guide and any other page that lists the tracks.
 - Follow-up: vtex/dev-portal-content#1234
 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,29 +20,18 @@ Before submitting, please verify:
 
 ## Public Documentation Sync
 
-VTEX Skills, the VTEX Developer MCP, and other AI-assisted development tooling are documented across the public developer portal (`developers.vtex.com`) and help center (`help.vtex.com`). When this PR changes user-facing behavior (new/removed skills, renamed tracks, install commands, supported platforms, CLI flags, repository URL, etc.), any related public page may need to be updated in lockstep.
+Public VTEX docs on `developers.vtex.com` and `help.vtex.com` may need to be updated when this PR ships. Pick one:
 
-Examples of pages that commonly mirror this repository (non-exhaustive):
-
-- [VTEX Skills guide](https://developers.vtex.com/docs/guides/vtex-skills)
-- [Release notes — VTEX Developer MCP and Skills](https://developers.vtex.com/updates/release-notes/2026-04-09-vtex-developer-mcp-and-skills)
-
-Search `developers.vtex.com` and `help.vtex.com` for any other page that references the affected tracks, skills, install commands, or repo URL — there may be more than the examples above.
-
-> **Tip:** if you have the `vtex-docs` MCP configured (or any AI assistant with the VTEX Developer MCP), ask it to run `search_documentation` for the changed concepts and `fetch_document` on the hits — it covers both `developers.vtex.com` and `help.vtex.com` in a single pass. AI agents working on this repo are already instructed to do this automatically (see [`AGENTS.md`](../AGENTS.md#use-the-vtex-docs-mcp-for-discovery-and-diffing)).
-
-Pick one:
-
-- [ ] **No public docs change needed** — this PR only affects internal content (skill body edits, validator tweaks, refactors, CI, etc.)
-- [ ] **Public docs update required** — list every page that needs to change and link the follow-up (issue, PR in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content), or ticket) below:
+- [ ] **No public docs change needed**
+- [ ] **Public docs update required** — list the affected pages and link the follow-up below:
 
 <!--
 Example:
-- Adds a new track `architecture` → update the "Tracks and skills" table on the VTEX Skills guide and any other page that lists the tracks.
+- developers.vtex.com/docs/guides/vtex-skills → update the "Tracks and skills" table.
 - Follow-up: vtex/dev-portal-content#1234
 -->
 
-See [Public documentation sync](../CONTRIBUTING.md#public-documentation-sync) in `CONTRIBUTING.md` for the full checklist of what triggers a docs update.
+See [Public documentation sync](../CONTRIBUTING.md#public-documentation-sync) in `CONTRIBUTING.md` for what triggers a docs update and how to find every affected page.
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,30 @@ Before submitting, please verify:
 
 ---
 
+## Public Documentation Sync
+
+VTEX Skills and the VTEX Developer MCP are documented on the public developer portal. When this PR changes user-facing behavior (new/removed skills, renamed tracks, install commands, supported platforms, CLI flags, repository URL, etc.), the public docs may need to be updated in lockstep.
+
+Check the pages that mirror this repository:
+
+- [VTEX Skills guide](https://developers.vtex.com/docs/guides/vtex-skills)
+- [Release notes — VTEX Developer MCP and Skills](https://developers.vtex.com/updates/release-notes/2026-04-09-vtex-developer-mcp-and-skills)
+
+Pick one:
+
+- [ ] **No public docs change needed** — this PR only affects internal content (skill body edits, validator tweaks, refactors, CI, etc.)
+- [ ] **Public docs update required** — describe what needs to change and link the follow-up (issue, PR in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content), or ticket) below:
+
+<!--
+Example:
+- Adds a new track `architecture` → update the "Tracks and skills" table on the VTEX Skills guide.
+- Follow-up: vtex/dev-portal-content#1234
+-->
+
+See [Public documentation sync](../CONTRIBUTING.md#public-documentation-sync) in `CONTRIBUTING.md` for the full checklist of what triggers a docs update.
+
+---
+
 ## Related Issues
 
 <!-- Link to related issues if applicable -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,23 @@ When evaluating a change, also consider: the AI-assisted development overview/in
 
 The source for the developer portal pages lives in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content). Help center articles are owned by the docs team. Whenever you finish a change in this repo, evaluate whether the public docs need a follow-up and surface it to the user.
 
+### Use the `vtex-docs` MCP for discovery and diffing
+
+If the `vtex-docs` MCP server is available in your environment (server identifier `user-vtex-docs`, tools: `search_documentation`, `fetch_document`, `search_endpoints`, `get_endpoint_details`), prefer it over guessing. It indexes both `developers.vtex.com` and `help.vtex.com` and is the most reliable way to find pages that may need updates.
+
+Recommended workflow when a change in this repo could affect public docs:
+
+1. **Discover** with `search_documentation` (locale `en` by default; also check `pt` and `es` for translated pages). Run multiple targeted queries, for example:
+   - The track or skill name that changed (e.g. `"VTEX IO MasterData skill"`, `"FastStore overrides"`).
+   - User-facing strings that appear in install snippets (e.g. `"npx skills add"`, `"vtex/skills"`, `"agents-md.tar.gz"`).
+   - Concept names from the catalog (e.g. `"VTEX Skills"`, `"VTEX Developer MCP"`, `"AI-assisted development"`).
+2. **Fetch** each promising URL with `fetch_document` and read the relevant sections. Confirm whether the page genuinely references the changed behavior, or just mentions an unrelated topic.
+3. **Diff in your head**: compare the page content against the change in this PR. Identify the exact paragraphs, table rows, code blocks, or counts that are now stale.
+4. **Report** the findings to the user as part of the "Public docs sync" note: list each affected URL, what is stale on it, and a concrete proposed edit (e.g. "the 'Tracks and skills' table on `developers.vtex.com/docs/guides/vtex-skills` lists `Custom VTEX IO Apps — 24 skills`; this PR brings the count to 25").
+5. **Recommend the follow-up venue**: developer portal pages → PR in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content); help center articles → ticket with the docs team.
+
+If the MCP is **not** available, say so explicitly in your "Public docs sync" note, fall back to the known examples listed above, and ask the user to verify on `developers.vtex.com` and `help.vtex.com`. Do not invent URLs — only cite pages you have actually retrieved or that are linked from this repository.
+
 ### Trigger checklist
 
 Suggest a public docs update when the change does any of the following:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file provides instructions for AI coding agents working on this repository.
 1. **Source files only**: Edit skill files in `tracks/{track}/skills/{name}/skill.md`. Never edit `exports/`, `skills/`, or `rules/` — they are auto-generated and will be silently overwritten the next time `bun run export` runs.
 2. **Validate before committing**: Run `bun run validate`. All hard checks must pass; soft checks produce warnings but do not block CI.
 3. **Regenerate exports**: Run `bun run export` after any skill change. Commit both source and generated files.
-4. **Flag public docs sync**: After completing the change, evaluate whether the public VTEX developer portal needs to be updated and tell the user. See [Public documentation sync](#public-documentation-sync) below.
+4. **Flag public docs sync**: After completing the change, evaluate whether public VTEX docs (developer portal + help center) need to be updated and tell the user. See [Public documentation sync](#public-documentation-sync) below.
 
 ## Skill template
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,14 @@ This file provides instructions for AI coding agents working on this repository.
 1. **Source files only**: Edit skill files in `tracks/{track}/skills/{name}/skill.md`. Never edit `exports/`, `skills/`, or `rules/` — they are auto-generated and will be silently overwritten the next time `bun run export` runs.
 2. **Validate before committing**: Run `bun run validate`. All hard checks must pass; soft checks produce warnings but do not block CI.
 3. **Regenerate exports**: Run `bun run export` after any skill change. Commit both source and generated files.
+4. **Flag public docs sync**: After completing the change, evaluate whether the public VTEX developer portal needs to be updated and tell the user. See [Public documentation sync](#public-documentation-sync) below.
 
 ## Skill template
 
 The decision-oriented template at `_templates/skill-template.md` is the recommended structure for new skills.
 
 Recommended H2 sections (in order):
+
 1. `## When this skill applies`
 2. `## Decision rules`
 3. `## Hard constraints`
@@ -31,7 +33,7 @@ Skills that use a different structure (e.g., rules-based or tutorial-style) will
 name: skill-name-kebab-case
 description: Apply when [trigger condition]. Covers [key areas]. Use for [specific task].
 metadata:
-  track: faststore  # one of: faststore, payment, vtex-io, marketplace, headless
+  track: faststore # one of: faststore, payment, vtex-io, marketplace, headless
   tags: [keyword1, keyword2]
   globs: ["src/path/**/*.ts"]
   version: "1.0"
@@ -79,12 +81,43 @@ Releases are automated via [Release Please](https://github.com/googleapis/releas
 
 **Commit prefix → version bump:**
 
-| Prefix | Bump | Example |
-|---|---|---|
-| `feat:` / `feat(scope):` | minor | new skill, new export platform |
-| `fix:` / `fix(scope):` | patch | bug fix, broken URL |
-| `refactor:` / `refactor(scope):` | patch | skill content improvement |
-| `chore:`, `docs:` | none | no release PR opened |
-| `feat!:` or `BREAKING CHANGE:` in footer | major | removed skill, renamed track |
+| Prefix                                   | Bump  | Example                        |
+| ---------------------------------------- | ----- | ------------------------------ |
+| `feat:` / `feat(scope):`                 | minor | new skill, new export platform |
+| `fix:` / `fix(scope):`                   | patch | bug fix, broken URL            |
+| `refactor:` / `refactor(scope):`         | patch | skill content improvement      |
+| `chore:`, `docs:`                        | none  | no release PR opened           |
+| `feat!:` or `BREAKING CHANGE:` in footer | major | removed skill, renamed track   |
 
 Use `refactor(track):` for skill content changes so they appear in the changelog under "Skill Improvements" without triggering a minor bump.
+
+## Public documentation sync
+
+This repository is mirrored on the official VTEX developer portal:
+
+- [VTEX Skills guide](https://developers.vtex.com/docs/guides/vtex-skills) — install commands, supported platforms, track and skill counts, behavior overview.
+- [Release notes — VTEX Developer MCP and Skills](https://developers.vtex.com/updates/release-notes/2026-04-09-vtex-developer-mcp-and-skills) — historical announcement; only correct factual errors here.
+
+The source for both pages lives in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content). Whenever you finish a change in this repo, evaluate whether the public docs need a follow-up and surface it to the user.
+
+### Trigger checklist
+
+Suggest a public docs update when the change does any of the following:
+
+- Adds, removes, or renames a track.
+- Changes the total number of skills, or the per-track skill count.
+- Adds, removes, or renames a supported export platform (AGENTS.md, Cursor, Copilot, Claude, OpenCode, Kiro, …).
+- Changes any install command, release asset name, repository URL, or directory layout that appears in install snippets.
+- Changes the description, scope, or behavior of the skill catalog itself.
+- Changes the relationship with the VTEX Developer MCP.
+
+Do **not** suggest a docs update for purely internal changes: edits to skill bodies (constraints, examples, references), validator/exporter/CI tweaks, refactors, or in-repo docs (`README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `_templates/`).
+
+### What to tell the user
+
+At the end of the task, include a short "Public docs sync" note with one of:
+
+- **No public docs change needed** — state why (e.g. "skill body edit only, no install command or counts changed").
+- **Public docs update required** — list the specific pages and sections that need to change, and suggest opening a follow-up in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content). When relevant, draft the exact wording or table cell that needs updating.
+
+Also remind the user that the PR template's **Public Documentation Sync** section needs to be filled out before merging. The full criteria are in [`CONTRIBUTING.md`](CONTRIBUTING.md#public-documentation-sync).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,12 +93,16 @@ Use `refactor(track):` for skill content changes so they appear in the changelog
 
 ## Public documentation sync
 
-This repository is mirrored on the official VTEX developer portal:
+This repository is mirrored across the official VTEX developer portal (`developers.vtex.com`) and referenced from the help center (`help.vtex.com`). The pages below are **examples**, not an exhaustive list — there are likely other pages that reference VTEX Skills, the VTEX Developer MCP, or specific tracks/skills, and you should treat all of them as in scope.
+
+Known examples:
 
 - [VTEX Skills guide](https://developers.vtex.com/docs/guides/vtex-skills) — install commands, supported platforms, track and skill counts, behavior overview.
 - [Release notes — VTEX Developer MCP and Skills](https://developers.vtex.com/updates/release-notes/2026-04-09-vtex-developer-mcp-and-skills) — historical announcement; only correct factual errors here.
 
-The source for both pages lives in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content). Whenever you finish a change in this repo, evaluate whether the public docs need a follow-up and surface it to the user.
+When evaluating a change, also consider: the AI-assisted development overview/index, track-specific guides that link into this catalog, more recent release notes, and any onboarding material that embeds install snippets. If you are uncertain whether other pages exist, say so explicitly and recommend the user search `developers.vtex.com` and `help.vtex.com` for the affected terms.
+
+The source for the developer portal pages lives in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content). Help center articles are owned by the docs team. Whenever you finish a change in this repo, evaluate whether the public docs need a follow-up and surface it to the user.
 
 ### Trigger checklist
 
@@ -118,6 +122,6 @@ Do **not** suggest a docs update for purely internal changes: edits to skill bod
 At the end of the task, include a short "Public docs sync" note with one of:
 
 - **No public docs change needed** — state why (e.g. "skill body edit only, no install command or counts changed").
-- **Public docs update required** — list the specific pages and sections that need to change, and suggest opening a follow-up in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content). When relevant, draft the exact wording or table cell that needs updating.
+- **Public docs update required** — list every page you can identify that needs to change (the known examples above plus any others you spotted), and suggest opening a follow-up in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content) or with the docs team for help-center articles. When relevant, draft the exact wording or table cell that needs updating. If you suspect there are additional pages you cannot enumerate, call that out and ask the user to verify.
 
 Also remind the user that the PR template's **Public Documentation Sync** section needs to be filled out before merging. The full criteria are in [`CONTRIBUTING.md`](CONTRIBUTING.md#public-documentation-sync).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,14 +305,23 @@ Before submitting a pull request, verify all of these:
 
 ## Public Documentation Sync
 
-This repository is mirrored on the official VTEX developer portal. When user-facing behavior changes here, the public docs must be updated so external developers see consistent information.
+This repository is mirrored on the official VTEX developer portal (`developers.vtex.com`) and referenced from the help center (`help.vtex.com`). When user-facing behavior changes here, every public page that references the affected concepts must be updated so external developers see consistent information.
 
-### Pages that mirror this repository
+### Example pages that commonly mirror this repository
+
+The list below is **not exhaustive** — treat it as a starting point. Always search `developers.vtex.com` and `help.vtex.com` for any other page that references the affected tracks, skills, install commands, supported platforms, or the repository URL.
 
 - [VTEX Skills guide](https://developers.vtex.com/docs/guides/vtex-skills) — install commands, supported platforms, track and skill counts, behavior overview
 - [Release notes — VTEX Developer MCP and Skills](https://developers.vtex.com/updates/release-notes/2026-04-09-vtex-developer-mcp-and-skills) — historical announcement; only correct factual errors here, do not rewrite history
 
-The source for these pages lives in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content). Documentation changes are landed via a PR in that repository.
+Other places to check before opening the docs follow-up:
+
+- The AI-assisted development overview / index page on `developers.vtex.com`
+- Any track-specific guide that links into this catalog (FastStore, Payment, VTEX IO, Marketplace, Headless, Architecture)
+- More recent release notes that mention VTEX Skills or the VTEX Developer MCP
+- Any internal portals or onboarding material that embed install snippets
+
+The source for the developer portal pages lives in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content). Help center articles are managed by the docs team. Documentation changes are landed via a PR or ticket in the appropriate repository.
 
 ### When a docs update is required
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,12 @@ This guide covers everything you need to add skills, tracks, and export platform
 
 The workflow is always: **edit `tracks/` → validate → export → commit both.**
 
-| Path | What it is | Editable? |
-|---|---|---|
-| `tracks/{track}/skills/{name}/skill.md` | Skill source of truth | ✅ Edit here |
-| `exports/` | All platform exports (cursor, copilot, agents-md, etc.) | ❌ Auto-generated |
-| `skills/` *(root-level)* | OpenCode exports | ❌ Auto-generated |
-| `rules/` | Cursor `.mdc` exports | ❌ Auto-generated |
+| Path                                    | What it is                                              | Editable?         |
+| --------------------------------------- | ------------------------------------------------------- | ----------------- |
+| `tracks/{track}/skills/{name}/skill.md` | Skill source of truth                                   | ✅ Edit here      |
+| `exports/`                              | All platform exports (cursor, copilot, agents-md, etc.) | ❌ Auto-generated |
+| `skills/` _(root-level)_                | OpenCode exports                                        | ❌ Auto-generated |
+| `rules/`                                | Cursor `.mdc` exports                                   | ❌ Auto-generated |
 
 > **Common trap**: There is a `skills/` directory at the repository root that looks like source
 > files. It is not — it is the auto-generated OpenCode export. Source files live under
@@ -27,6 +27,7 @@ The workflow is always: **edit `tracks/` → validate → export → commit both
 - [Adding a New Track](#adding-a-new-track)
 - [Adding a New Export Platform](#adding-a-new-export-platform)
 - [Quality Checklist](#quality-checklist)
+- [Public Documentation Sync](#public-documentation-sync)
 - [Naming Conventions](#naming-conventions)
 
 ---
@@ -100,18 +101,18 @@ See [Skill Template Reference](#skill-template-reference) for what goes in each 
 
 Every opening code fence must have a language annotation. The validator will fail on bare fences.
 
-```typescript
+````typescript
 // Good
 ```typescript
 const x = 1
-```
+````
 
-```text
+````text
 // Also good for diagrams and directory trees
 ```text
 src/
   components/
-```
+````
 
 Closing fences are always bare (just ` ``` `). Only opening fences need the annotation.
 
@@ -188,11 +189,13 @@ Cross-skill links use a relative path from the current skill's directory:
 ```
 
 Add `Related skills` when:
+
 - the skill sits near a real decision boundary, such as `graphql` vs `http-routes`
 - the user or AI would plausibly pick the wrong adjacent skill without guidance
 - another skill is a natural companion needed right after this one
 
 Skip `Related skills` when:
+
 - the links would only restate the obvious track structure
 - there is no meaningful ambiguity about when to use the skill
 - the section would become a second reference list instead of a decision aid
@@ -296,6 +299,52 @@ Before submitting a pull request, verify all of these:
 - [ ] The `metadata.vtex_docs_verified` date reflects when you last checked the docs
 - [ ] The track `index.md` includes the new skill in its table and learning order
 - [ ] The `exports/` directory is updated (run `bun run export` and commit the output)
+- [ ] [Public documentation sync](#public-documentation-sync) considered — either confirmed not needed, or a follow-up is linked in the PR
+
+---
+
+## Public Documentation Sync
+
+This repository is mirrored on the official VTEX developer portal. When user-facing behavior changes here, the public docs must be updated so external developers see consistent information.
+
+### Pages that mirror this repository
+
+- [VTEX Skills guide](https://developers.vtex.com/docs/guides/vtex-skills) — install commands, supported platforms, track and skill counts, behavior overview
+- [Release notes — VTEX Developer MCP and Skills](https://developers.vtex.com/updates/release-notes/2026-04-09-vtex-developer-mcp-and-skills) — historical announcement; only correct factual errors here, do not rewrite history
+
+The source for these pages lives in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content). Documentation changes are landed via a PR in that repository.
+
+### When a docs update is required
+
+Open a follow-up in `vtex/dev-portal-content` (or flag it in the PR description) when this PR does any of the following:
+
+- **Adds, removes, or renames a track** — update the "Tracks and skills" table and the per-track skill counts.
+- **Changes the total number of skills** — update the count in the page intro and the per-track totals.
+- **Adds or removes a supported export platform** — update both the "Installation" and "Supported platforms" sections.
+- **Changes any install command** — `npx`, `curl`, `git clone`, paths, or release asset names.
+- **Renames a release asset or changes the GitHub release layout** — every `curl -sL https://github.com/vtex/skills/releases/...` command on the public page must still work.
+- **Renames the repository or moves it under a different org** — every link to `github.com/vtex/skills` must be updated.
+- **Changes the AGENTS.md / Cursor / Copilot / Claude / OpenCode / Kiro layout** — update the corresponding "Auto-detection" row and code snippet.
+- **Changes the description, purpose, or scope of the skill catalog** — update the "Behavior" section.
+- **Changes the relationship with the VTEX Developer MCP** — update the "VTEX Skills vs. VTEX Developer MCP" section.
+
+### When a docs update is **not** required
+
+Most skill-content work does not require a public docs update:
+
+- Edits to the body of an existing `skill.md` (constraints, examples, references).
+- Validator, exporter, or CI changes that do not change the install commands or output layout.
+- Internal refactors, template changes, or documentation inside this repo (`README.md`, `AGENTS.md`, `CONTRIBUTING.md`).
+- Release-please or version bumps.
+
+### How to flag the follow-up
+
+In the PR description, fill out the "Public Documentation Sync" section of the PR template with one of:
+
+1. **Confirmation that no docs change is needed**, or
+2. **A description of what needs to change** plus a link to the follow-up issue or PR in `vtex/dev-portal-content`.
+
+If you cannot open the follow-up yourself, file an issue on `vtex/dev-portal-content` describing the change so the docs team can pick it up.
 
 ---
 
@@ -347,13 +396,13 @@ This repository uses [Release Please](https://github.com/googleapis/release-plea
 
 ### Commit conventions → version bump
 
-| Commit prefix | Version bump | When to use |
-|---|---|---|
-| `feat(scope):` | **minor** | New skill, new export platform, new validator check |
-| `fix(scope):` | patch | Bug fix, broken reference URL, wrong constraint |
-| `refactor(scope):` | patch | Skill content improvement, template conversion |
-| `chore:`, `docs:` | none | No release opened |
-| `feat!:` or `BREAKING CHANGE:` in footer | **major** | Removed skill, renamed track, changed skill name |
+| Commit prefix                            | Version bump | When to use                                         |
+| ---------------------------------------- | ------------ | --------------------------------------------------- |
+| `feat(scope):`                           | **minor**    | New skill, new export platform, new validator check |
+| `fix(scope):`                            | patch        | Bug fix, broken reference URL, wrong constraint     |
+| `refactor(scope):`                       | patch        | Skill content improvement, template conversion      |
+| `chore:`, `docs:`                        | none         | No release opened                                   |
+| `feat!:` or `BREAKING CHANGE:` in footer | **major**    | Removed skill, renamed track, changed skill name    |
 
 Use `refactor(track-name):` for skill content work (e.g. `refactor(payment): improve idempotency examples`). This creates a patch bump and shows up in the changelog under "Skill Improvements".
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,19 +99,19 @@ See [Skill Template Reference](#skill-template-reference) for what goes in each 
 
 ### Step 5: Annotate all code blocks
 
-Every opening code fence must have a language annotation. The validator will fail on bare fences.
+Every opening code fence must have a language annotation. The validator will fail on bare fences. The examples below use a 4-backtick outer fence so the inner 3-backtick fence (and its bare closing fence) are rendered literally:
 
-````typescript
-// Good
+````markdown
 ```typescript
-const x = 1
+const x = 1;
+```
 ````
 
-````text
-// Also good for diagrams and directory trees
+````markdown
 ```text
 src/
   components/
+```
 ````
 
 Closing fences are always bare (just ` ``` `). Only opening fences need the annotation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -323,6 +323,8 @@ Other places to check before opening the docs follow-up:
 
 The source for the developer portal pages lives in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content). Help center articles are managed by the docs team. Documentation changes are landed via a PR or ticket in the appropriate repository.
 
+> **Tip — use the `vtex-docs` MCP if you have it.** The [`vtex-docs` MCP server](https://developers.vtex.com/docs/guides/vtex-developer-mcp) (and the broader VTEX Developer MCP) indexes both `developers.vtex.com` and `help.vtex.com`. From any MCP-aware AI assistant you can call `search_documentation` with track names, skill names, or install snippet strings to discover every page that references the affected behavior, then `fetch_document` to read the current content and propose precise edits. AI agents working on this repo are instructed to use it automatically — see [`AGENTS.md`](AGENTS.md#use-the-vtex-docs-mcp-for-discovery-and-diffing).
+
 ### When a docs update is required
 
 Open a follow-up in `vtex/dev-portal-content` (or flag it in the PR description) when this PR does any of the following:


### PR DESCRIPTION
## Summary

- Add a **Public Documentation Sync** section to `.github/pull_request_template.md` so every PR has to confirm whether the public docs need an update.
- Add a matching **Public Documentation Sync** guide to `CONTRIBUTING.md` describing exactly which changes in this repo require a follow-up in [`vtex/dev-portal-content`](https://github.com/vtex/dev-portal-content) (and which do not).
- Update `AGENTS.md` with a new quick rule and a dedicated section instructing AI contributors to evaluate the docs-sync question at the end of every task and surface it to the user.

The two public pages this keeps in sync:
- [VTEX Skills guide](https://developers.vtex.com/docs/guides/vtex-skills)
- [Release notes — VTEX Developer MCP and Skills](https://developers.vtex.com/updates/release-notes/2026-04-09-vtex-developer-mcp-and-skills)

## Why

Today nothing prompts contributors (or AI agents) to remember that public docs on `developers.vtex.com` mirror this repository. When tracks, skill counts, install commands, supported platforms, or the repo URL change, the public page silently drifts. A lightweight checklist in the PR template + a clear guide in `CONTRIBUTING.md` + an AI-facing rule in `AGENTS.md` should catch this consistently without adding any required CI step.

## Out of scope

- No changes to `tracks/`, so no `bun run validate` / `bun run export` regeneration is needed.
- Does not automate the docs sync — the follow-up still lives in `vtex/dev-portal-content`.

## Test plan

- [ ] Open a draft PR and confirm the new "Public Documentation Sync" section renders correctly in the PR template.
- [ ] Verify the cross-link from the PR template to `CONTRIBUTING.md#public-documentation-sync` resolves.
- [ ] Verify the cross-link from `AGENTS.md` to `CONTRIBUTING.md#public-documentation-sync` resolves.