### PR TITLE
fix(headless,payment): require card data to go directly to vtexpayments.com.br

### DIFF
--- a/exports/agents-md/headless/AGENTS.md
+++ b/exports/agents-md/headless/AGENTS.md
@@ -1154,48 +1154,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](../headless-bff-architecture/skill.md))
 - Search API integration (use [`headless-intelligent-search`](../headless-intelligent-search/skill.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](../headless-caching-strategy/skill.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](../../../payment/skills/payment-pci-security/skill.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -1215,7 +1223,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -1225,10 +1237,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -1288,7 +1411,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -1304,7 +1429,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -1312,7 +1437,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -1367,7 +1492,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -1457,7 +1583,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -1472,7 +1598,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -1490,7 +1618,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -1551,14 +1679,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -1579,22 +1716,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1602,7 +1737,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -1612,78 +1746,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -1711,59 +1859,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 

--- a/exports/agents-md/headless/AGENTS.md
+++ b/exports/agents-md/headless/AGENTS.md
@@ -286,6 +286,14 @@ app.use(
 );
 app.use(
   session({
+    // Production BFFs are typically multi-replica. Configure a shared session
+    // store (e.g. connect-redis, connect-memcached, a Postgres-backed store)
+    // here — the default MemoryStore is per-pod and silently drops values such
+    // as orderFormId and vtexAuthToken when requests are routed to a different
+    // replica. For ephemeral cross-step values that the browser already sees
+    // (e.g. orderGroup between Step 1 and Step 3 of order placement), prefer
+    // passing them through the request body instead of writing them to the
+    // session — see headless-checkout-proxy.
     secret: process.env.SESSION_SECRET!,
     resave: false,
     saveUninitialized: false,
@@ -1168,6 +1176,7 @@ Do not use this skill for:
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
 - Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
+- Pass intermediate flow values such as `orderGroup` between Step 1 (`/place`) and Step 3 (`/process`) **through the request body**, not through `req.session`. Production BFFs are typically multi-replica; `express-session`'s default `MemoryStore` (and any per-pod cache) loses the value when the two requests land on different pods, returning a misleading "no pending order to process" 400. If a shared session store (Redis, Memcached, database) is already required for `orderFormId`/`vtexCookies`, see the Hard constraint below for why the cross-step handoff still belongs in the request body — it stays correct under partial outages, sticky-routing failures, and replay/refresh after a tab reload.
 
 OrderForm attachment endpoints:
 
@@ -1441,6 +1450,104 @@ async function getCart(): Promise<OrderForm> {
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Multi-step order flow handoffs MUST travel in the request body, not in `req.session`
+
+Values that link `/place` (Step 1) and `/process` (Step 3) — most importantly `orderGroup`, but also any per-attempt `transactionId` or merchant context the frontend needs to echo back — MUST be returned by `/place` to the browser and sent back by the browser in the `/process` request body. The handler MUST NOT rely on `req.session.pendingOrderGroup` (or any per-pod cache) as the only source of truth for the in-flight order.
+
+**Why this matters**
+
+Production BFFs run multiple replicas (Kubernetes deployments, ECS services, lambdas behind an ALB, edge runtimes). `express-session` defaults to `MemoryStore`, which is per-pod, so a session value written on one pod is invisible to every other pod. Even with a shared session store (Redis, DynamoDB, Memcached), Step 1 and Step 3 fire as fast as the user can roundtrip through `vtexpayments.com.br`, so any partial Redis outage, write replication lag, sticky-routing failure, tab refresh, or session regeneration on login surfaces as `400 — no pending order to process`. From the shopper's point of view the order is paid (their card was charged in Step 2) but the storefront reports failure, and support has to reconcile by hand. The 5-minute order processing window leaves no time for retries.
+
+`orderGroup` is not a secret. It already returns to the browser from Step 1 and is required by the direct browser → `vtexpayments.com.br` call in Step 2. Echoing it back in Step 3 is strictly less surface area than session-backed state. Authentication and ownership are still enforced server-side through the session-bound `vtexCookies`, `orderFormId`, and (when present) `vtexAuthToken` — the BFF never trusts `orderGroup` alone.
+
+**Detection**
+
+If you find any of the following in BFF / server-side checkout code, STOP immediately:
+
+- Any read or write of `req.session.pendingOrderGroup`, `req.session.orderGroup`, `req.session.lastTransactionId`, or similar per-flow values written in `/place` and read in `/process`.
+- A `/process` (or `/gatewayCallback`) handler whose only source of `orderGroup` is `req.session`, with no `req.body.orderGroup` fallback or validation.
+- A frontend `placeOrder` flow that calls `/api/bff/order/process` with no body and no `orderGroup`, relying on the BFF to "remember" the order.
+- Comments like "// rely on session to recover orderGroup" or commits that move `orderGroup` from request bodies into the session for "tidiness".
+
+**Correct**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  const orderFormId = req.session.orderFormId;
+  if (!orderFormId) return res.status(400).json({ error: "No active cart" });
+
+  const { data } = await vtexCheckout<PlaceOrderResponse>({
+    path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
+    method: "POST",
+    body: { referenceId: orderFormId },
+    cookies: req.session.vtexCookies || {},
+    userToken: req.session.vtexAuthToken,
+  });
+
+  res.json({
+    account: process.env.VTEX_ACCOUNT,
+    orderId: data.orders[0].orderId,
+    orderGroup: data.orderGroup,
+    transactionId: data.orders[0].transactionData.merchantTransactions[0].transactionId,
+    merchantName: data.orders[0].transactionData.merchantTransactions[0].merchantName,
+  });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.orderFormId;
+  delete req.session.vtexCookies;
+  res.json({ orderGroup, status: "processed" });
+});
+```
+
+The matching browser flow — `/place` returns `orderGroup` and the browser echoes it back in the `/process` body — is shown in the Preferred pattern below.
+
+**Wrong**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  // ... call /transaction ...
+  req.session.pendingOrderGroup = orderGroup;
+  res.json({ account, orderId, orderGroup, transactionId, merchantName });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  // BUG: works in dev with one Node process and MemoryStore, returns
+  // `400 — no pending order to process` the moment the load balancer routes
+  // /place and /process to different replicas.
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.pendingOrderGroup;
+  res.json({ status: "processed" });
+});
 ```
 
 ---
@@ -1729,7 +1836,11 @@ export const orderRoutes = Router();
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
 
 // POST /api/bff/order/place — Step 1: place order from existing cart.
-// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
+// Returns the data the browser needs to call vtexpayments.com.br directly in
+// Step 2 AND to call /api/bff/order/process in Step 3. The browser is the
+// authority for `orderGroup` between Step 1 and Step 3 — the BFF does NOT
+// stash it in `req.session`, because that would silently break in any
+// multi-replica deployment whose session store is in-memory or sticky-routed.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1758,8 +1869,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     const transactionId = merchantTransaction?.transactionId;
     const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    req.session.pendingOrderGroup = orderGroup;
-
     res.json({
       account: VTEX_ACCOUNT,
       orderId,
@@ -1775,11 +1884,18 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
 
 // POST /api/bff/order/process — Step 3: process gateway callback after the
 // browser has submitted payment data directly to vtexpayments.com.br in Step 2.
-// Carries no card data; safe to run server-side.
+// Carries no card data; safe to run server-side. The browser passes back the
+// same `orderGroup` it received from /place so the handler is stateless across
+// replicas. The BFF still validates ownership through the session-bound
+// orderFormId + checkout cookies before calling VTEX.
 orderRoutes.post("/process", async (req: Request, res: Response) => {
-  const orderGroup = req.session.pendingOrderGroup;
-  if (!orderGroup) {
-    return res.status(400).json({ error: "No pending order to process" });
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
   }
 
   try {
@@ -1791,7 +1907,6 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 
     delete req.session.orderFormId;
     delete req.session.vtexCookies;
-    delete req.session.pendingOrderGroup;
 
     res.json({ orderGroup, status: "processed" });
   } catch (error) {
@@ -1804,6 +1919,8 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 ```typescript
 // frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
 // Card fields stay on the device; the BFF never sees them.
+// Step 3 echoes `orderGroup` back to the BFF in the request body so it works
+// the same way whether the BFF runs on one pod or fifty.
 async function placeOrderWithCard(card: CardPaymentInformation) {
   const placeResp = await fetch("/api/bff/order/place", {
     method: "POST",
@@ -1830,6 +1947,8 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
   await fetch("/api/bff/order/process", {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orderGroup }),
   });
 }
 ```
@@ -1876,11 +1995,16 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
       card,
     });
 
-    await fetchJson("/api/bff/order/process", { method: "POST" });
+    await fetchJson("/api/bff/order/process", {
+      method: "POST",
+      body: { orderGroup },
+    });
   }
   ```
 
 - **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
+
+- **Storing `orderGroup` in `req.session` between `/place` and `/process`**: Writing `req.session.pendingOrderGroup` in Step 1 and reading it in Step 3 looks tidy and works in single-process local development. With `express-session`'s default `MemoryStore` (and any per-pod cache) a horizontally scaled BFF loses the value the moment the two requests land on different replicas, so `/process` returns `400 — no pending order to process` while the shopper's card has already been charged in Step 2. Return `orderGroup` from `/place` to the browser and require the browser to send it back in the `/process` body — see the dedicated hard constraint above. Even with a shared session store (Redis, Memcached, database) in place for `orderFormId`/`vtexCookies`, the cross-step handoff still belongs in the request body so the flow stays correct under partial outages, sticky-routing failures, replication lag, and tab refresh.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
@@ -1926,6 +2050,7 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
 - [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
+- [ ] Is `orderGroup` returned by `/place` and sent back by the browser in the `/process` request body, instead of being stashed in `req.session.pendingOrderGroup` between the two BFF calls?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
 ## Reference

--- a/exports/agents-md/payment/AGENTS.md
+++ b/exports/agents-md/payment/AGENTS.md
@@ -1093,12 +1093,14 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](../payment-async-flow/skill.md)
@@ -1126,8 +1128,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -1143,9 +1149,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -1159,8 +1165,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -1169,7 +1179,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -1212,7 +1222,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -1221,9 +1231,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -1238,6 +1252,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -1249,16 +1365,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -1272,15 +1392,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -1301,8 +1425,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -1310,15 +1438,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -1334,8 +1464,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -1380,18 +1514,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -1426,12 +1560,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -1444,21 +1578,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });

--- a/exports/claude/headless-headless-bff-architecture.md
+++ b/exports/claude/headless-headless-bff-architecture.md
@@ -279,6 +279,14 @@ app.use(
 );
 app.use(
   session({
+    // Production BFFs are typically multi-replica. Configure a shared session
+    // store (e.g. connect-redis, connect-memcached, a Postgres-backed store)
+    // here — the default MemoryStore is per-pod and silently drops values such
+    // as orderFormId and vtexAuthToken when requests are routed to a different
+    // replica. For ephemeral cross-step values that the browser already sees
+    // (e.g. orderGroup between Step 1 and Step 3 of order placement), prefer
+    // passing them through the request body instead of writing them to the
+    // session — see headless-checkout-proxy.
     secret: process.env.SESSION_SECRET!,
     resave: false,
     saveUninitialized: false,

--- a/exports/claude/headless-headless-checkout-proxy.md
+++ b/exports/claude/headless-headless-checkout-proxy.md
@@ -12,48 +12,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](../headless-bff-architecture/skill.md))
 - Search API integration (use [`headless-intelligent-search`](../headless-intelligent-search/skill.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](../headless-caching-strategy/skill.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](../../../payment/skills/payment-pci-security/skill.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -73,7 +81,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -83,10 +95,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -146,7 +269,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -162,7 +287,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -170,7 +295,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -225,7 +350,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -315,7 +441,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -330,7 +456,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -348,7 +476,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -409,14 +537,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -437,22 +574,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -460,7 +595,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -470,78 +604,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -569,59 +717,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 

--- a/exports/claude/headless-headless-checkout-proxy.md
+++ b/exports/claude/headless-headless-checkout-proxy.md
@@ -26,6 +26,7 @@ Do not use this skill for:
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
 - Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
+- Pass intermediate flow values such as `orderGroup` between Step 1 (`/place`) and Step 3 (`/process`) **through the request body**, not through `req.session`. Production BFFs are typically multi-replica; `express-session`'s default `MemoryStore` (and any per-pod cache) loses the value when the two requests land on different pods, returning a misleading "no pending order to process" 400. If a shared session store (Redis, Memcached, database) is already required for `orderFormId`/`vtexCookies`, see the Hard constraint below for why the cross-step handoff still belongs in the request body — it stays correct under partial outages, sticky-routing failures, and replay/refresh after a tab reload.
 
 OrderForm attachment endpoints:
 
@@ -299,6 +300,104 @@ async function getCart(): Promise<OrderForm> {
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Multi-step order flow handoffs MUST travel in the request body, not in `req.session`
+
+Values that link `/place` (Step 1) and `/process` (Step 3) — most importantly `orderGroup`, but also any per-attempt `transactionId` or merchant context the frontend needs to echo back — MUST be returned by `/place` to the browser and sent back by the browser in the `/process` request body. The handler MUST NOT rely on `req.session.pendingOrderGroup` (or any per-pod cache) as the only source of truth for the in-flight order.
+
+**Why this matters**
+
+Production BFFs run multiple replicas (Kubernetes deployments, ECS services, lambdas behind an ALB, edge runtimes). `express-session` defaults to `MemoryStore`, which is per-pod, so a session value written on one pod is invisible to every other pod. Even with a shared session store (Redis, DynamoDB, Memcached), Step 1 and Step 3 fire as fast as the user can roundtrip through `vtexpayments.com.br`, so any partial Redis outage, write replication lag, sticky-routing failure, tab refresh, or session regeneration on login surfaces as `400 — no pending order to process`. From the shopper's point of view the order is paid (their card was charged in Step 2) but the storefront reports failure, and support has to reconcile by hand. The 5-minute order processing window leaves no time for retries.
+
+`orderGroup` is not a secret. It already returns to the browser from Step 1 and is required by the direct browser → `vtexpayments.com.br` call in Step 2. Echoing it back in Step 3 is strictly less surface area than session-backed state. Authentication and ownership are still enforced server-side through the session-bound `vtexCookies`, `orderFormId`, and (when present) `vtexAuthToken` — the BFF never trusts `orderGroup` alone.
+
+**Detection**
+
+If you find any of the following in BFF / server-side checkout code, STOP immediately:
+
+- Any read or write of `req.session.pendingOrderGroup`, `req.session.orderGroup`, `req.session.lastTransactionId`, or similar per-flow values written in `/place` and read in `/process`.
+- A `/process` (or `/gatewayCallback`) handler whose only source of `orderGroup` is `req.session`, with no `req.body.orderGroup` fallback or validation.
+- A frontend `placeOrder` flow that calls `/api/bff/order/process` with no body and no `orderGroup`, relying on the BFF to "remember" the order.
+- Comments like "// rely on session to recover orderGroup" or commits that move `orderGroup` from request bodies into the session for "tidiness".
+
+**Correct**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  const orderFormId = req.session.orderFormId;
+  if (!orderFormId) return res.status(400).json({ error: "No active cart" });
+
+  const { data } = await vtexCheckout<PlaceOrderResponse>({
+    path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
+    method: "POST",
+    body: { referenceId: orderFormId },
+    cookies: req.session.vtexCookies || {},
+    userToken: req.session.vtexAuthToken,
+  });
+
+  res.json({
+    account: process.env.VTEX_ACCOUNT,
+    orderId: data.orders[0].orderId,
+    orderGroup: data.orderGroup,
+    transactionId: data.orders[0].transactionData.merchantTransactions[0].transactionId,
+    merchantName: data.orders[0].transactionData.merchantTransactions[0].merchantName,
+  });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.orderFormId;
+  delete req.session.vtexCookies;
+  res.json({ orderGroup, status: "processed" });
+});
+```
+
+The matching browser flow — `/place` returns `orderGroup` and the browser echoes it back in the `/process` body — is shown in the Preferred pattern below.
+
+**Wrong**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  // ... call /transaction ...
+  req.session.pendingOrderGroup = orderGroup;
+  res.json({ account, orderId, orderGroup, transactionId, merchantName });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  // BUG: works in dev with one Node process and MemoryStore, returns
+  // `400 — no pending order to process` the moment the load balancer routes
+  // /place and /process to different replicas.
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.pendingOrderGroup;
+  res.json({ status: "processed" });
+});
 ```
 
 ---
@@ -587,7 +686,11 @@ export const orderRoutes = Router();
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
 
 // POST /api/bff/order/place — Step 1: place order from existing cart.
-// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
+// Returns the data the browser needs to call vtexpayments.com.br directly in
+// Step 2 AND to call /api/bff/order/process in Step 3. The browser is the
+// authority for `orderGroup` between Step 1 and Step 3 — the BFF does NOT
+// stash it in `req.session`, because that would silently break in any
+// multi-replica deployment whose session store is in-memory or sticky-routed.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -616,8 +719,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     const transactionId = merchantTransaction?.transactionId;
     const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    req.session.pendingOrderGroup = orderGroup;
-
     res.json({
       account: VTEX_ACCOUNT,
       orderId,
@@ -633,11 +734,18 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
 
 // POST /api/bff/order/process — Step 3: process gateway callback after the
 // browser has submitted payment data directly to vtexpayments.com.br in Step 2.
-// Carries no card data; safe to run server-side.
+// Carries no card data; safe to run server-side. The browser passes back the
+// same `orderGroup` it received from /place so the handler is stateless across
+// replicas. The BFF still validates ownership through the session-bound
+// orderFormId + checkout cookies before calling VTEX.
 orderRoutes.post("/process", async (req: Request, res: Response) => {
-  const orderGroup = req.session.pendingOrderGroup;
-  if (!orderGroup) {
-    return res.status(400).json({ error: "No pending order to process" });
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
   }
 
   try {
@@ -649,7 +757,6 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 
     delete req.session.orderFormId;
     delete req.session.vtexCookies;
-    delete req.session.pendingOrderGroup;
 
     res.json({ orderGroup, status: "processed" });
   } catch (error) {
@@ -662,6 +769,8 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 ```typescript
 // frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
 // Card fields stay on the device; the BFF never sees them.
+// Step 3 echoes `orderGroup` back to the BFF in the request body so it works
+// the same way whether the BFF runs on one pod or fifty.
 async function placeOrderWithCard(card: CardPaymentInformation) {
   const placeResp = await fetch("/api/bff/order/place", {
     method: "POST",
@@ -688,6 +797,8 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
   await fetch("/api/bff/order/process", {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orderGroup }),
   });
 }
 ```
@@ -734,11 +845,16 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
       card,
     });
 
-    await fetchJson("/api/bff/order/process", { method: "POST" });
+    await fetchJson("/api/bff/order/process", {
+      method: "POST",
+      body: { orderGroup },
+    });
   }
   ```
 
 - **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
+
+- **Storing `orderGroup` in `req.session` between `/place` and `/process`**: Writing `req.session.pendingOrderGroup` in Step 1 and reading it in Step 3 looks tidy and works in single-process local development. With `express-session`'s default `MemoryStore` (and any per-pod cache) a horizontally scaled BFF loses the value the moment the two requests land on different replicas, so `/process` returns `400 — no pending order to process` while the shopper's card has already been charged in Step 2. Return `orderGroup` from `/place` to the browser and require the browser to send it back in the `/process` body — see the dedicated hard constraint above. Even with a shared session store (Redis, Memcached, database) in place for `orderFormId`/`vtexCookies`, the cross-step handoff still belongs in the request body so the flow stays correct under partial outages, sticky-routing failures, replication lag, and tab refresh.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
@@ -784,6 +900,7 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
 - [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
+- [ ] Is `orderGroup` returned by `/place` and sent back by the browser in the `/process` request body, instead of being stashed in `req.session.pendingOrderGroup` between the two BFF calls?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
 ## Reference

--- a/exports/claude/headless.md
+++ b/exports/claude/headless.md
@@ -1143,48 +1143,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](../headless-bff-architecture/skill.md))
 - Search API integration (use [`headless-intelligent-search`](../headless-intelligent-search/skill.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](../headless-caching-strategy/skill.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](../../../payment/skills/payment-pci-security/skill.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -1204,7 +1212,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -1214,10 +1226,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -1277,7 +1400,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -1293,7 +1418,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -1301,7 +1426,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -1356,7 +1481,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -1446,7 +1572,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -1461,7 +1587,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -1479,7 +1607,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -1540,14 +1668,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -1568,22 +1705,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1591,7 +1726,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -1601,78 +1735,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -1700,59 +1848,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 

--- a/exports/claude/headless.md
+++ b/exports/claude/headless.md
@@ -279,6 +279,14 @@ app.use(
 );
 app.use(
   session({
+    // Production BFFs are typically multi-replica. Configure a shared session
+    // store (e.g. connect-redis, connect-memcached, a Postgres-backed store)
+    // here — the default MemoryStore is per-pod and silently drops values such
+    // as orderFormId and vtexAuthToken when requests are routed to a different
+    // replica. For ephemeral cross-step values that the browser already sees
+    // (e.g. orderGroup between Step 1 and Step 3 of order placement), prefer
+    // passing them through the request body instead of writing them to the
+    // session — see headless-checkout-proxy.
     secret: process.env.SESSION_SECRET!,
     resave: false,
     saveUninitialized: false,
@@ -1157,6 +1165,7 @@ Do not use this skill for:
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
 - Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
+- Pass intermediate flow values such as `orderGroup` between Step 1 (`/place`) and Step 3 (`/process`) **through the request body**, not through `req.session`. Production BFFs are typically multi-replica; `express-session`'s default `MemoryStore` (and any per-pod cache) loses the value when the two requests land on different pods, returning a misleading "no pending order to process" 400. If a shared session store (Redis, Memcached, database) is already required for `orderFormId`/`vtexCookies`, see the Hard constraint below for why the cross-step handoff still belongs in the request body — it stays correct under partial outages, sticky-routing failures, and replay/refresh after a tab reload.
 
 OrderForm attachment endpoints:
 
@@ -1430,6 +1439,104 @@ async function getCart(): Promise<OrderForm> {
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Multi-step order flow handoffs MUST travel in the request body, not in `req.session`
+
+Values that link `/place` (Step 1) and `/process` (Step 3) — most importantly `orderGroup`, but also any per-attempt `transactionId` or merchant context the frontend needs to echo back — MUST be returned by `/place` to the browser and sent back by the browser in the `/process` request body. The handler MUST NOT rely on `req.session.pendingOrderGroup` (or any per-pod cache) as the only source of truth for the in-flight order.
+
+**Why this matters**
+
+Production BFFs run multiple replicas (Kubernetes deployments, ECS services, lambdas behind an ALB, edge runtimes). `express-session` defaults to `MemoryStore`, which is per-pod, so a session value written on one pod is invisible to every other pod. Even with a shared session store (Redis, DynamoDB, Memcached), Step 1 and Step 3 fire as fast as the user can roundtrip through `vtexpayments.com.br`, so any partial Redis outage, write replication lag, sticky-routing failure, tab refresh, or session regeneration on login surfaces as `400 — no pending order to process`. From the shopper's point of view the order is paid (their card was charged in Step 2) but the storefront reports failure, and support has to reconcile by hand. The 5-minute order processing window leaves no time for retries.
+
+`orderGroup` is not a secret. It already returns to the browser from Step 1 and is required by the direct browser → `vtexpayments.com.br` call in Step 2. Echoing it back in Step 3 is strictly less surface area than session-backed state. Authentication and ownership are still enforced server-side through the session-bound `vtexCookies`, `orderFormId`, and (when present) `vtexAuthToken` — the BFF never trusts `orderGroup` alone.
+
+**Detection**
+
+If you find any of the following in BFF / server-side checkout code, STOP immediately:
+
+- Any read or write of `req.session.pendingOrderGroup`, `req.session.orderGroup`, `req.session.lastTransactionId`, or similar per-flow values written in `/place` and read in `/process`.
+- A `/process` (or `/gatewayCallback`) handler whose only source of `orderGroup` is `req.session`, with no `req.body.orderGroup` fallback or validation.
+- A frontend `placeOrder` flow that calls `/api/bff/order/process` with no body and no `orderGroup`, relying on the BFF to "remember" the order.
+- Comments like "// rely on session to recover orderGroup" or commits that move `orderGroup` from request bodies into the session for "tidiness".
+
+**Correct**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  const orderFormId = req.session.orderFormId;
+  if (!orderFormId) return res.status(400).json({ error: "No active cart" });
+
+  const { data } = await vtexCheckout<PlaceOrderResponse>({
+    path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
+    method: "POST",
+    body: { referenceId: orderFormId },
+    cookies: req.session.vtexCookies || {},
+    userToken: req.session.vtexAuthToken,
+  });
+
+  res.json({
+    account: process.env.VTEX_ACCOUNT,
+    orderId: data.orders[0].orderId,
+    orderGroup: data.orderGroup,
+    transactionId: data.orders[0].transactionData.merchantTransactions[0].transactionId,
+    merchantName: data.orders[0].transactionData.merchantTransactions[0].merchantName,
+  });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.orderFormId;
+  delete req.session.vtexCookies;
+  res.json({ orderGroup, status: "processed" });
+});
+```
+
+The matching browser flow — `/place` returns `orderGroup` and the browser echoes it back in the `/process` body — is shown in the Preferred pattern below.
+
+**Wrong**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  // ... call /transaction ...
+  req.session.pendingOrderGroup = orderGroup;
+  res.json({ account, orderId, orderGroup, transactionId, merchantName });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  // BUG: works in dev with one Node process and MemoryStore, returns
+  // `400 — no pending order to process` the moment the load balancer routes
+  // /place and /process to different replicas.
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.pendingOrderGroup;
+  res.json({ status: "processed" });
+});
 ```
 
 ---
@@ -1718,7 +1825,11 @@ export const orderRoutes = Router();
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
 
 // POST /api/bff/order/place — Step 1: place order from existing cart.
-// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
+// Returns the data the browser needs to call vtexpayments.com.br directly in
+// Step 2 AND to call /api/bff/order/process in Step 3. The browser is the
+// authority for `orderGroup` between Step 1 and Step 3 — the BFF does NOT
+// stash it in `req.session`, because that would silently break in any
+// multi-replica deployment whose session store is in-memory or sticky-routed.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1747,8 +1858,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     const transactionId = merchantTransaction?.transactionId;
     const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    req.session.pendingOrderGroup = orderGroup;
-
     res.json({
       account: VTEX_ACCOUNT,
       orderId,
@@ -1764,11 +1873,18 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
 
 // POST /api/bff/order/process — Step 3: process gateway callback after the
 // browser has submitted payment data directly to vtexpayments.com.br in Step 2.
-// Carries no card data; safe to run server-side.
+// Carries no card data; safe to run server-side. The browser passes back the
+// same `orderGroup` it received from /place so the handler is stateless across
+// replicas. The BFF still validates ownership through the session-bound
+// orderFormId + checkout cookies before calling VTEX.
 orderRoutes.post("/process", async (req: Request, res: Response) => {
-  const orderGroup = req.session.pendingOrderGroup;
-  if (!orderGroup) {
-    return res.status(400).json({ error: "No pending order to process" });
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
   }
 
   try {
@@ -1780,7 +1896,6 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 
     delete req.session.orderFormId;
     delete req.session.vtexCookies;
-    delete req.session.pendingOrderGroup;
 
     res.json({ orderGroup, status: "processed" });
   } catch (error) {
@@ -1793,6 +1908,8 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 ```typescript
 // frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
 // Card fields stay on the device; the BFF never sees them.
+// Step 3 echoes `orderGroup` back to the BFF in the request body so it works
+// the same way whether the BFF runs on one pod or fifty.
 async function placeOrderWithCard(card: CardPaymentInformation) {
   const placeResp = await fetch("/api/bff/order/place", {
     method: "POST",
@@ -1819,6 +1936,8 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
   await fetch("/api/bff/order/process", {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orderGroup }),
   });
 }
 ```
@@ -1865,11 +1984,16 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
       card,
     });
 
-    await fetchJson("/api/bff/order/process", { method: "POST" });
+    await fetchJson("/api/bff/order/process", {
+      method: "POST",
+      body: { orderGroup },
+    });
   }
   ```
 
 - **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
+
+- **Storing `orderGroup` in `req.session` between `/place` and `/process`**: Writing `req.session.pendingOrderGroup` in Step 1 and reading it in Step 3 looks tidy and works in single-process local development. With `express-session`'s default `MemoryStore` (and any per-pod cache) a horizontally scaled BFF loses the value the moment the two requests land on different replicas, so `/process` returns `400 — no pending order to process` while the shopper's card has already been charged in Step 2. Return `orderGroup` from `/place` to the browser and require the browser to send it back in the `/process` body — see the dedicated hard constraint above. Even with a shared session store (Redis, Memcached, database) in place for `orderFormId`/`vtexCookies`, the cross-step handoff still belongs in the request body so the flow stays correct under partial outages, sticky-routing failures, replication lag, and tab refresh.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
@@ -1915,6 +2039,7 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
 - [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
+- [ ] Is `orderGroup` returned by `/place` and sent back by the browser in the `/process` request body, instead of being stashed in `req.session.pendingOrderGroup` between the two BFF calls?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
 ## Reference

--- a/exports/claude/payment-payment-pci-security.md
+++ b/exports/claude/payment-payment-pci-security.md
@@ -5,12 +5,14 @@ This skill provides guidance for AI agents working with VTEX Payment Connector D
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](../payment-async-flow/skill.md)
@@ -38,8 +40,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -55,9 +61,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -71,8 +77,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -81,7 +91,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -124,7 +134,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -133,9 +143,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -150,6 +164,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -161,16 +277,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -184,15 +304,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -213,8 +337,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -222,15 +350,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -246,8 +376,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -292,18 +426,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -338,12 +472,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -356,21 +490,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });

--- a/exports/claude/payment.md
+++ b/exports/claude/payment.md
@@ -1082,12 +1082,14 @@ This skill provides guidance for AI agents working with VTEX Payment Connector D
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](../payment-async-flow/skill.md)
@@ -1115,8 +1117,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -1132,9 +1138,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -1148,8 +1154,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -1158,7 +1168,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -1201,7 +1211,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -1210,9 +1220,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -1227,6 +1241,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -1238,16 +1354,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -1261,15 +1381,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -1290,8 +1414,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -1299,15 +1427,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -1323,8 +1453,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -1369,18 +1503,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -1415,12 +1549,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -1433,21 +1567,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -1517,48 +1517,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](../headless-bff-architecture/skill.md))
 - Search API integration (use [`headless-intelligent-search`](../headless-intelligent-search/skill.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](../headless-caching-strategy/skill.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](../../../payment/skills/payment-pci-security/skill.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -1578,7 +1586,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -1588,10 +1600,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -1651,7 +1774,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -1667,7 +1792,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -1675,7 +1800,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -1730,7 +1855,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -1820,7 +1946,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -1835,7 +1961,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -1853,7 +1981,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -1914,14 +2042,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -1942,22 +2079,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1965,7 +2100,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -1975,78 +2109,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -2074,59 +2222,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
@@ -6886,12 +7047,14 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](../payment-async-flow/skill.md)
@@ -6919,8 +7082,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -6936,9 +7103,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -6952,8 +7119,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -6962,7 +7133,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -7005,7 +7176,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -7014,9 +7185,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -7031,6 +7206,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -7042,16 +7319,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -7065,15 +7346,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -7094,8 +7379,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -7103,15 +7392,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -7127,8 +7418,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -7173,18 +7468,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -7219,12 +7514,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -7237,21 +7532,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -657,6 +657,14 @@ app.use(
 );
 app.use(
   session({
+    // Production BFFs are typically multi-replica. Configure a shared session
+    // store (e.g. connect-redis, connect-memcached, a Postgres-backed store)
+    // here — the default MemoryStore is per-pod and silently drops values such
+    // as orderFormId and vtexAuthToken when requests are routed to a different
+    // replica. For ephemeral cross-step values that the browser already sees
+    // (e.g. orderGroup between Step 1 and Step 3 of order placement), prefer
+    // passing them through the request body instead of writing them to the
+    // session — see headless-checkout-proxy.
     secret: process.env.SESSION_SECRET!,
     resave: false,
     saveUninitialized: false,
@@ -1531,6 +1539,7 @@ Do not use this skill for:
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
 - Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
+- Pass intermediate flow values such as `orderGroup` between Step 1 (`/place`) and Step 3 (`/process`) **through the request body**, not through `req.session`. Production BFFs are typically multi-replica; `express-session`'s default `MemoryStore` (and any per-pod cache) loses the value when the two requests land on different pods, returning a misleading "no pending order to process" 400. If a shared session store (Redis, Memcached, database) is already required for `orderFormId`/`vtexCookies`, see the Hard constraint below for why the cross-step handoff still belongs in the request body — it stays correct under partial outages, sticky-routing failures, and replay/refresh after a tab reload.
 
 OrderForm attachment endpoints:
 
@@ -1804,6 +1813,104 @@ async function getCart(): Promise<OrderForm> {
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Multi-step order flow handoffs MUST travel in the request body, not in `req.session`
+
+Values that link `/place` (Step 1) and `/process` (Step 3) — most importantly `orderGroup`, but also any per-attempt `transactionId` or merchant context the frontend needs to echo back — MUST be returned by `/place` to the browser and sent back by the browser in the `/process` request body. The handler MUST NOT rely on `req.session.pendingOrderGroup` (or any per-pod cache) as the only source of truth for the in-flight order.
+
+**Why this matters**
+
+Production BFFs run multiple replicas (Kubernetes deployments, ECS services, lambdas behind an ALB, edge runtimes). `express-session` defaults to `MemoryStore`, which is per-pod, so a session value written on one pod is invisible to every other pod. Even with a shared session store (Redis, DynamoDB, Memcached), Step 1 and Step 3 fire as fast as the user can roundtrip through `vtexpayments.com.br`, so any partial Redis outage, write replication lag, sticky-routing failure, tab refresh, or session regeneration on login surfaces as `400 — no pending order to process`. From the shopper's point of view the order is paid (their card was charged in Step 2) but the storefront reports failure, and support has to reconcile by hand. The 5-minute order processing window leaves no time for retries.
+
+`orderGroup` is not a secret. It already returns to the browser from Step 1 and is required by the direct browser → `vtexpayments.com.br` call in Step 2. Echoing it back in Step 3 is strictly less surface area than session-backed state. Authentication and ownership are still enforced server-side through the session-bound `vtexCookies`, `orderFormId`, and (when present) `vtexAuthToken` — the BFF never trusts `orderGroup` alone.
+
+**Detection**
+
+If you find any of the following in BFF / server-side checkout code, STOP immediately:
+
+- Any read or write of `req.session.pendingOrderGroup`, `req.session.orderGroup`, `req.session.lastTransactionId`, or similar per-flow values written in `/place` and read in `/process`.
+- A `/process` (or `/gatewayCallback`) handler whose only source of `orderGroup` is `req.session`, with no `req.body.orderGroup` fallback or validation.
+- A frontend `placeOrder` flow that calls `/api/bff/order/process` with no body and no `orderGroup`, relying on the BFF to "remember" the order.
+- Comments like "// rely on session to recover orderGroup" or commits that move `orderGroup` from request bodies into the session for "tidiness".
+
+**Correct**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  const orderFormId = req.session.orderFormId;
+  if (!orderFormId) return res.status(400).json({ error: "No active cart" });
+
+  const { data } = await vtexCheckout<PlaceOrderResponse>({
+    path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
+    method: "POST",
+    body: { referenceId: orderFormId },
+    cookies: req.session.vtexCookies || {},
+    userToken: req.session.vtexAuthToken,
+  });
+
+  res.json({
+    account: process.env.VTEX_ACCOUNT,
+    orderId: data.orders[0].orderId,
+    orderGroup: data.orderGroup,
+    transactionId: data.orders[0].transactionData.merchantTransactions[0].transactionId,
+    merchantName: data.orders[0].transactionData.merchantTransactions[0].merchantName,
+  });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.orderFormId;
+  delete req.session.vtexCookies;
+  res.json({ orderGroup, status: "processed" });
+});
+```
+
+The matching browser flow — `/place` returns `orderGroup` and the browser echoes it back in the `/process` body — is shown in the Preferred pattern below.
+
+**Wrong**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  // ... call /transaction ...
+  req.session.pendingOrderGroup = orderGroup;
+  res.json({ account, orderId, orderGroup, transactionId, merchantName });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  // BUG: works in dev with one Node process and MemoryStore, returns
+  // `400 — no pending order to process` the moment the load balancer routes
+  // /place and /process to different replicas.
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.pendingOrderGroup;
+  res.json({ status: "processed" });
+});
 ```
 
 ---
@@ -2092,7 +2199,11 @@ export const orderRoutes = Router();
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
 
 // POST /api/bff/order/place — Step 1: place order from existing cart.
-// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
+// Returns the data the browser needs to call vtexpayments.com.br directly in
+// Step 2 AND to call /api/bff/order/process in Step 3. The browser is the
+// authority for `orderGroup` between Step 1 and Step 3 — the BFF does NOT
+// stash it in `req.session`, because that would silently break in any
+// multi-replica deployment whose session store is in-memory or sticky-routed.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -2121,8 +2232,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     const transactionId = merchantTransaction?.transactionId;
     const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    req.session.pendingOrderGroup = orderGroup;
-
     res.json({
       account: VTEX_ACCOUNT,
       orderId,
@@ -2138,11 +2247,18 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
 
 // POST /api/bff/order/process — Step 3: process gateway callback after the
 // browser has submitted payment data directly to vtexpayments.com.br in Step 2.
-// Carries no card data; safe to run server-side.
+// Carries no card data; safe to run server-side. The browser passes back the
+// same `orderGroup` it received from /place so the handler is stateless across
+// replicas. The BFF still validates ownership through the session-bound
+// orderFormId + checkout cookies before calling VTEX.
 orderRoutes.post("/process", async (req: Request, res: Response) => {
-  const orderGroup = req.session.pendingOrderGroup;
-  if (!orderGroup) {
-    return res.status(400).json({ error: "No pending order to process" });
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
   }
 
   try {
@@ -2154,7 +2270,6 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 
     delete req.session.orderFormId;
     delete req.session.vtexCookies;
-    delete req.session.pendingOrderGroup;
 
     res.json({ orderGroup, status: "processed" });
   } catch (error) {
@@ -2167,6 +2282,8 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 ```typescript
 // frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
 // Card fields stay on the device; the BFF never sees them.
+// Step 3 echoes `orderGroup` back to the BFF in the request body so it works
+// the same way whether the BFF runs on one pod or fifty.
 async function placeOrderWithCard(card: CardPaymentInformation) {
   const placeResp = await fetch("/api/bff/order/place", {
     method: "POST",
@@ -2193,6 +2310,8 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
   await fetch("/api/bff/order/process", {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orderGroup }),
   });
 }
 ```
@@ -2239,11 +2358,16 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
       card,
     });
 
-    await fetchJson("/api/bff/order/process", { method: "POST" });
+    await fetchJson("/api/bff/order/process", {
+      method: "POST",
+      body: { orderGroup },
+    });
   }
   ```
 
 - **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
+
+- **Storing `orderGroup` in `req.session` between `/place` and `/process`**: Writing `req.session.pendingOrderGroup` in Step 1 and reading it in Step 3 looks tidy and works in single-process local development. With `express-session`'s default `MemoryStore` (and any per-pod cache) a horizontally scaled BFF loses the value the moment the two requests land on different replicas, so `/process` returns `400 — no pending order to process` while the shopper's card has already been charged in Step 2. Return `orderGroup` from `/place` to the browser and require the browser to send it back in the `/process` body — see the dedicated hard constraint above. Even with a shared session store (Redis, Memcached, database) in place for `orderFormId`/`vtexCookies`, the cross-step handoff still belongs in the request body so the flow stays correct under partial outages, sticky-routing failures, replication lag, and tab refresh.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
@@ -2289,6 +2413,7 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
 - [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
+- [ ] Is `orderGroup` returned by `/place` and sent back by the browser in the `/process` request body, instead of being stashed in `req.session.pendingOrderGroup` between the two BFF calls?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
 ## Reference

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -1517,48 +1517,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](../headless-bff-architecture/skill.md))
 - Search API integration (use [`headless-intelligent-search`](../headless-intelligent-search/skill.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](../headless-caching-strategy/skill.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](../../../payment/skills/payment-pci-security/skill.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -1578,7 +1586,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -1588,10 +1600,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -1651,7 +1774,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -1667,7 +1792,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -1675,7 +1800,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -1730,7 +1855,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -1820,7 +1946,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -1835,7 +1961,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -1853,7 +1981,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -1914,14 +2042,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -1942,22 +2079,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1965,7 +2100,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -1975,78 +2109,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -2074,59 +2222,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
@@ -7299,12 +7460,14 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](../payment-async-flow/skill.md)
@@ -7332,8 +7495,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -7349,9 +7516,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -7365,8 +7532,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -7375,7 +7546,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -7418,7 +7589,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -7427,9 +7598,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -7444,6 +7619,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -7455,16 +7732,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -7478,15 +7759,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -7507,8 +7792,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -7516,15 +7805,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -7540,8 +7831,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -7586,18 +7881,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -7632,12 +7927,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -7650,21 +7945,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });

--- a/exports/copilot/headless.md
+++ b/exports/copilot/headless.md
@@ -1139,48 +1139,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](../headless-bff-architecture/skill.md))
 - Search API integration (use [`headless-intelligent-search`](../headless-intelligent-search/skill.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](../headless-caching-strategy/skill.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](../../../payment/skills/payment-pci-security/skill.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -1200,7 +1208,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -1210,10 +1222,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -1273,7 +1396,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -1289,7 +1414,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -1297,7 +1422,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -1352,7 +1477,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -1442,7 +1568,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -1457,7 +1583,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -1475,7 +1603,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -1536,14 +1664,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -1564,22 +1701,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1587,7 +1722,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -1597,78 +1731,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -1696,59 +1844,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 

--- a/exports/copilot/headless.md
+++ b/exports/copilot/headless.md
@@ -279,6 +279,14 @@ app.use(
 );
 app.use(
   session({
+    // Production BFFs are typically multi-replica. Configure a shared session
+    // store (e.g. connect-redis, connect-memcached, a Postgres-backed store)
+    // here — the default MemoryStore is per-pod and silently drops values such
+    // as orderFormId and vtexAuthToken when requests are routed to a different
+    // replica. For ephemeral cross-step values that the browser already sees
+    // (e.g. orderGroup between Step 1 and Step 3 of order placement), prefer
+    // passing them through the request body instead of writing them to the
+    // session — see headless-checkout-proxy.
     secret: process.env.SESSION_SECRET!,
     resave: false,
     saveUninitialized: false,
@@ -1153,6 +1161,7 @@ Do not use this skill for:
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
 - Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
+- Pass intermediate flow values such as `orderGroup` between Step 1 (`/place`) and Step 3 (`/process`) **through the request body**, not through `req.session`. Production BFFs are typically multi-replica; `express-session`'s default `MemoryStore` (and any per-pod cache) loses the value when the two requests land on different pods, returning a misleading "no pending order to process" 400. If a shared session store (Redis, Memcached, database) is already required for `orderFormId`/`vtexCookies`, see the Hard constraint below for why the cross-step handoff still belongs in the request body — it stays correct under partial outages, sticky-routing failures, and replay/refresh after a tab reload.
 
 OrderForm attachment endpoints:
 
@@ -1426,6 +1435,104 @@ async function getCart(): Promise<OrderForm> {
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Multi-step order flow handoffs MUST travel in the request body, not in `req.session`
+
+Values that link `/place` (Step 1) and `/process` (Step 3) — most importantly `orderGroup`, but also any per-attempt `transactionId` or merchant context the frontend needs to echo back — MUST be returned by `/place` to the browser and sent back by the browser in the `/process` request body. The handler MUST NOT rely on `req.session.pendingOrderGroup` (or any per-pod cache) as the only source of truth for the in-flight order.
+
+**Why this matters**
+
+Production BFFs run multiple replicas (Kubernetes deployments, ECS services, lambdas behind an ALB, edge runtimes). `express-session` defaults to `MemoryStore`, which is per-pod, so a session value written on one pod is invisible to every other pod. Even with a shared session store (Redis, DynamoDB, Memcached), Step 1 and Step 3 fire as fast as the user can roundtrip through `vtexpayments.com.br`, so any partial Redis outage, write replication lag, sticky-routing failure, tab refresh, or session regeneration on login surfaces as `400 — no pending order to process`. From the shopper's point of view the order is paid (their card was charged in Step 2) but the storefront reports failure, and support has to reconcile by hand. The 5-minute order processing window leaves no time for retries.
+
+`orderGroup` is not a secret. It already returns to the browser from Step 1 and is required by the direct browser → `vtexpayments.com.br` call in Step 2. Echoing it back in Step 3 is strictly less surface area than session-backed state. Authentication and ownership are still enforced server-side through the session-bound `vtexCookies`, `orderFormId`, and (when present) `vtexAuthToken` — the BFF never trusts `orderGroup` alone.
+
+**Detection**
+
+If you find any of the following in BFF / server-side checkout code, STOP immediately:
+
+- Any read or write of `req.session.pendingOrderGroup`, `req.session.orderGroup`, `req.session.lastTransactionId`, or similar per-flow values written in `/place` and read in `/process`.
+- A `/process` (or `/gatewayCallback`) handler whose only source of `orderGroup` is `req.session`, with no `req.body.orderGroup` fallback or validation.
+- A frontend `placeOrder` flow that calls `/api/bff/order/process` with no body and no `orderGroup`, relying on the BFF to "remember" the order.
+- Comments like "// rely on session to recover orderGroup" or commits that move `orderGroup` from request bodies into the session for "tidiness".
+
+**Correct**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  const orderFormId = req.session.orderFormId;
+  if (!orderFormId) return res.status(400).json({ error: "No active cart" });
+
+  const { data } = await vtexCheckout<PlaceOrderResponse>({
+    path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
+    method: "POST",
+    body: { referenceId: orderFormId },
+    cookies: req.session.vtexCookies || {},
+    userToken: req.session.vtexAuthToken,
+  });
+
+  res.json({
+    account: process.env.VTEX_ACCOUNT,
+    orderId: data.orders[0].orderId,
+    orderGroup: data.orderGroup,
+    transactionId: data.orders[0].transactionData.merchantTransactions[0].transactionId,
+    merchantName: data.orders[0].transactionData.merchantTransactions[0].merchantName,
+  });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.orderFormId;
+  delete req.session.vtexCookies;
+  res.json({ orderGroup, status: "processed" });
+});
+```
+
+The matching browser flow — `/place` returns `orderGroup` and the browser echoes it back in the `/process` body — is shown in the Preferred pattern below.
+
+**Wrong**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  // ... call /transaction ...
+  req.session.pendingOrderGroup = orderGroup;
+  res.json({ account, orderId, orderGroup, transactionId, merchantName });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  // BUG: works in dev with one Node process and MemoryStore, returns
+  // `400 — no pending order to process` the moment the load balancer routes
+  // /place and /process to different replicas.
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.pendingOrderGroup;
+  res.json({ status: "processed" });
+});
 ```
 
 ---
@@ -1714,7 +1821,11 @@ export const orderRoutes = Router();
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
 
 // POST /api/bff/order/place — Step 1: place order from existing cart.
-// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
+// Returns the data the browser needs to call vtexpayments.com.br directly in
+// Step 2 AND to call /api/bff/order/process in Step 3. The browser is the
+// authority for `orderGroup` between Step 1 and Step 3 — the BFF does NOT
+// stash it in `req.session`, because that would silently break in any
+// multi-replica deployment whose session store is in-memory or sticky-routed.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1743,8 +1854,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     const transactionId = merchantTransaction?.transactionId;
     const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    req.session.pendingOrderGroup = orderGroup;
-
     res.json({
       account: VTEX_ACCOUNT,
       orderId,
@@ -1760,11 +1869,18 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
 
 // POST /api/bff/order/process — Step 3: process gateway callback after the
 // browser has submitted payment data directly to vtexpayments.com.br in Step 2.
-// Carries no card data; safe to run server-side.
+// Carries no card data; safe to run server-side. The browser passes back the
+// same `orderGroup` it received from /place so the handler is stateless across
+// replicas. The BFF still validates ownership through the session-bound
+// orderFormId + checkout cookies before calling VTEX.
 orderRoutes.post("/process", async (req: Request, res: Response) => {
-  const orderGroup = req.session.pendingOrderGroup;
-  if (!orderGroup) {
-    return res.status(400).json({ error: "No pending order to process" });
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
   }
 
   try {
@@ -1776,7 +1892,6 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 
     delete req.session.orderFormId;
     delete req.session.vtexCookies;
-    delete req.session.pendingOrderGroup;
 
     res.json({ orderGroup, status: "processed" });
   } catch (error) {
@@ -1789,6 +1904,8 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 ```typescript
 // frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
 // Card fields stay on the device; the BFF never sees them.
+// Step 3 echoes `orderGroup` back to the BFF in the request body so it works
+// the same way whether the BFF runs on one pod or fifty.
 async function placeOrderWithCard(card: CardPaymentInformation) {
   const placeResp = await fetch("/api/bff/order/place", {
     method: "POST",
@@ -1815,6 +1932,8 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
   await fetch("/api/bff/order/process", {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orderGroup }),
   });
 }
 ```
@@ -1861,11 +1980,16 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
       card,
     });
 
-    await fetchJson("/api/bff/order/process", { method: "POST" });
+    await fetchJson("/api/bff/order/process", {
+      method: "POST",
+      body: { orderGroup },
+    });
   }
   ```
 
 - **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
+
+- **Storing `orderGroup` in `req.session` between `/place` and `/process`**: Writing `req.session.pendingOrderGroup` in Step 1 and reading it in Step 3 looks tidy and works in single-process local development. With `express-session`'s default `MemoryStore` (and any per-pod cache) a horizontally scaled BFF loses the value the moment the two requests land on different replicas, so `/process` returns `400 — no pending order to process` while the shopper's card has already been charged in Step 2. Return `orderGroup` from `/place` to the browser and require the browser to send it back in the `/process` body — see the dedicated hard constraint above. Even with a shared session store (Redis, Memcached, database) in place for `orderFormId`/`vtexCookies`, the cross-step handoff still belongs in the request body so the flow stays correct under partial outages, sticky-routing failures, replication lag, and tab refresh.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
@@ -1911,6 +2035,7 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
 - [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
+- [ ] Is `orderGroup` returned by `/place` and sent back by the browser in the `/process` request body, instead of being stashed in `req.session.pendingOrderGroup` between the two BFF calls?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
 ## Reference

--- a/exports/copilot/payment.md
+++ b/exports/copilot/payment.md
@@ -1078,12 +1078,14 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](../payment-async-flow/skill.md)
@@ -1111,8 +1113,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -1128,9 +1134,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -1144,8 +1150,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -1154,7 +1164,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -1197,7 +1207,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -1206,9 +1216,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -1223,6 +1237,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -1234,16 +1350,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -1257,15 +1377,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -1286,8 +1410,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -1295,15 +1423,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -1319,8 +1449,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -1365,18 +1499,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -1411,12 +1545,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -1429,21 +1563,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });

--- a/exports/cursor/headless-all.mdc
+++ b/exports/cursor/headless-all.mdc
@@ -1143,48 +1143,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](../headless-bff-architecture/skill.md))
 - Search API integration (use [`headless-intelligent-search`](../headless-intelligent-search/skill.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](../headless-caching-strategy/skill.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](../../../payment/skills/payment-pci-security/skill.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -1204,7 +1212,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -1214,10 +1226,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -1277,7 +1400,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -1293,7 +1418,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -1301,7 +1426,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -1356,7 +1481,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -1446,7 +1572,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -1461,7 +1587,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -1479,7 +1607,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -1540,14 +1668,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -1568,22 +1705,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1591,7 +1726,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -1601,78 +1735,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -1700,59 +1848,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 

--- a/exports/cursor/headless-all.mdc
+++ b/exports/cursor/headless-all.mdc
@@ -283,6 +283,14 @@ app.use(
 );
 app.use(
   session({
+    // Production BFFs are typically multi-replica. Configure a shared session
+    // store (e.g. connect-redis, connect-memcached, a Postgres-backed store)
+    // here — the default MemoryStore is per-pod and silently drops values such
+    // as orderFormId and vtexAuthToken when requests are routed to a different
+    // replica. For ephemeral cross-step values that the browser already sees
+    // (e.g. orderGroup between Step 1 and Step 3 of order placement), prefer
+    // passing them through the request body instead of writing them to the
+    // session — see headless-checkout-proxy.
     secret: process.env.SESSION_SECRET!,
     resave: false,
     saveUninitialized: false,
@@ -1157,6 +1165,7 @@ Do not use this skill for:
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
 - Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
+- Pass intermediate flow values such as `orderGroup` between Step 1 (`/place`) and Step 3 (`/process`) **through the request body**, not through `req.session`. Production BFFs are typically multi-replica; `express-session`'s default `MemoryStore` (and any per-pod cache) loses the value when the two requests land on different pods, returning a misleading "no pending order to process" 400. If a shared session store (Redis, Memcached, database) is already required for `orderFormId`/`vtexCookies`, see the Hard constraint below for why the cross-step handoff still belongs in the request body — it stays correct under partial outages, sticky-routing failures, and replay/refresh after a tab reload.
 
 OrderForm attachment endpoints:
 
@@ -1430,6 +1439,104 @@ async function getCart(): Promise<OrderForm> {
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Multi-step order flow handoffs MUST travel in the request body, not in `req.session`
+
+Values that link `/place` (Step 1) and `/process` (Step 3) — most importantly `orderGroup`, but also any per-attempt `transactionId` or merchant context the frontend needs to echo back — MUST be returned by `/place` to the browser and sent back by the browser in the `/process` request body. The handler MUST NOT rely on `req.session.pendingOrderGroup` (or any per-pod cache) as the only source of truth for the in-flight order.
+
+**Why this matters**
+
+Production BFFs run multiple replicas (Kubernetes deployments, ECS services, lambdas behind an ALB, edge runtimes). `express-session` defaults to `MemoryStore`, which is per-pod, so a session value written on one pod is invisible to every other pod. Even with a shared session store (Redis, DynamoDB, Memcached), Step 1 and Step 3 fire as fast as the user can roundtrip through `vtexpayments.com.br`, so any partial Redis outage, write replication lag, sticky-routing failure, tab refresh, or session regeneration on login surfaces as `400 — no pending order to process`. From the shopper's point of view the order is paid (their card was charged in Step 2) but the storefront reports failure, and support has to reconcile by hand. The 5-minute order processing window leaves no time for retries.
+
+`orderGroup` is not a secret. It already returns to the browser from Step 1 and is required by the direct browser → `vtexpayments.com.br` call in Step 2. Echoing it back in Step 3 is strictly less surface area than session-backed state. Authentication and ownership are still enforced server-side through the session-bound `vtexCookies`, `orderFormId`, and (when present) `vtexAuthToken` — the BFF never trusts `orderGroup` alone.
+
+**Detection**
+
+If you find any of the following in BFF / server-side checkout code, STOP immediately:
+
+- Any read or write of `req.session.pendingOrderGroup`, `req.session.orderGroup`, `req.session.lastTransactionId`, or similar per-flow values written in `/place` and read in `/process`.
+- A `/process` (or `/gatewayCallback`) handler whose only source of `orderGroup` is `req.session`, with no `req.body.orderGroup` fallback or validation.
+- A frontend `placeOrder` flow that calls `/api/bff/order/process` with no body and no `orderGroup`, relying on the BFF to "remember" the order.
+- Comments like "// rely on session to recover orderGroup" or commits that move `orderGroup` from request bodies into the session for "tidiness".
+
+**Correct**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  const orderFormId = req.session.orderFormId;
+  if (!orderFormId) return res.status(400).json({ error: "No active cart" });
+
+  const { data } = await vtexCheckout<PlaceOrderResponse>({
+    path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
+    method: "POST",
+    body: { referenceId: orderFormId },
+    cookies: req.session.vtexCookies || {},
+    userToken: req.session.vtexAuthToken,
+  });
+
+  res.json({
+    account: process.env.VTEX_ACCOUNT,
+    orderId: data.orders[0].orderId,
+    orderGroup: data.orderGroup,
+    transactionId: data.orders[0].transactionData.merchantTransactions[0].transactionId,
+    merchantName: data.orders[0].transactionData.merchantTransactions[0].merchantName,
+  });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.orderFormId;
+  delete req.session.vtexCookies;
+  res.json({ orderGroup, status: "processed" });
+});
+```
+
+The matching browser flow — `/place` returns `orderGroup` and the browser echoes it back in the `/process` body — is shown in the Preferred pattern below.
+
+**Wrong**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  // ... call /transaction ...
+  req.session.pendingOrderGroup = orderGroup;
+  res.json({ account, orderId, orderGroup, transactionId, merchantName });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  // BUG: works in dev with one Node process and MemoryStore, returns
+  // `400 — no pending order to process` the moment the load balancer routes
+  // /place and /process to different replicas.
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.pendingOrderGroup;
+  res.json({ status: "processed" });
+});
 ```
 
 ---
@@ -1718,7 +1825,11 @@ export const orderRoutes = Router();
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
 
 // POST /api/bff/order/place — Step 1: place order from existing cart.
-// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
+// Returns the data the browser needs to call vtexpayments.com.br directly in
+// Step 2 AND to call /api/bff/order/process in Step 3. The browser is the
+// authority for `orderGroup` between Step 1 and Step 3 — the BFF does NOT
+// stash it in `req.session`, because that would silently break in any
+// multi-replica deployment whose session store is in-memory or sticky-routed.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1747,8 +1858,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     const transactionId = merchantTransaction?.transactionId;
     const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    req.session.pendingOrderGroup = orderGroup;
-
     res.json({
       account: VTEX_ACCOUNT,
       orderId,
@@ -1764,11 +1873,18 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
 
 // POST /api/bff/order/process — Step 3: process gateway callback after the
 // browser has submitted payment data directly to vtexpayments.com.br in Step 2.
-// Carries no card data; safe to run server-side.
+// Carries no card data; safe to run server-side. The browser passes back the
+// same `orderGroup` it received from /place so the handler is stateless across
+// replicas. The BFF still validates ownership through the session-bound
+// orderFormId + checkout cookies before calling VTEX.
 orderRoutes.post("/process", async (req: Request, res: Response) => {
-  const orderGroup = req.session.pendingOrderGroup;
-  if (!orderGroup) {
-    return res.status(400).json({ error: "No pending order to process" });
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
   }
 
   try {
@@ -1780,7 +1896,6 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 
     delete req.session.orderFormId;
     delete req.session.vtexCookies;
-    delete req.session.pendingOrderGroup;
 
     res.json({ orderGroup, status: "processed" });
   } catch (error) {
@@ -1793,6 +1908,8 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 ```typescript
 // frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
 // Card fields stay on the device; the BFF never sees them.
+// Step 3 echoes `orderGroup` back to the BFF in the request body so it works
+// the same way whether the BFF runs on one pod or fifty.
 async function placeOrderWithCard(card: CardPaymentInformation) {
   const placeResp = await fetch("/api/bff/order/place", {
     method: "POST",
@@ -1819,6 +1936,8 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
   await fetch("/api/bff/order/process", {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orderGroup }),
   });
 }
 ```
@@ -1865,11 +1984,16 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
       card,
     });
 
-    await fetchJson("/api/bff/order/process", { method: "POST" });
+    await fetchJson("/api/bff/order/process", {
+      method: "POST",
+      body: { orderGroup },
+    });
   }
   ```
 
 - **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
+
+- **Storing `orderGroup` in `req.session` between `/place` and `/process`**: Writing `req.session.pendingOrderGroup` in Step 1 and reading it in Step 3 looks tidy and works in single-process local development. With `express-session`'s default `MemoryStore` (and any per-pod cache) a horizontally scaled BFF loses the value the moment the two requests land on different replicas, so `/process` returns `400 — no pending order to process` while the shopper's card has already been charged in Step 2. Return `orderGroup` from `/place` to the browser and require the browser to send it back in the `/process` body — see the dedicated hard constraint above. Even with a shared session store (Redis, Memcached, database) in place for `orderFormId`/`vtexCookies`, the cross-step handoff still belongs in the request body so the flow stays correct under partial outages, sticky-routing failures, replication lag, and tab refresh.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
@@ -1915,6 +2039,7 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
 - [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
+- [ ] Is `orderGroup` returned by `/place` and sent back by the browser in the `/process` request body, instead of being stashed in `req.session.pendingOrderGroup` between the two BFF calls?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
 ## Reference

--- a/exports/cursor/headless-headless-bff-architecture.mdc
+++ b/exports/cursor/headless-headless-bff-architecture.mdc
@@ -283,6 +283,14 @@ app.use(
 );
 app.use(
   session({
+    // Production BFFs are typically multi-replica. Configure a shared session
+    // store (e.g. connect-redis, connect-memcached, a Postgres-backed store)
+    // here — the default MemoryStore is per-pod and silently drops values such
+    // as orderFormId and vtexAuthToken when requests are routed to a different
+    // replica. For ephemeral cross-step values that the browser already sees
+    // (e.g. orderGroup between Step 1 and Step 3 of order placement), prefer
+    // passing them through the request body instead of writing them to the
+    // session — see headless-checkout-proxy.
     secret: process.env.SESSION_SECRET!,
     resave: false,
     saveUninitialized: false,

--- a/exports/cursor/headless-headless-checkout-proxy.mdc
+++ b/exports/cursor/headless-headless-checkout-proxy.mdc
@@ -16,48 +16,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](../headless-bff-architecture/skill.md))
 - Search API integration (use [`headless-intelligent-search`](../headless-intelligent-search/skill.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](../headless-caching-strategy/skill.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](../../../payment/skills/payment-pci-security/skill.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -77,7 +85,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -87,10 +99,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -150,7 +273,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -166,7 +291,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -174,7 +299,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -229,7 +354,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -319,7 +445,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -334,7 +460,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -352,7 +480,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -413,14 +541,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -441,22 +578,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -464,7 +599,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -474,78 +608,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -573,59 +721,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 

--- a/exports/cursor/headless-headless-checkout-proxy.mdc
+++ b/exports/cursor/headless-headless-checkout-proxy.mdc
@@ -30,6 +30,7 @@ Do not use this skill for:
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
 - Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
+- Pass intermediate flow values such as `orderGroup` between Step 1 (`/place`) and Step 3 (`/process`) **through the request body**, not through `req.session`. Production BFFs are typically multi-replica; `express-session`'s default `MemoryStore` (and any per-pod cache) loses the value when the two requests land on different pods, returning a misleading "no pending order to process" 400. If a shared session store (Redis, Memcached, database) is already required for `orderFormId`/`vtexCookies`, see the Hard constraint below for why the cross-step handoff still belongs in the request body — it stays correct under partial outages, sticky-routing failures, and replay/refresh after a tab reload.
 
 OrderForm attachment endpoints:
 
@@ -303,6 +304,104 @@ async function getCart(): Promise<OrderForm> {
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Multi-step order flow handoffs MUST travel in the request body, not in `req.session`
+
+Values that link `/place` (Step 1) and `/process` (Step 3) — most importantly `orderGroup`, but also any per-attempt `transactionId` or merchant context the frontend needs to echo back — MUST be returned by `/place` to the browser and sent back by the browser in the `/process` request body. The handler MUST NOT rely on `req.session.pendingOrderGroup` (or any per-pod cache) as the only source of truth for the in-flight order.
+
+**Why this matters**
+
+Production BFFs run multiple replicas (Kubernetes deployments, ECS services, lambdas behind an ALB, edge runtimes). `express-session` defaults to `MemoryStore`, which is per-pod, so a session value written on one pod is invisible to every other pod. Even with a shared session store (Redis, DynamoDB, Memcached), Step 1 and Step 3 fire as fast as the user can roundtrip through `vtexpayments.com.br`, so any partial Redis outage, write replication lag, sticky-routing failure, tab refresh, or session regeneration on login surfaces as `400 — no pending order to process`. From the shopper's point of view the order is paid (their card was charged in Step 2) but the storefront reports failure, and support has to reconcile by hand. The 5-minute order processing window leaves no time for retries.
+
+`orderGroup` is not a secret. It already returns to the browser from Step 1 and is required by the direct browser → `vtexpayments.com.br` call in Step 2. Echoing it back in Step 3 is strictly less surface area than session-backed state. Authentication and ownership are still enforced server-side through the session-bound `vtexCookies`, `orderFormId`, and (when present) `vtexAuthToken` — the BFF never trusts `orderGroup` alone.
+
+**Detection**
+
+If you find any of the following in BFF / server-side checkout code, STOP immediately:
+
+- Any read or write of `req.session.pendingOrderGroup`, `req.session.orderGroup`, `req.session.lastTransactionId`, or similar per-flow values written in `/place` and read in `/process`.
+- A `/process` (or `/gatewayCallback`) handler whose only source of `orderGroup` is `req.session`, with no `req.body.orderGroup` fallback or validation.
+- A frontend `placeOrder` flow that calls `/api/bff/order/process` with no body and no `orderGroup`, relying on the BFF to "remember" the order.
+- Comments like "// rely on session to recover orderGroup" or commits that move `orderGroup` from request bodies into the session for "tidiness".
+
+**Correct**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  const orderFormId = req.session.orderFormId;
+  if (!orderFormId) return res.status(400).json({ error: "No active cart" });
+
+  const { data } = await vtexCheckout<PlaceOrderResponse>({
+    path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
+    method: "POST",
+    body: { referenceId: orderFormId },
+    cookies: req.session.vtexCookies || {},
+    userToken: req.session.vtexAuthToken,
+  });
+
+  res.json({
+    account: process.env.VTEX_ACCOUNT,
+    orderId: data.orders[0].orderId,
+    orderGroup: data.orderGroup,
+    transactionId: data.orders[0].transactionData.merchantTransactions[0].transactionId,
+    merchantName: data.orders[0].transactionData.merchantTransactions[0].merchantName,
+  });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.orderFormId;
+  delete req.session.vtexCookies;
+  res.json({ orderGroup, status: "processed" });
+});
+```
+
+The matching browser flow — `/place` returns `orderGroup` and the browser echoes it back in the `/process` body — is shown in the Preferred pattern below.
+
+**Wrong**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  // ... call /transaction ...
+  req.session.pendingOrderGroup = orderGroup;
+  res.json({ account, orderId, orderGroup, transactionId, merchantName });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  // BUG: works in dev with one Node process and MemoryStore, returns
+  // `400 — no pending order to process` the moment the load balancer routes
+  // /place and /process to different replicas.
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.pendingOrderGroup;
+  res.json({ status: "processed" });
+});
 ```
 
 ---
@@ -591,7 +690,11 @@ export const orderRoutes = Router();
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
 
 // POST /api/bff/order/place — Step 1: place order from existing cart.
-// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
+// Returns the data the browser needs to call vtexpayments.com.br directly in
+// Step 2 AND to call /api/bff/order/process in Step 3. The browser is the
+// authority for `orderGroup` between Step 1 and Step 3 — the BFF does NOT
+// stash it in `req.session`, because that would silently break in any
+// multi-replica deployment whose session store is in-memory or sticky-routed.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -620,8 +723,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     const transactionId = merchantTransaction?.transactionId;
     const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    req.session.pendingOrderGroup = orderGroup;
-
     res.json({
       account: VTEX_ACCOUNT,
       orderId,
@@ -637,11 +738,18 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
 
 // POST /api/bff/order/process — Step 3: process gateway callback after the
 // browser has submitted payment data directly to vtexpayments.com.br in Step 2.
-// Carries no card data; safe to run server-side.
+// Carries no card data; safe to run server-side. The browser passes back the
+// same `orderGroup` it received from /place so the handler is stateless across
+// replicas. The BFF still validates ownership through the session-bound
+// orderFormId + checkout cookies before calling VTEX.
 orderRoutes.post("/process", async (req: Request, res: Response) => {
-  const orderGroup = req.session.pendingOrderGroup;
-  if (!orderGroup) {
-    return res.status(400).json({ error: "No pending order to process" });
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
   }
 
   try {
@@ -653,7 +761,6 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 
     delete req.session.orderFormId;
     delete req.session.vtexCookies;
-    delete req.session.pendingOrderGroup;
 
     res.json({ orderGroup, status: "processed" });
   } catch (error) {
@@ -666,6 +773,8 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 ```typescript
 // frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
 // Card fields stay on the device; the BFF never sees them.
+// Step 3 echoes `orderGroup` back to the BFF in the request body so it works
+// the same way whether the BFF runs on one pod or fifty.
 async function placeOrderWithCard(card: CardPaymentInformation) {
   const placeResp = await fetch("/api/bff/order/place", {
     method: "POST",
@@ -692,6 +801,8 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
   await fetch("/api/bff/order/process", {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orderGroup }),
   });
 }
 ```
@@ -738,11 +849,16 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
       card,
     });
 
-    await fetchJson("/api/bff/order/process", { method: "POST" });
+    await fetchJson("/api/bff/order/process", {
+      method: "POST",
+      body: { orderGroup },
+    });
   }
   ```
 
 - **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
+
+- **Storing `orderGroup` in `req.session` between `/place` and `/process`**: Writing `req.session.pendingOrderGroup` in Step 1 and reading it in Step 3 looks tidy and works in single-process local development. With `express-session`'s default `MemoryStore` (and any per-pod cache) a horizontally scaled BFF loses the value the moment the two requests land on different replicas, so `/process` returns `400 — no pending order to process` while the shopper's card has already been charged in Step 2. Return `orderGroup` from `/place` to the browser and require the browser to send it back in the `/process` body — see the dedicated hard constraint above. Even with a shared session store (Redis, Memcached, database) in place for `orderFormId`/`vtexCookies`, the cross-step handoff still belongs in the request body so the flow stays correct under partial outages, sticky-routing failures, replication lag, and tab refresh.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
@@ -788,6 +904,7 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
 - [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
+- [ ] Is `orderGroup` returned by `/place` and sent back by the browser in the `/process` request body, instead of being stashed in `req.session.pendingOrderGroup` between the two BFF calls?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
 ## Reference

--- a/exports/cursor/payment-all.mdc
+++ b/exports/cursor/payment-all.mdc
@@ -1082,12 +1082,14 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](../payment-async-flow/skill.md)
@@ -1115,8 +1117,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -1132,9 +1138,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -1148,8 +1154,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -1158,7 +1168,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -1201,7 +1211,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -1210,9 +1220,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -1227,6 +1241,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -1238,16 +1354,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -1261,15 +1381,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -1290,8 +1414,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -1299,15 +1427,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -1323,8 +1453,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -1369,18 +1503,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -1415,12 +1549,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -1433,21 +1567,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });

--- a/exports/cursor/payment-payment-pci-security.mdc
+++ b/exports/cursor/payment-payment-pci-security.mdc
@@ -9,12 +9,14 @@ alwaysApply: false
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](../payment-async-flow/skill.md)
@@ -42,8 +44,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -59,9 +65,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -75,8 +81,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -85,7 +95,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -128,7 +138,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -137,9 +147,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -154,6 +168,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -165,16 +281,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -188,15 +308,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -217,8 +341,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -226,15 +354,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -250,8 +380,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -296,18 +430,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -342,12 +476,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -360,21 +494,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });

--- a/exports/kiro/steering/headless-all.md
+++ b/exports/kiro/steering/headless-all.md
@@ -1139,48 +1139,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](headless-headless-bff-architecture.md))
 - Search API integration (use [`headless-intelligent-search`](headless-headless-intelligent-search.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](headless-headless-caching-strategy.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](payment-payment-pci-security.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -1200,7 +1208,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -1210,10 +1222,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -1273,7 +1396,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -1289,7 +1414,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -1297,7 +1422,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -1352,7 +1477,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -1442,7 +1568,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -1457,7 +1583,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -1475,7 +1603,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -1536,14 +1664,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -1564,22 +1701,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1587,7 +1722,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -1597,78 +1731,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -1696,59 +1844,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 

--- a/exports/kiro/steering/headless-all.md
+++ b/exports/kiro/steering/headless-all.md
@@ -279,6 +279,14 @@ app.use(
 );
 app.use(
   session({
+    // Production BFFs are typically multi-replica. Configure a shared session
+    // store (e.g. connect-redis, connect-memcached, a Postgres-backed store)
+    // here — the default MemoryStore is per-pod and silently drops values such
+    // as orderFormId and vtexAuthToken when requests are routed to a different
+    // replica. For ephemeral cross-step values that the browser already sees
+    // (e.g. orderGroup between Step 1 and Step 3 of order placement), prefer
+    // passing them through the request body instead of writing them to the
+    // session — see headless-checkout-proxy.
     secret: process.env.SESSION_SECRET!,
     resave: false,
     saveUninitialized: false,
@@ -1153,6 +1161,7 @@ Do not use this skill for:
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
 - Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
+- Pass intermediate flow values such as `orderGroup` between Step 1 (`/place`) and Step 3 (`/process`) **through the request body**, not through `req.session`. Production BFFs are typically multi-replica; `express-session`'s default `MemoryStore` (and any per-pod cache) loses the value when the two requests land on different pods, returning a misleading "no pending order to process" 400. If a shared session store (Redis, Memcached, database) is already required for `orderFormId`/`vtexCookies`, see the Hard constraint below for why the cross-step handoff still belongs in the request body — it stays correct under partial outages, sticky-routing failures, and replay/refresh after a tab reload.
 
 OrderForm attachment endpoints:
 
@@ -1426,6 +1435,104 @@ async function getCart(): Promise<OrderForm> {
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Multi-step order flow handoffs MUST travel in the request body, not in `req.session`
+
+Values that link `/place` (Step 1) and `/process` (Step 3) — most importantly `orderGroup`, but also any per-attempt `transactionId` or merchant context the frontend needs to echo back — MUST be returned by `/place` to the browser and sent back by the browser in the `/process` request body. The handler MUST NOT rely on `req.session.pendingOrderGroup` (or any per-pod cache) as the only source of truth for the in-flight order.
+
+**Why this matters**
+
+Production BFFs run multiple replicas (Kubernetes deployments, ECS services, lambdas behind an ALB, edge runtimes). `express-session` defaults to `MemoryStore`, which is per-pod, so a session value written on one pod is invisible to every other pod. Even with a shared session store (Redis, DynamoDB, Memcached), Step 1 and Step 3 fire as fast as the user can roundtrip through `vtexpayments.com.br`, so any partial Redis outage, write replication lag, sticky-routing failure, tab refresh, or session regeneration on login surfaces as `400 — no pending order to process`. From the shopper's point of view the order is paid (their card was charged in Step 2) but the storefront reports failure, and support has to reconcile by hand. The 5-minute order processing window leaves no time for retries.
+
+`orderGroup` is not a secret. It already returns to the browser from Step 1 and is required by the direct browser → `vtexpayments.com.br` call in Step 2. Echoing it back in Step 3 is strictly less surface area than session-backed state. Authentication and ownership are still enforced server-side through the session-bound `vtexCookies`, `orderFormId`, and (when present) `vtexAuthToken` — the BFF never trusts `orderGroup` alone.
+
+**Detection**
+
+If you find any of the following in BFF / server-side checkout code, STOP immediately:
+
+- Any read or write of `req.session.pendingOrderGroup`, `req.session.orderGroup`, `req.session.lastTransactionId`, or similar per-flow values written in `/place` and read in `/process`.
+- A `/process` (or `/gatewayCallback`) handler whose only source of `orderGroup` is `req.session`, with no `req.body.orderGroup` fallback or validation.
+- A frontend `placeOrder` flow that calls `/api/bff/order/process` with no body and no `orderGroup`, relying on the BFF to "remember" the order.
+- Comments like "// rely on session to recover orderGroup" or commits that move `orderGroup` from request bodies into the session for "tidiness".
+
+**Correct**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  const orderFormId = req.session.orderFormId;
+  if (!orderFormId) return res.status(400).json({ error: "No active cart" });
+
+  const { data } = await vtexCheckout<PlaceOrderResponse>({
+    path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
+    method: "POST",
+    body: { referenceId: orderFormId },
+    cookies: req.session.vtexCookies || {},
+    userToken: req.session.vtexAuthToken,
+  });
+
+  res.json({
+    account: process.env.VTEX_ACCOUNT,
+    orderId: data.orders[0].orderId,
+    orderGroup: data.orderGroup,
+    transactionId: data.orders[0].transactionData.merchantTransactions[0].transactionId,
+    merchantName: data.orders[0].transactionData.merchantTransactions[0].merchantName,
+  });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.orderFormId;
+  delete req.session.vtexCookies;
+  res.json({ orderGroup, status: "processed" });
+});
+```
+
+The matching browser flow — `/place` returns `orderGroup` and the browser echoes it back in the `/process` body — is shown in the Preferred pattern below.
+
+**Wrong**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  // ... call /transaction ...
+  req.session.pendingOrderGroup = orderGroup;
+  res.json({ account, orderId, orderGroup, transactionId, merchantName });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  // BUG: works in dev with one Node process and MemoryStore, returns
+  // `400 — no pending order to process` the moment the load balancer routes
+  // /place and /process to different replicas.
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.pendingOrderGroup;
+  res.json({ status: "processed" });
+});
 ```
 
 ---
@@ -1714,7 +1821,11 @@ export const orderRoutes = Router();
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
 
 // POST /api/bff/order/place — Step 1: place order from existing cart.
-// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
+// Returns the data the browser needs to call vtexpayments.com.br directly in
+// Step 2 AND to call /api/bff/order/process in Step 3. The browser is the
+// authority for `orderGroup` between Step 1 and Step 3 — the BFF does NOT
+// stash it in `req.session`, because that would silently break in any
+// multi-replica deployment whose session store is in-memory or sticky-routed.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -1743,8 +1854,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     const transactionId = merchantTransaction?.transactionId;
     const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    req.session.pendingOrderGroup = orderGroup;
-
     res.json({
       account: VTEX_ACCOUNT,
       orderId,
@@ -1760,11 +1869,18 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
 
 // POST /api/bff/order/process — Step 3: process gateway callback after the
 // browser has submitted payment data directly to vtexpayments.com.br in Step 2.
-// Carries no card data; safe to run server-side.
+// Carries no card data; safe to run server-side. The browser passes back the
+// same `orderGroup` it received from /place so the handler is stateless across
+// replicas. The BFF still validates ownership through the session-bound
+// orderFormId + checkout cookies before calling VTEX.
 orderRoutes.post("/process", async (req: Request, res: Response) => {
-  const orderGroup = req.session.pendingOrderGroup;
-  if (!orderGroup) {
-    return res.status(400).json({ error: "No pending order to process" });
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
   }
 
   try {
@@ -1776,7 +1892,6 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 
     delete req.session.orderFormId;
     delete req.session.vtexCookies;
-    delete req.session.pendingOrderGroup;
 
     res.json({ orderGroup, status: "processed" });
   } catch (error) {
@@ -1789,6 +1904,8 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 ```typescript
 // frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
 // Card fields stay on the device; the BFF never sees them.
+// Step 3 echoes `orderGroup` back to the BFF in the request body so it works
+// the same way whether the BFF runs on one pod or fifty.
 async function placeOrderWithCard(card: CardPaymentInformation) {
   const placeResp = await fetch("/api/bff/order/place", {
     method: "POST",
@@ -1815,6 +1932,8 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
   await fetch("/api/bff/order/process", {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orderGroup }),
   });
 }
 ```
@@ -1861,11 +1980,16 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
       card,
     });
 
-    await fetchJson("/api/bff/order/process", { method: "POST" });
+    await fetchJson("/api/bff/order/process", {
+      method: "POST",
+      body: { orderGroup },
+    });
   }
   ```
 
 - **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
+
+- **Storing `orderGroup` in `req.session` between `/place` and `/process`**: Writing `req.session.pendingOrderGroup` in Step 1 and reading it in Step 3 looks tidy and works in single-process local development. With `express-session`'s default `MemoryStore` (and any per-pod cache) a horizontally scaled BFF loses the value the moment the two requests land on different replicas, so `/process` returns `400 — no pending order to process` while the shopper's card has already been charged in Step 2. Return `orderGroup` from `/place` to the browser and require the browser to send it back in the `/process` body — see the dedicated hard constraint above. Even with a shared session store (Redis, Memcached, database) in place for `orderFormId`/`vtexCookies`, the cross-step handoff still belongs in the request body so the flow stays correct under partial outages, sticky-routing failures, replication lag, and tab refresh.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
@@ -1911,6 +2035,7 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
 - [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
+- [ ] Is `orderGroup` returned by `/place` and sent back by the browser in the `/process` request body, instead of being stashed in `req.session.pendingOrderGroup` between the two BFF calls?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
 ## Reference

--- a/exports/kiro/steering/headless-headless-bff-architecture.md
+++ b/exports/kiro/steering/headless-headless-bff-architecture.md
@@ -281,6 +281,14 @@ app.use(
 );
 app.use(
   session({
+    // Production BFFs are typically multi-replica. Configure a shared session
+    // store (e.g. connect-redis, connect-memcached, a Postgres-backed store)
+    // here — the default MemoryStore is per-pod and silently drops values such
+    // as orderFormId and vtexAuthToken when requests are routed to a different
+    // replica. For ephemeral cross-step values that the browser already sees
+    // (e.g. orderGroup between Step 1 and Step 3 of order placement), prefer
+    // passing them through the request body instead of writing them to the
+    // session — see headless-checkout-proxy.
     secret: process.env.SESSION_SECRET!,
     resave: false,
     saveUninitialized: false,

--- a/exports/kiro/steering/headless-headless-checkout-proxy.md
+++ b/exports/kiro/steering/headless-headless-checkout-proxy.md
@@ -14,48 +14,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](headless-headless-bff-architecture.md))
 - Search API integration (use [`headless-intelligent-search`](headless-headless-intelligent-search.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](headless-headless-caching-strategy.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](payment-payment-pci-security.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -75,7 +83,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -85,10 +97,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -148,7 +271,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -164,7 +289,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -172,7 +297,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -227,7 +352,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -317,7 +443,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -332,7 +458,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -350,7 +478,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -411,14 +539,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -439,22 +576,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -462,7 +597,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -472,78 +606,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -571,59 +719,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 

--- a/exports/kiro/steering/headless-headless-checkout-proxy.md
+++ b/exports/kiro/steering/headless-headless-checkout-proxy.md
@@ -28,6 +28,7 @@ Do not use this skill for:
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
 - Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
+- Pass intermediate flow values such as `orderGroup` between Step 1 (`/place`) and Step 3 (`/process`) **through the request body**, not through `req.session`. Production BFFs are typically multi-replica; `express-session`'s default `MemoryStore` (and any per-pod cache) loses the value when the two requests land on different pods, returning a misleading "no pending order to process" 400. If a shared session store (Redis, Memcached, database) is already required for `orderFormId`/`vtexCookies`, see the Hard constraint below for why the cross-step handoff still belongs in the request body — it stays correct under partial outages, sticky-routing failures, and replay/refresh after a tab reload.
 
 OrderForm attachment endpoints:
 
@@ -301,6 +302,104 @@ async function getCart(): Promise<OrderForm> {
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Multi-step order flow handoffs MUST travel in the request body, not in `req.session`
+
+Values that link `/place` (Step 1) and `/process` (Step 3) — most importantly `orderGroup`, but also any per-attempt `transactionId` or merchant context the frontend needs to echo back — MUST be returned by `/place` to the browser and sent back by the browser in the `/process` request body. The handler MUST NOT rely on `req.session.pendingOrderGroup` (or any per-pod cache) as the only source of truth for the in-flight order.
+
+**Why this matters**
+
+Production BFFs run multiple replicas (Kubernetes deployments, ECS services, lambdas behind an ALB, edge runtimes). `express-session` defaults to `MemoryStore`, which is per-pod, so a session value written on one pod is invisible to every other pod. Even with a shared session store (Redis, DynamoDB, Memcached), Step 1 and Step 3 fire as fast as the user can roundtrip through `vtexpayments.com.br`, so any partial Redis outage, write replication lag, sticky-routing failure, tab refresh, or session regeneration on login surfaces as `400 — no pending order to process`. From the shopper's point of view the order is paid (their card was charged in Step 2) but the storefront reports failure, and support has to reconcile by hand. The 5-minute order processing window leaves no time for retries.
+
+`orderGroup` is not a secret. It already returns to the browser from Step 1 and is required by the direct browser → `vtexpayments.com.br` call in Step 2. Echoing it back in Step 3 is strictly less surface area than session-backed state. Authentication and ownership are still enforced server-side through the session-bound `vtexCookies`, `orderFormId`, and (when present) `vtexAuthToken` — the BFF never trusts `orderGroup` alone.
+
+**Detection**
+
+If you find any of the following in BFF / server-side checkout code, STOP immediately:
+
+- Any read or write of `req.session.pendingOrderGroup`, `req.session.orderGroup`, `req.session.lastTransactionId`, or similar per-flow values written in `/place` and read in `/process`.
+- A `/process` (or `/gatewayCallback`) handler whose only source of `orderGroup` is `req.session`, with no `req.body.orderGroup` fallback or validation.
+- A frontend `placeOrder` flow that calls `/api/bff/order/process` with no body and no `orderGroup`, relying on the BFF to "remember" the order.
+- Comments like "// rely on session to recover orderGroup" or commits that move `orderGroup` from request bodies into the session for "tidiness".
+
+**Correct**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  const orderFormId = req.session.orderFormId;
+  if (!orderFormId) return res.status(400).json({ error: "No active cart" });
+
+  const { data } = await vtexCheckout<PlaceOrderResponse>({
+    path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
+    method: "POST",
+    body: { referenceId: orderFormId },
+    cookies: req.session.vtexCookies || {},
+    userToken: req.session.vtexAuthToken,
+  });
+
+  res.json({
+    account: process.env.VTEX_ACCOUNT,
+    orderId: data.orders[0].orderId,
+    orderGroup: data.orderGroup,
+    transactionId: data.orders[0].transactionData.merchantTransactions[0].transactionId,
+    merchantName: data.orders[0].transactionData.merchantTransactions[0].merchantName,
+  });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.orderFormId;
+  delete req.session.vtexCookies;
+  res.json({ orderGroup, status: "processed" });
+});
+```
+
+The matching browser flow — `/place` returns `orderGroup` and the browser echoes it back in the `/process` body — is shown in the Preferred pattern below.
+
+**Wrong**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  // ... call /transaction ...
+  req.session.pendingOrderGroup = orderGroup;
+  res.json({ account, orderId, orderGroup, transactionId, merchantName });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  // BUG: works in dev with one Node process and MemoryStore, returns
+  // `400 — no pending order to process` the moment the load balancer routes
+  // /place and /process to different replicas.
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.pendingOrderGroup;
+  res.json({ status: "processed" });
+});
 ```
 
 ---
@@ -589,7 +688,11 @@ export const orderRoutes = Router();
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
 
 // POST /api/bff/order/place — Step 1: place order from existing cart.
-// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
+// Returns the data the browser needs to call vtexpayments.com.br directly in
+// Step 2 AND to call /api/bff/order/process in Step 3. The browser is the
+// authority for `orderGroup` between Step 1 and Step 3 — the BFF does NOT
+// stash it in `req.session`, because that would silently break in any
+// multi-replica deployment whose session store is in-memory or sticky-routed.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -618,8 +721,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     const transactionId = merchantTransaction?.transactionId;
     const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    req.session.pendingOrderGroup = orderGroup;
-
     res.json({
       account: VTEX_ACCOUNT,
       orderId,
@@ -635,11 +736,18 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
 
 // POST /api/bff/order/process — Step 3: process gateway callback after the
 // browser has submitted payment data directly to vtexpayments.com.br in Step 2.
-// Carries no card data; safe to run server-side.
+// Carries no card data; safe to run server-side. The browser passes back the
+// same `orderGroup` it received from /place so the handler is stateless across
+// replicas. The BFF still validates ownership through the session-bound
+// orderFormId + checkout cookies before calling VTEX.
 orderRoutes.post("/process", async (req: Request, res: Response) => {
-  const orderGroup = req.session.pendingOrderGroup;
-  if (!orderGroup) {
-    return res.status(400).json({ error: "No pending order to process" });
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
   }
 
   try {
@@ -651,7 +759,6 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 
     delete req.session.orderFormId;
     delete req.session.vtexCookies;
-    delete req.session.pendingOrderGroup;
 
     res.json({ orderGroup, status: "processed" });
   } catch (error) {
@@ -664,6 +771,8 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 ```typescript
 // frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
 // Card fields stay on the device; the BFF never sees them.
+// Step 3 echoes `orderGroup` back to the BFF in the request body so it works
+// the same way whether the BFF runs on one pod or fifty.
 async function placeOrderWithCard(card: CardPaymentInformation) {
   const placeResp = await fetch("/api/bff/order/place", {
     method: "POST",
@@ -690,6 +799,8 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
   await fetch("/api/bff/order/process", {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orderGroup }),
   });
 }
 ```
@@ -736,11 +847,16 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
       card,
     });
 
-    await fetchJson("/api/bff/order/process", { method: "POST" });
+    await fetchJson("/api/bff/order/process", {
+      method: "POST",
+      body: { orderGroup },
+    });
   }
   ```
 
 - **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
+
+- **Storing `orderGroup` in `req.session` between `/place` and `/process`**: Writing `req.session.pendingOrderGroup` in Step 1 and reading it in Step 3 looks tidy and works in single-process local development. With `express-session`'s default `MemoryStore` (and any per-pod cache) a horizontally scaled BFF loses the value the moment the two requests land on different replicas, so `/process` returns `400 — no pending order to process` while the shopper's card has already been charged in Step 2. Return `orderGroup` from `/place` to the browser and require the browser to send it back in the `/process` body — see the dedicated hard constraint above. Even with a shared session store (Redis, Memcached, database) in place for `orderFormId`/`vtexCookies`, the cross-step handoff still belongs in the request body so the flow stays correct under partial outages, sticky-routing failures, replication lag, and tab refresh.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
@@ -786,6 +902,7 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
 - [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
+- [ ] Is `orderGroup` returned by `/place` and sent back by the browser in the `/process` request body, instead of being stashed in `req.session.pendingOrderGroup` between the two BFF calls?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
 ## Reference

--- a/exports/kiro/steering/payment-all.md
+++ b/exports/kiro/steering/payment-all.md
@@ -1078,12 +1078,14 @@ async function cancelPaymentHandler(req: Request, res: Response): Promise<void> 
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](payment-payment-provider-protocol.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](payment-payment-idempotency.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](payment-payment-async-flow.md)
@@ -1111,8 +1113,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -1128,9 +1134,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -1144,8 +1150,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -1154,7 +1164,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -1197,7 +1207,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -1206,9 +1216,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -1223,6 +1237,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -1234,16 +1350,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -1257,15 +1377,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -1286,8 +1410,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -1295,15 +1423,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -1319,8 +1449,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -1365,18 +1499,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -1411,12 +1545,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -1429,21 +1563,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });

--- a/exports/kiro/steering/payment-payment-pci-security.md
+++ b/exports/kiro/steering/payment-payment-pci-security.md
@@ -7,12 +7,14 @@ Apply when handling credit card data, implementing secureProxyUrl flows, or work
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](payment-payment-provider-protocol.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](payment-payment-idempotency.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](payment-payment-async-flow.md)
@@ -40,8 +42,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -57,9 +63,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -73,8 +79,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -83,7 +93,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -126,7 +136,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -135,9 +145,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -152,6 +166,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -163,16 +279,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -186,15 +306,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -215,8 +339,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -224,15 +352,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -248,8 +378,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -294,18 +428,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -340,12 +474,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -358,21 +492,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });

--- a/exports/opencode/headless-bff-architecture/SKILL.md
+++ b/exports/opencode/headless-bff-architecture/SKILL.md
@@ -282,6 +282,14 @@ app.use(
 );
 app.use(
   session({
+    // Production BFFs are typically multi-replica. Configure a shared session
+    // store (e.g. connect-redis, connect-memcached, a Postgres-backed store)
+    // here — the default MemoryStore is per-pod and silently drops values such
+    // as orderFormId and vtexAuthToken when requests are routed to a different
+    // replica. For ephemeral cross-step values that the browser already sees
+    // (e.g. orderGroup between Step 1 and Step 3 of order placement), prefer
+    // passing them through the request body instead of writing them to the
+    // session — see headless-checkout-proxy.
     secret: process.env.SESSION_SECRET!,
     resave: false,
     saveUninitialized: false,

--- a/exports/opencode/headless-checkout-proxy/SKILL.md
+++ b/exports/opencode/headless-checkout-proxy/SKILL.md
@@ -15,48 +15,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](../headless-bff-architecture/SKILL.md))
 - Search API integration (use [`headless-intelligent-search`](../headless-intelligent-search/SKILL.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](../headless-caching-strategy/SKILL.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](../../../payment/skills/payment-pci-security/SKILL.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -76,7 +84,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -86,10 +98,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -149,7 +272,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -165,7 +290,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -173,7 +298,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -228,7 +353,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -318,7 +444,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -333,7 +459,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -351,7 +479,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -412,14 +540,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -440,22 +577,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -463,7 +598,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -473,78 +607,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -572,59 +720,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 

--- a/exports/opencode/headless-checkout-proxy/SKILL.md
+++ b/exports/opencode/headless-checkout-proxy/SKILL.md
@@ -29,6 +29,7 @@ Do not use this skill for:
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
 - Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
+- Pass intermediate flow values such as `orderGroup` between Step 1 (`/place`) and Step 3 (`/process`) **through the request body**, not through `req.session`. Production BFFs are typically multi-replica; `express-session`'s default `MemoryStore` (and any per-pod cache) loses the value when the two requests land on different pods, returning a misleading "no pending order to process" 400. If a shared session store (Redis, Memcached, database) is already required for `orderFormId`/`vtexCookies`, see the Hard constraint below for why the cross-step handoff still belongs in the request body — it stays correct under partial outages, sticky-routing failures, and replay/refresh after a tab reload.
 
 OrderForm attachment endpoints:
 
@@ -302,6 +303,104 @@ async function getCart(): Promise<OrderForm> {
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Multi-step order flow handoffs MUST travel in the request body, not in `req.session`
+
+Values that link `/place` (Step 1) and `/process` (Step 3) — most importantly `orderGroup`, but also any per-attempt `transactionId` or merchant context the frontend needs to echo back — MUST be returned by `/place` to the browser and sent back by the browser in the `/process` request body. The handler MUST NOT rely on `req.session.pendingOrderGroup` (or any per-pod cache) as the only source of truth for the in-flight order.
+
+**Why this matters**
+
+Production BFFs run multiple replicas (Kubernetes deployments, ECS services, lambdas behind an ALB, edge runtimes). `express-session` defaults to `MemoryStore`, which is per-pod, so a session value written on one pod is invisible to every other pod. Even with a shared session store (Redis, DynamoDB, Memcached), Step 1 and Step 3 fire as fast as the user can roundtrip through `vtexpayments.com.br`, so any partial Redis outage, write replication lag, sticky-routing failure, tab refresh, or session regeneration on login surfaces as `400 — no pending order to process`. From the shopper's point of view the order is paid (their card was charged in Step 2) but the storefront reports failure, and support has to reconcile by hand. The 5-minute order processing window leaves no time for retries.
+
+`orderGroup` is not a secret. It already returns to the browser from Step 1 and is required by the direct browser → `vtexpayments.com.br` call in Step 2. Echoing it back in Step 3 is strictly less surface area than session-backed state. Authentication and ownership are still enforced server-side through the session-bound `vtexCookies`, `orderFormId`, and (when present) `vtexAuthToken` — the BFF never trusts `orderGroup` alone.
+
+**Detection**
+
+If you find any of the following in BFF / server-side checkout code, STOP immediately:
+
+- Any read or write of `req.session.pendingOrderGroup`, `req.session.orderGroup`, `req.session.lastTransactionId`, or similar per-flow values written in `/place` and read in `/process`.
+- A `/process` (or `/gatewayCallback`) handler whose only source of `orderGroup` is `req.session`, with no `req.body.orderGroup` fallback or validation.
+- A frontend `placeOrder` flow that calls `/api/bff/order/process` with no body and no `orderGroup`, relying on the BFF to "remember" the order.
+- Comments like "// rely on session to recover orderGroup" or commits that move `orderGroup` from request bodies into the session for "tidiness".
+
+**Correct**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  const orderFormId = req.session.orderFormId;
+  if (!orderFormId) return res.status(400).json({ error: "No active cart" });
+
+  const { data } = await vtexCheckout<PlaceOrderResponse>({
+    path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
+    method: "POST",
+    body: { referenceId: orderFormId },
+    cookies: req.session.vtexCookies || {},
+    userToken: req.session.vtexAuthToken,
+  });
+
+  res.json({
+    account: process.env.VTEX_ACCOUNT,
+    orderId: data.orders[0].orderId,
+    orderGroup: data.orderGroup,
+    transactionId: data.orders[0].transactionData.merchantTransactions[0].transactionId,
+    merchantName: data.orders[0].transactionData.merchantTransactions[0].merchantName,
+  });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.orderFormId;
+  delete req.session.vtexCookies;
+  res.json({ orderGroup, status: "processed" });
+});
+```
+
+The matching browser flow — `/place` returns `orderGroup` and the browser echoes it back in the `/process` body — is shown in the Preferred pattern below.
+
+**Wrong**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  // ... call /transaction ...
+  req.session.pendingOrderGroup = orderGroup;
+  res.json({ account, orderId, orderGroup, transactionId, merchantName });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  // BUG: works in dev with one Node process and MemoryStore, returns
+  // `400 — no pending order to process` the moment the load balancer routes
+  // /place and /process to different replicas.
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.pendingOrderGroup;
+  res.json({ status: "processed" });
+});
 ```
 
 ---
@@ -590,7 +689,11 @@ export const orderRoutes = Router();
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
 
 // POST /api/bff/order/place — Step 1: place order from existing cart.
-// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
+// Returns the data the browser needs to call vtexpayments.com.br directly in
+// Step 2 AND to call /api/bff/order/process in Step 3. The browser is the
+// authority for `orderGroup` between Step 1 and Step 3 — the BFF does NOT
+// stash it in `req.session`, because that would silently break in any
+// multi-replica deployment whose session store is in-memory or sticky-routed.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -619,8 +722,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     const transactionId = merchantTransaction?.transactionId;
     const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    req.session.pendingOrderGroup = orderGroup;
-
     res.json({
       account: VTEX_ACCOUNT,
       orderId,
@@ -636,11 +737,18 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
 
 // POST /api/bff/order/process — Step 3: process gateway callback after the
 // browser has submitted payment data directly to vtexpayments.com.br in Step 2.
-// Carries no card data; safe to run server-side.
+// Carries no card data; safe to run server-side. The browser passes back the
+// same `orderGroup` it received from /place so the handler is stateless across
+// replicas. The BFF still validates ownership through the session-bound
+// orderFormId + checkout cookies before calling VTEX.
 orderRoutes.post("/process", async (req: Request, res: Response) => {
-  const orderGroup = req.session.pendingOrderGroup;
-  if (!orderGroup) {
-    return res.status(400).json({ error: "No pending order to process" });
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
   }
 
   try {
@@ -652,7 +760,6 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 
     delete req.session.orderFormId;
     delete req.session.vtexCookies;
-    delete req.session.pendingOrderGroup;
 
     res.json({ orderGroup, status: "processed" });
   } catch (error) {
@@ -665,6 +772,8 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 ```typescript
 // frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
 // Card fields stay on the device; the BFF never sees them.
+// Step 3 echoes `orderGroup` back to the BFF in the request body so it works
+// the same way whether the BFF runs on one pod or fifty.
 async function placeOrderWithCard(card: CardPaymentInformation) {
   const placeResp = await fetch("/api/bff/order/place", {
     method: "POST",
@@ -691,6 +800,8 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
   await fetch("/api/bff/order/process", {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orderGroup }),
   });
 }
 ```
@@ -737,11 +848,16 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
       card,
     });
 
-    await fetchJson("/api/bff/order/process", { method: "POST" });
+    await fetchJson("/api/bff/order/process", {
+      method: "POST",
+      body: { orderGroup },
+    });
   }
   ```
 
 - **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
+
+- **Storing `orderGroup` in `req.session` between `/place` and `/process`**: Writing `req.session.pendingOrderGroup` in Step 1 and reading it in Step 3 looks tidy and works in single-process local development. With `express-session`'s default `MemoryStore` (and any per-pod cache) a horizontally scaled BFF loses the value the moment the two requests land on different replicas, so `/process` returns `400 — no pending order to process` while the shopper's card has already been charged in Step 2. Return `orderGroup` from `/place` to the browser and require the browser to send it back in the `/process` body — see the dedicated hard constraint above. Even with a shared session store (Redis, Memcached, database) in place for `orderFormId`/`vtexCookies`, the cross-step handoff still belongs in the request body so the flow stays correct under partial outages, sticky-routing failures, replication lag, and tab refresh.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
@@ -787,6 +903,7 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
 - [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
+- [ ] Is `orderGroup` returned by `/place` and sent back by the browser in the `/process` request body, instead of being stashed in `req.session.pendingOrderGroup` between the two BFF calls?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
 ## Reference

--- a/exports/opencode/payment-pci-security/SKILL.md
+++ b/exports/opencode/payment-pci-security/SKILL.md
@@ -8,12 +8,14 @@ description: "Apply when handling credit card data, implementing secureProxyUrl 
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](../payment-provider-protocol/SKILL.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](../payment-idempotency/SKILL.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](../payment-async-flow/SKILL.md)
@@ -41,8 +43,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -58,9 +64,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -74,8 +80,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -84,7 +94,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -127,7 +137,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -136,9 +146,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -153,6 +167,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -164,16 +280,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -187,15 +307,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -216,8 +340,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -225,15 +353,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -249,8 +379,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -295,18 +429,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -341,12 +475,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -359,21 +493,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });

--- a/tracks/headless/skills/headless-bff-architecture/skill.md
+++ b/tracks/headless/skills/headless-bff-architecture/skill.md
@@ -317,6 +317,14 @@ app.use(
 );
 app.use(
   session({
+    // Production BFFs are typically multi-replica. Configure a shared session
+    // store (e.g. connect-redis, connect-memcached, a Postgres-backed store)
+    // here — the default MemoryStore is per-pod and silently drops values such
+    // as orderFormId and vtexAuthToken when requests are routed to a different
+    // replica. For ephemeral cross-step values that the browser already sees
+    // (e.g. orderGroup between Step 1 and Step 3 of order placement), prefer
+    // passing them through the request body instead of writing them to the
+    // session — see headless-checkout-proxy.
     secret: process.env.SESSION_SECRET!,
     resave: false,
     saveUninitialized: false,

--- a/tracks/headless/skills/headless-checkout-proxy/skill.md
+++ b/tracks/headless/skills/headless-checkout-proxy/skill.md
@@ -49,48 +49,56 @@ Use this skill when building cart and checkout functionality for any headless VT
 - Managing `orderFormId` and `CheckoutOrderFormOwnership` cookies server-side
 
 Do not use this skill for:
+
 - General BFF architecture and API routing (use [`headless-bff-architecture`](../headless-bff-architecture/skill.md))
 - Search API integration (use [`headless-intelligent-search`](../headless-intelligent-search/skill.md))
 - Caching strategy decisions (use [`headless-caching-strategy`](../headless-caching-strategy/skill.md))
 
 ## Decision rules
 
-- ALL Checkout API calls MUST be proxied through the BFF — no exceptions. The Checkout API handles sensitive personal data (profile, address, payment).
+- ALL Checkout API calls (`/api/checkout/...` on `vtexcommercestable.com.br`) MUST be proxied through the BFF. The Checkout API handles sensitive personal data (profile, address, payment-method selection).
+- **PCI carve-out:** the Send payments information call to the VTEX Payment Gateway (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST go directly from the browser/app to `vtexpayments.com.br` whenever it carries card data. The merchant BFF MUST NOT be in the card-data path. See the dedicated hard constraint below and [`payment-pci-security`](../../../payment/skills/payment-pci-security/skill.md).
 - Store `orderFormId` in a server-side session, never in `localStorage` or `sessionStorage`.
 - Capture and forward `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies between the BFF and VTEX on every request.
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
-- Execute the 3-step order placement flow (place order → send payment → process order) in a single synchronous BFF handler to stay within the **5-minute window**.
+- Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
 
 OrderForm attachment endpoints:
 
-| Attachment | Endpoint | Purpose |
-|---|---|---|
-| items | `POST .../orderForm/{id}/items` | Add, remove, or update cart items |
-| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info |
-| shippingData | `POST .../orderForm/{id}/attachments/shippingData` | Address and delivery option |
-| paymentData | `POST .../orderForm/{id}/attachments/paymentData` | Payment method selection |
-| marketingData | `POST .../orderForm/{id}/attachments/marketingData` | Coupons and UTM data |
+| Attachment        | Endpoint                                                | Purpose                           |
+| ----------------- | ------------------------------------------------------- | --------------------------------- |
+| items             | `POST .../orderForm/{id}/items`                         | Add, remove, or update cart items |
+| clientProfileData | `POST .../orderForm/{id}/attachments/clientProfileData` | Customer profile info             |
+| shippingData      | `POST .../orderForm/{id}/attachments/shippingData`      | Address and delivery option       |
+| paymentData       | `POST .../orderForm/{id}/attachments/paymentData`       | Payment method selection          |
+| marketingData     | `POST .../orderForm/{id}/attachments/marketingData`     | Coupons and UTM data              |
 
 ## Hard constraints
 
-### Constraint: ALL checkout operations MUST go through BFF
+### Constraint: ALL Checkout API operations MUST go through BFF
 
-Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint (`/api/checkout/`). All checkout operations — cart creation, item management, profile updates, shipping, payment, and order placement — must be proxied through the BFF layer.
+Client-side code MUST NOT make direct HTTP requests to any VTEX Checkout API endpoint on `vtexcommercestable.com.br/api/checkout/...`. All Checkout API operations — cart creation, item management, profile updates, shipping, payment-method selection (`paymentData` attachment), order placement (`/transaction`), and order processing (`/gatewayCallback`) — must be proxied through the BFF.
+
+This rule applies to the Checkout API only. The Send payments information call on `vtexpayments.com.br` is governed by the next constraint and goes the opposite way (browser-direct) for PCI reasons; do not generalize this rule to that endpoint.
 
 **Why this matters**
 
-Checkout endpoints handle sensitive personal data (email, address, phone, payment details). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
+Checkout endpoints handle sensitive personal data (email, address, phone, payment-method selection). Direct frontend calls expose the request/response flow to browser DevTools, extensions, and XSS attacks. Additionally, the BFF layer is needed to manage `VtexIdclientAutCookie` and `CheckoutOrderFormOwnership` cookies server-side, validate inputs, and prevent cart manipulation (e.g., price tampering).
 
 **Detection**
 
-If you see `fetch` or `axios` calls to `/api/checkout/` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All checkout calls must route through BFF endpoints.
+If you see `fetch` or `axios` calls to `vtexcommercestable.com.br/api/checkout/...` in any client-side code (browser-executed JavaScript, frontend source files) → STOP immediately. All Checkout API calls must route through BFF endpoints.
 
 **Correct**
 
 ```typescript
 // Frontend — calls BFF endpoint, never VTEX directly
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const response = await fetch("/api/bff/cart/items", {
     method: "POST",
     credentials: "include",
@@ -110,7 +118,11 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
 
 ```typescript
 // Frontend — calls VTEX Checkout API directly (SECURITY VULNERABILITY)
-async function addItemToCart(skuId: string, quantity: number, seller: string): Promise<OrderForm> {
+async function addItemToCart(
+  skuId: string,
+  quantity: number,
+  seller: string,
+): Promise<OrderForm> {
   const orderFormId = localStorage.getItem("orderFormId"); // Also wrong: see next constraint
   const response = await fetch(
     `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}/items`,
@@ -120,10 +132,121 @@ async function addItemToCart(skuId: string, quantity: number, seller: string): P
       body: JSON.stringify({
         orderItems: [{ id: skuId, quantity, seller }],
       }),
-    }
+    },
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Card data MUST go directly from browser/app to vtexpayments.com.br — never through the BFF
+
+The Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments?orderId={orderGroup}`) carries card data when the shopper pays with a credit, debit, or co-branded card. This call MUST originate from the shopper's browser or native app and MUST target `vtexpayments.com.br` directly. The BFF MUST NOT proxy this call when card data is involved, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This is the inverse of the previous constraint. Treating it as a generic "checkout" call and routing it through the BFF — as some agents do when applying the "all checkout through BFF" rule too broadly — is a PCI DSS violation, not a security improvement.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches — application logs, APM/observability tools, reverse proxies, load balancers, error trackers — inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, and legal liability.
+
+The browser → `vtexpayments.com.br` path is the PCI-compliant pattern: the VTEX Payment Gateway is PCI DSS Level 1 certified and is the only environment in this flow authorized to receive raw card data. The Send payments call is authenticated by the shopper's session cookies set by the previous Place Order step — no merchant credentials are needed on the BFF for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser and forwards them to any VTEX endpoint,
+- A "Payments client" / `ExternalClient` / `axios` instance that targets `vtexpayments.com.br` for the Send payments information endpoint.
+
+Move that call to the browser/app. The BFF should instead return `transactionId`, `orderGroup`, and `merchantName` from the Place Order step so the frontend can post payment data directly to the Payment Gateway.
+
+This rule applies even when:
+
+- The merchant has a VTEX `appKey`/`appToken` with payment permissions — possessing the credentials does not grant PCI authorization.
+- Only "tokenized" card fields are forwarded — token values still reference real card data and are in PCI scope.
+- The BFF code "redacts" sensitive fields before logging — the request still transits the merchant infrastructure before redaction.
+- The BFF runs on a private VPC with TLS — PCI scope is determined by what data passes through, not by how the network is configured.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
 ```
 
 ---
@@ -183,7 +306,9 @@ cartRoutes.get("/", async (req: Request, res: Response) => {
 });
 
 // Remove sensitive data before sending to frontend
-function sanitizeOrderForm(orderForm: Record<string, unknown>): Record<string, unknown> {
+function sanitizeOrderForm(
+  orderForm: Record<string, unknown>,
+): Record<string, unknown> {
   const sanitized = { ...orderForm };
   delete sanitized._cookies;
   return sanitized;
@@ -199,7 +324,7 @@ async function getCart(): Promise<OrderForm> {
 
   if (!orderFormId) {
     const response = await fetch(
-      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm"
+      "https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm",
     );
     const data = await response.json();
     orderFormId = data.orderFormId;
@@ -207,7 +332,7 @@ async function getCart(): Promise<OrderForm> {
   }
 
   const response = await fetch(
-    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`
+    `https://mystore.vtexcommercestable.com.br/api/checkout/pub/orderForm/${orderFormId}`,
   );
   return response.json();
 }
@@ -262,7 +387,8 @@ cartItemsRoutes.post("/", async (req: Request, res: Response) => {
   if (!validateAddItemInput(req.body)) {
     return res.status(400).json({
       error: "Invalid input",
-      details: "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
+      details:
+        "skuId must be numeric, quantity must be 1-100, seller must be alphanumeric",
     });
   }
 
@@ -352,7 +478,7 @@ interface CheckoutResponse<T = unknown> {
 }
 
 export async function vtexCheckout<T>(
-  options: CheckoutRequestOptions
+  options: CheckoutRequestOptions,
 ): Promise<CheckoutResponse<T>> {
   const { path, method = "GET", body, cookies = {}, userToken } = options;
 
@@ -367,7 +493,9 @@ export async function vtexCheckout<T>(
     cookieParts.push(`checkout.vtex.com=${cookies["checkout.vtex.com"]}`);
   }
   if (cookies["CheckoutOrderFormOwnership"]) {
-    cookieParts.push(`CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`);
+    cookieParts.push(
+      `CheckoutOrderFormOwnership=${cookies["CheckoutOrderFormOwnership"]}`,
+    );
   }
   if (userToken) {
     cookieParts.push(`VtexIdclientAutCookie=${userToken}`);
@@ -385,7 +513,7 @@ export async function vtexCheckout<T>(
   if (!response.ok) {
     const errorBody = await response.text();
     throw new Error(
-      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`
+      `Checkout API error: ${response.status} for ${method} ${path}: ${errorBody}`,
     );
   }
 
@@ -446,14 +574,23 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
   }
 
   for (const item of items) {
-    if (!item.id || typeof item.quantity !== "number" || item.quantity < 1 || !item.seller) {
-      return res.status(400).json({ error: "Each item must have id, quantity (>0), and seller" });
+    if (
+      !item.id ||
+      typeof item.quantity !== "number" ||
+      item.quantity < 1 ||
+      !item.seller
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Each item must have id, quantity (>0), and seller" });
     }
   }
 
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
-    return res.status(400).json({ error: "No active cart. Call GET /api/bff/cart first." });
+    return res
+      .status(400)
+      .json({ error: "No active cart. Call GET /api/bff/cart first." });
   }
 
   try {
@@ -474,22 +611,20 @@ cartRoutes.post("/items", async (req: Request, res: Response) => {
 });
 ```
 
-Order placement — all 3 steps in a single handler to respect the **5-minute window**:
+Order placement — Steps 1 and 3 run in the BFF; Step 2 runs in the browser per the PCI carve-out. All 3 steps must complete within the **5-minute window**.
 
 ```typescript
-// server/routes/order.ts
+// server/routes/order.ts — BFF handles Step 1 (place) and Step 3 (process) only.
+// Step 2 (send payment data) runs in the browser; see the card-data carve-out constraint.
 import { Router, Request, Response } from "express";
 import { vtexCheckout } from "../vtex-checkout-client";
 
 export const orderRoutes = Router();
 
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
-const VTEX_ENVIRONMENT = process.env.VTEX_ENVIRONMENT || "vtexcommercestable";
-const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
-const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
 
-// POST /api/bff/order/place — place order from existing cart
-// CRITICAL: All 3 steps must complete within 5 minutes or the order is canceled
+// POST /api/bff/order/place — Step 1: place order from existing cart.
+// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -497,7 +632,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   }
 
   try {
-    // Step 1: Place order — starts the 5-minute timer
     const placeResult = await vtexCheckout<PlaceOrderResponse>({
       path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
       method: "POST",
@@ -507,78 +641,92 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     });
 
     const { orders, orderGroup } = placeResult.data;
-
-    if (!orders || orders.length === 0) {
-      return res.status(500).json({ error: "Order placement returned no orders" });
+    if (!orders?.length) {
+      return res
+        .status(500)
+        .json({ error: "Order placement returned no orders" });
     }
 
     const orderId = orders[0].orderId;
-    const transactionId =
-      orders[0].transactionData.merchantTransactions[0]?.transactionId;
+    const merchantTransaction =
+      orders[0].transactionData.merchantTransactions[0];
+    const transactionId = merchantTransaction?.transactionId;
+    const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    // Step 2: Send payment — immediately after placement
-    const { paymentData } = req.body as {
-      paymentData: {
-        paymentSystem: number;
-        installments: number;
-        value: number;
-        referenceValue: number;
-      };
-    };
-
-    if (!paymentData) {
-      return res.status(400).json({ error: "Payment data is required" });
-    }
-
-    const paymentUrl = `https://${VTEX_ACCOUNT}.${VTEX_ENVIRONMENT}.com.br/api/payments/transactions/${transactionId}/payments`;
-    const paymentResponse = await fetch(paymentUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-VTEX-API-AppKey": VTEX_APP_KEY,
-        "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
-      },
-      body: JSON.stringify([
-        {
-          paymentSystem: paymentData.paymentSystem,
-          installments: paymentData.installments,
-          currencyCode: "BRL",
-          value: paymentData.value,
-          installmentsInterestRate: 0,
-          installmentsValue: paymentData.value,
-          referenceValue: paymentData.referenceValue,
-          fields: {},
-          transaction: { id: transactionId, merchantName: VTEX_ACCOUNT },
-        },
-      ]),
-    });
-
-    if (!paymentResponse.ok) {
-      return res.status(500).json({ error: "Payment submission failed" });
-    }
-
-    // Step 3: Process order — immediately after payment
-    await vtexCheckout<unknown>({
-      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
-      method: "POST",
-      cookies: req.session.vtexCookies || {},
-    });
-
-    // Clear cart session after successful order
-    delete req.session.orderFormId;
-    delete req.session.vtexCookies;
+    req.session.pendingOrderGroup = orderGroup;
 
     res.json({
+      account: VTEX_ACCOUNT,
       orderId,
       orderGroup,
       transactionId,
-      status: "placed",
+      merchantName,
     });
   } catch (error) {
     console.error("Error placing order:", error);
     res.status(500).json({ error: "Failed to place order" });
   }
 });
+
+// POST /api/bff/order/process — Step 3: process gateway callback after the
+// browser has submitted payment data directly to vtexpayments.com.br in Step 2.
+// Carries no card data; safe to run server-side.
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  try {
+    await vtexCheckout<unknown>({
+      path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+      method: "POST",
+      cookies: req.session.vtexCookies || {},
+    });
+
+    delete req.session.orderFormId;
+    delete req.session.vtexCookies;
+    delete req.session.pendingOrderGroup;
+
+    res.json({ orderGroup, status: "processed" });
+  } catch (error) {
+    console.error("Error processing order:", error);
+    res.status(500).json({ error: "Failed to process order" });
+  }
+});
+```
+
+```typescript
+// frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
+// Card fields stay on the device; the BFF never sees them.
+async function placeOrderWithCard(card: CardPaymentInformation) {
+  const placeResp = await fetch("/api/bff/order/place", {
+    method: "POST",
+    credentials: "include",
+  });
+  const { account, orderGroup, transactionId, merchantName } =
+    await placeResp.json();
+
+  await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        { ...card, transaction: { id: transactionId, merchantName } },
+      ]),
+    },
+  );
+
+  await fetch("/api/bff/order/process", {
+    method: "POST",
+    credentials: "include",
+  });
+}
 ```
 
 ## Common failure modes
@@ -606,59 +754,72 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
   });
   ```
 
-- **Ignoring the 5-minute order processing window**: Placing an order (step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute all three steps (place order → send payment → process order) sequentially and immediately in a single BFF request handler. Never split these across multiple independent frontend calls.
+- **Ignoring the 5-minute order processing window**: Placing an order (Step 1) but delaying payment or processing beyond 5 minutes causes VTEX to automatically cancel the order as `incomplete`. Execute Steps 1 → 2 → 3 sequentially and immediately as a single user interaction. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data) runs in the browser per the card-data carve-out above. Do not pause for additional UI between steps.
 
   ```typescript
-  // Execute all 3 steps in a single, synchronous flow
-  orderRoutes.post("/place", async (req: Request, res: Response) => {
-    try {
-      // Step 1: Place order — starts the 5-minute timer
-      const placeResult = await vtexCheckout<PlaceOrderResponse>({
-        path: `/api/checkout/pub/orderForm/${req.session.orderFormId}/transaction`,
-        method: "POST",
-        body: { referenceId: req.session.orderFormId },
-        cookies: req.session.vtexCookies || {},
-      });
+  // Frontend orchestrates Place (BFF) → Pay (browser → vtexpayments.com.br) → Process (BFF)
+  // on a single click, well within the 5-minute window.
+  async function onPlaceOrderClick(card: CardPaymentInformation) {
+    const { account, orderGroup, transactionId, merchantName } =
+      await fetchJson("/api/bff/order/place", { method: "POST" });
 
-      // Step 2: Send payment — immediately after placement
-      await sendPayment(placeResult.data);
+    await sendPaymentDirectToGateway({
+      account,
+      transactionId,
+      orderGroup,
+      merchantName,
+      card,
+    });
 
-      // Step 3: Process order — immediately after payment
-      await processOrder(placeResult.data.orderGroup);
-
-      res.json({ success: true, orderId: placeResult.data.orders[0].orderId });
-    } catch (error) {
-      console.error("Order placement failed:", error);
-      res.status(500).json({ error: "Order placement failed" });
-    }
-  });
+    await fetchJson("/api/bff/order/process", { method: "POST" });
+  }
   ```
+
+- **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
   ```typescript
   // Map VTEX errors to safe, user-friendly messages
-  function mapCheckoutError(vtexError: string, statusCode: number): { code: string; message: string } {
+  function mapCheckoutError(
+    vtexError: string,
+    statusCode: number,
+  ): { code: string; message: string } {
     if (statusCode === 400 && vtexError.includes("item")) {
-      return { code: "INVALID_ITEM", message: "One or more items are unavailable" };
+      return {
+        code: "INVALID_ITEM",
+        message: "One or more items are unavailable",
+      };
     }
     if (statusCode === 400 && vtexError.includes("address")) {
-      return { code: "INVALID_ADDRESS", message: "Please check your shipping address" };
+      return {
+        code: "INVALID_ADDRESS",
+        message: "Please check your shipping address",
+      };
     }
     if (statusCode === 409) {
-      return { code: "CART_CONFLICT", message: "Your cart was updated. Please review your items." };
+      return {
+        code: "CART_CONFLICT",
+        message: "Your cart was updated. Please review your items.",
+      };
     }
-    return { code: "CHECKOUT_ERROR", message: "An error occurred during checkout. Please try again." };
+    return {
+      code: "CHECKOUT_ERROR",
+      message: "An error occurred during checkout. Please try again.",
+    };
   }
   ```
 
 ## Review checklist
 
-- [ ] Are ALL checkout API calls routed through the BFF (no direct frontend calls to `/api/checkout/`)?
+- [ ] Are ALL Checkout API calls (`vtexcommercestable.com.br/api/checkout/...`) routed through the BFF (no direct frontend calls)?
+- [ ] Is the Send payments information call (`vtexpayments.com.br/api/pub/transactions/{tid}/payments`) sent from the browser/app directly, NOT proxied through the BFF, when card data is involved?
+- [ ] Are `cardNumber`, `holderName`, `validationCode`/`csc`, and `dueDate` absent from every BFF route handler and log statement?
+- [ ] Does any reference to `vtexpayments.com.br` in the codebase appear only in browser/app code, never in `server/`, `bff/`, `api/`, or other backend directories?
 - [ ] Is `orderFormId` stored in a server-side session, not in `localStorage` or `sessionStorage`?
 - [ ] Are `CheckoutOrderFormOwnership` and `checkout.vtex.com` cookies captured from VTEX responses and forwarded on subsequent requests?
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
-- [ ] Does the order placement handler execute all 3 steps (place → pay → process) in a single synchronous flow within the 5-minute window?
+- [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 

--- a/tracks/headless/skills/headless-checkout-proxy/skill.md
+++ b/tracks/headless/skills/headless-checkout-proxy/skill.md
@@ -34,7 +34,7 @@ metadata:
     - orderform-session-management
     - checkout-cookie-handling
     - order-placement-flow-design
-  vtex_docs_verified: "2026-03-16"
+  vtex_docs_verified: "2026-05-12"
 ---
 
 # Checkout API Proxy & OrderForm Management
@@ -63,6 +63,7 @@ Do not use this skill for:
 - Validate all inputs server-side before forwarding to VTEX — never pass raw `req.body` directly.
 - Execute the 3-step order placement flow (place order → send payment → process order) as a single synchronous user interaction within the **5-minute window**. Step 1 (place) and Step 3 (gateway callback) run in the BFF; Step 2 (send payment data to `vtexpayments.com.br`) runs in the browser per the PCI carve-out above.
 - Always store and reuse the existing `orderFormId` from the session — only create a new cart when no `orderFormId` exists.
+- Pass intermediate flow values such as `orderGroup` between Step 1 (`/place`) and Step 3 (`/process`) **through the request body**, not through `req.session`. Production BFFs are typically multi-replica; `express-session`'s default `MemoryStore` (and any per-pod cache) loses the value when the two requests land on different pods, returning a misleading "no pending order to process" 400. If a shared session store (Redis, Memcached, database) is already required for `orderFormId`/`vtexCookies`, see the Hard constraint below for why the cross-step handoff still belongs in the request body — it stays correct under partial outages, sticky-routing failures, and replay/refresh after a tab reload.
 
 OrderForm attachment endpoints:
 
@@ -336,6 +337,104 @@ async function getCart(): Promise<OrderForm> {
   );
   return response.json();
 }
+```
+
+---
+
+### Constraint: Multi-step order flow handoffs MUST travel in the request body, not in `req.session`
+
+Values that link `/place` (Step 1) and `/process` (Step 3) — most importantly `orderGroup`, but also any per-attempt `transactionId` or merchant context the frontend needs to echo back — MUST be returned by `/place` to the browser and sent back by the browser in the `/process` request body. The handler MUST NOT rely on `req.session.pendingOrderGroup` (or any per-pod cache) as the only source of truth for the in-flight order.
+
+**Why this matters**
+
+Production BFFs run multiple replicas (Kubernetes deployments, ECS services, lambdas behind an ALB, edge runtimes). `express-session` defaults to `MemoryStore`, which is per-pod, so a session value written on one pod is invisible to every other pod. Even with a shared session store (Redis, DynamoDB, Memcached), Step 1 and Step 3 fire as fast as the user can roundtrip through `vtexpayments.com.br`, so any partial Redis outage, write replication lag, sticky-routing failure, tab refresh, or session regeneration on login surfaces as `400 — no pending order to process`. From the shopper's point of view the order is paid (their card was charged in Step 2) but the storefront reports failure, and support has to reconcile by hand. The 5-minute order processing window leaves no time for retries.
+
+`orderGroup` is not a secret. It already returns to the browser from Step 1 and is required by the direct browser → `vtexpayments.com.br` call in Step 2. Echoing it back in Step 3 is strictly less surface area than session-backed state. Authentication and ownership are still enforced server-side through the session-bound `vtexCookies`, `orderFormId`, and (when present) `vtexAuthToken` — the BFF never trusts `orderGroup` alone.
+
+**Detection**
+
+If you find any of the following in BFF / server-side checkout code, STOP immediately:
+
+- Any read or write of `req.session.pendingOrderGroup`, `req.session.orderGroup`, `req.session.lastTransactionId`, or similar per-flow values written in `/place` and read in `/process`.
+- A `/process` (or `/gatewayCallback`) handler whose only source of `orderGroup` is `req.session`, with no `req.body.orderGroup` fallback or validation.
+- A frontend `placeOrder` flow that calls `/api/bff/order/process` with no body and no `orderGroup`, relying on the BFF to "remember" the order.
+- Comments like "// rely on session to recover orderGroup" or commits that move `orderGroup` from request bodies into the session for "tidiness".
+
+**Correct**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  const orderFormId = req.session.orderFormId;
+  if (!orderFormId) return res.status(400).json({ error: "No active cart" });
+
+  const { data } = await vtexCheckout<PlaceOrderResponse>({
+    path: `/api/checkout/pub/orderForm/${orderFormId}/transaction`,
+    method: "POST",
+    body: { referenceId: orderFormId },
+    cookies: req.session.vtexCookies || {},
+    userToken: req.session.vtexAuthToken,
+  });
+
+  res.json({
+    account: process.env.VTEX_ACCOUNT,
+    orderId: data.orders[0].orderId,
+    orderGroup: data.orderGroup,
+    transactionId: data.orders[0].transactionData.merchantTransactions[0].transactionId,
+    merchantName: data.orders[0].transactionData.merchantTransactions[0].merchantName,
+  });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.orderFormId;
+  delete req.session.vtexCookies;
+  res.json({ orderGroup, status: "processed" });
+});
+```
+
+The matching browser flow — `/place` returns `orderGroup` and the browser echoes it back in the `/process` body — is shown in the Preferred pattern below.
+
+**Wrong**
+
+```typescript
+orderRoutes.post("/place", async (req: Request, res: Response) => {
+  // ... call /transaction ...
+  req.session.pendingOrderGroup = orderGroup;
+  res.json({ account, orderId, orderGroup, transactionId, merchantName });
+});
+
+orderRoutes.post("/process", async (req: Request, res: Response) => {
+  // BUG: works in dev with one Node process and MemoryStore, returns
+  // `400 — no pending order to process` the moment the load balancer routes
+  // /place and /process to different replicas.
+  const orderGroup = req.session.pendingOrderGroup;
+  if (!orderGroup) {
+    return res.status(400).json({ error: "No pending order to process" });
+  }
+
+  await vtexCheckout({
+    path: `/api/checkout/pub/gatewayCallback/${orderGroup}`,
+    method: "POST",
+    cookies: req.session.vtexCookies || {},
+  });
+
+  delete req.session.pendingOrderGroup;
+  res.json({ status: "processed" });
+});
 ```
 
 ---
@@ -624,7 +723,11 @@ export const orderRoutes = Router();
 const VTEX_ACCOUNT = process.env.VTEX_ACCOUNT!;
 
 // POST /api/bff/order/place — Step 1: place order from existing cart.
-// Returns the data the browser needs to call vtexpayments.com.br directly in Step 2.
+// Returns the data the browser needs to call vtexpayments.com.br directly in
+// Step 2 AND to call /api/bff/order/process in Step 3. The browser is the
+// authority for `orderGroup` between Step 1 and Step 3 — the BFF does NOT
+// stash it in `req.session`, because that would silently break in any
+// multi-replica deployment whose session store is in-memory or sticky-routed.
 orderRoutes.post("/place", async (req: Request, res: Response) => {
   const orderFormId = req.session.orderFormId;
   if (!orderFormId) {
@@ -653,8 +756,6 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
     const transactionId = merchantTransaction?.transactionId;
     const merchantName = merchantTransaction?.merchantName ?? VTEX_ACCOUNT;
 
-    req.session.pendingOrderGroup = orderGroup;
-
     res.json({
       account: VTEX_ACCOUNT,
       orderId,
@@ -670,11 +771,18 @@ orderRoutes.post("/place", async (req: Request, res: Response) => {
 
 // POST /api/bff/order/process — Step 3: process gateway callback after the
 // browser has submitted payment data directly to vtexpayments.com.br in Step 2.
-// Carries no card data; safe to run server-side.
+// Carries no card data; safe to run server-side. The browser passes back the
+// same `orderGroup` it received from /place so the handler is stateless across
+// replicas. The BFF still validates ownership through the session-bound
+// orderFormId + checkout cookies before calling VTEX.
 orderRoutes.post("/process", async (req: Request, res: Response) => {
-  const orderGroup = req.session.pendingOrderGroup;
-  if (!orderGroup) {
-    return res.status(400).json({ error: "No pending order to process" });
+  const orderGroup =
+    typeof req.body?.orderGroup === "string" ? req.body.orderGroup : undefined;
+  if (!orderGroup || !/^[A-Za-z0-9-]+$/.test(orderGroup)) {
+    return res.status(400).json({ error: "Missing or invalid orderGroup" });
+  }
+  if (!req.session.orderFormId) {
+    return res.status(400).json({ error: "No active checkout session" });
   }
 
   try {
@@ -686,7 +794,6 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 
     delete req.session.orderFormId;
     delete req.session.vtexCookies;
-    delete req.session.pendingOrderGroup;
 
     res.json({ orderGroup, status: "processed" });
   } catch (error) {
@@ -699,6 +806,8 @@ orderRoutes.post("/process", async (req: Request, res: Response) => {
 ```typescript
 // frontend/checkout/placeOrder.ts — Step 2 runs in the browser.
 // Card fields stay on the device; the BFF never sees them.
+// Step 3 echoes `orderGroup` back to the BFF in the request body so it works
+// the same way whether the BFF runs on one pod or fifty.
 async function placeOrderWithCard(card: CardPaymentInformation) {
   const placeResp = await fetch("/api/bff/order/place", {
     method: "POST",
@@ -725,6 +834,8 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
   await fetch("/api/bff/order/process", {
     method: "POST",
     credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orderGroup }),
   });
 }
 ```
@@ -771,11 +882,16 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
       card,
     });
 
-    await fetchJson("/api/bff/order/process", { method: "POST" });
+    await fetchJson("/api/bff/order/process", {
+      method: "POST",
+      body: { orderGroup },
+    });
   }
   ```
 
 - **Proxying `vtexpayments.com.br` payment submission through the BFF "for consistency"**: Routing the Send payments information call through the BFF feels symmetrical with the rest of the BFF mandate, and some agents add it to "centralize all VTEX calls". When card data is involved this is a PCI DSS violation, not a refactor. Keep Step 2 in the browser; the BFF should expose `/api/bff/order/place` (returns `transactionId`/`orderGroup`/`merchantName`) and `/api/bff/order/process` (calls `/gatewayCallback`) but never `/api/bff/order/payment` for card flows.
+
+- **Storing `orderGroup` in `req.session` between `/place` and `/process`**: Writing `req.session.pendingOrderGroup` in Step 1 and reading it in Step 3 looks tidy and works in single-process local development. With `express-session`'s default `MemoryStore` (and any per-pod cache) a horizontally scaled BFF loses the value the moment the two requests land on different replicas, so `/process` returns `400 — no pending order to process` while the shopper's card has already been charged in Step 2. Return `orderGroup` from `/place` to the browser and require the browser to send it back in the `/process` body — see the dedicated hard constraint above. Even with a shared session store (Redis, Memcached, database) in place for `orderFormId`/`vtexCookies`, the cross-step handoff still belongs in the request body so the flow stays correct under partial outages, sticky-routing failures, replication lag, and tab refresh.
 
 - **Exposing raw VTEX error messages to the frontend**: Forwarding VTEX API error responses directly to the frontend leaks internal details (account names, API paths, data structures). Map VTEX errors to user-friendly messages in the BFF and log the full error server-side.
 
@@ -821,6 +937,7 @@ async function placeOrderWithCard(card: CardPaymentInformation) {
 - [ ] Are all inputs validated server-side before forwarding to VTEX?
 - [ ] Do all 3 order-placement steps (place → pay → process) execute as a single user interaction within the 5-minute window, with Steps 1 and 3 in the BFF and Step 2 in the browser direct to `vtexpayments.com.br`?
 - [ ] Is the existing `orderFormId` reused from the session rather than creating a new cart on every page load?
+- [ ] Is `orderGroup` returned by `/place` and sent back by the browser in the `/process` request body, instead of being stashed in `req.session.pendingOrderGroup` between the two BFF calls?
 - [ ] Are VTEX error responses sanitized before being sent to the frontend?
 
 ## Reference

--- a/tracks/payment/skills/payment-pci-security/skill.md
+++ b/tracks/payment/skills/payment-pci-security/skill.md
@@ -42,12 +42,14 @@ metadata:
 ## When this skill applies
 
 Use this skill when:
+
 - Building a payment connector that accepts credit cards, debit cards, or co-branded cards
 - The connector needs to process card data or communicate with an acquirer
 - Determining whether Secure Proxy is required for the hosting environment
 - Auditing a connector for PCI DSS compliance (data storage, logging, transmission)
 
 Do not use this skill for:
+
 - PPP endpoint contracts and response shapes — use [`payment-provider-protocol`](../payment-provider-protocol/skill.md)
 - Idempotency and duplicate prevention — use [`payment-idempotency`](../payment-idempotency/skill.md)
 - Async payment flows (Boleto, Pix) and callbacks — use [`payment-async-flow`](../payment-async-flow/skill.md)
@@ -75,8 +77,12 @@ Non-PCI environments are not authorized to handle raw card data. Calling the acq
 If the connector calls an acquirer endpoint directly (without going through `secureProxyUrl`) when `secureProxyUrl` is present in the request, STOP immediately. All acquirer communication must go through the Secure Proxy.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   if (secureProxyUrl) {
@@ -92,9 +98,9 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
       body: JSON.stringify({
         orderId: paymentId,
         payment: {
-          cardNumber: card.numberToken,     // Token, not real number
-          holder: card.holderToken,          // Token, not real name
-          securityCode: card.cscToken,       // Token, not real CVV
+          cardNumber: card.numberToken, // Token, not real number
+          holder: card.holderToken, // Token, not real name
+          securityCode: card.cscToken, // Token, not real CVV
           expirationMonth: card.expiration.month,
           expirationYear: card.expiration.year,
         },
@@ -108,8 +114,12 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, secureProxyUrl, card } = req.body;
 
   // WRONG: Calling acquirer directly, bypassing Secure Proxy
@@ -118,7 +128,7 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
     },
     body: JSON.stringify({
       orderId: paymentId,
@@ -161,7 +171,7 @@ export class PspSecureClient extends SecureExternalClient {
   public async authorize(data: object, secureProxyUrl: string) {
     return this.http.post("/payments", data, {
       secureProxy: secureProxyUrl,
-    } as any)
+    } as any);
   }
 }
 
@@ -170,9 +180,13 @@ import { ExternalClient } from "@vtex/api";
 
 export class PspClient extends ExternalClient {
   public async capture(tid: string, amount: number) {
-    return this.http.post(`/payments/${tid}/capture`, { amount }, {
-      headers: { "X-API-Key": "..." },
-    })
+    return this.http.post(
+      `/payments/${tid}/capture`,
+      { amount },
+      {
+        headers: { "X-API-Key": "..." },
+      },
+    );
   }
 }
 ```
@@ -187,6 +201,108 @@ async settle(request: SettlementRequest) {
 }
 ```
 
+### Constraint: Headless storefront BFFs MUST NOT proxy card data to vtexpayments.com.br
+
+In a headless storefront, the Send payments information call (`POST https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments`) MUST originate from the shopper's browser or native app. The merchant's BFF (Node, Next.js route handler, edge function, lambda, reverse proxy, or any server-side component) MUST NOT receive card fields from the browser and MUST NOT forward them to the Payment Gateway, even with redaction, even with `appKey`/`appToken` on the server side, and even when only "tokenized" fields appear to be forwarded.
+
+This constraint extends the same PCI principle that drives Secure Proxy: a non-PCI environment is not allowed to handle card data. For payment connectors that environment is the IO app; for headless storefronts it is the merchant BFF. The destination differs — Secure Proxy protects the connector → acquirer path, the browser → `vtexpayments.com.br` pattern protects the storefront → Payment Gateway path — but the rule is identical: keep raw card data inside the certified perimeter.
+
+**Why this matters**
+
+The merchant operating the headless storefront is rarely PCI DSS Level 1 certified. Routing card numbers, holder names, or CVV through the merchant's BFF places the BFF and every system it touches (application logs, APM, reverse proxies, load balancers, error trackers) inside PCI scope. Operating a non-PCI environment that handles card data violates PCI DSS Requirements 3 and 4 and can result in fines from $5,000 to over $100,000 per month from card networks, mandatory forensic investigation costs, loss of card processing ability, class-action exposure, and criminal liability in some jurisdictions.
+
+The VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified. The browser → Payment Gateway path keeps card data inside the certified perimeter; the merchant BFF stays out of the card-data flow entirely. The Send payments information endpoint is authenticated by the shopper's session cookies set during the previous Place Order step — no merchant credentials are required for this hop.
+
+**Detection**
+
+If you find any of the following in BFF / server-side code (`server/`, `bff/`, `api/`, route handlers, middleware, edge functions, lambdas), STOP immediately:
+
+- A request from the BFF to `https://*.vtexpayments.com.br/api/pub/transactions/.../payments`,
+- A handler that accepts `cardNumber`, `holderName`, `validationCode`, `csc`, `dueDate`, or full payment `fields` from the browser,
+- A "Payments client" / `ExternalClient` / `axios` instance on the server pointing at `vtexpayments.com.br` for the Send payments information endpoint.
+
+The BFF should expose `/api/bff/order/place` (returns `transactionId`, `orderGroup`, `merchantName`) and `/api/bff/order/process` (calls `/api/checkout/pub/gatewayCallback/{orderGroup}` — no card data) but never an endpoint that forwards card fields to `vtexpayments.com.br`.
+
+**Correct**
+
+```typescript
+async function sendPaymentDataDirect(args: {
+  account: string;
+  transactionId: string;
+  orderGroup: string;
+  merchantName: string;
+  paymentInformation: PaymentField[];
+}): Promise<void> {
+  const {
+    account,
+    transactionId,
+    orderGroup,
+    merchantName,
+    paymentInformation,
+  } = args;
+
+  const response = await fetch(
+    `https://${account}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(
+        paymentInformation.map((p) => ({
+          ...p,
+          transaction: { id: transactionId, merchantName },
+        })),
+      ),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Payment submission failed: ${response.status}`);
+  }
+}
+```
+
+**Wrong**
+
+```typescript
+const VTEX_APP_KEY = process.env.VTEX_APP_KEY!;
+const VTEX_APP_TOKEN = process.env.VTEX_APP_TOKEN!;
+
+paymentRoutes.post("/", async (req: Request, res: Response) => {
+  const { transactionId, orderGroup, paymentInformation } = req.body as {
+    transactionId: string;
+    orderGroup: string;
+    paymentInformation: Array<{
+      paymentSystem: number;
+      installments: number;
+      value: number;
+      fields: {
+        cardNumber: string;
+        holderName: string;
+        validationCode: string;
+        dueDate: string;
+      };
+    }>;
+  };
+
+  const url = `https://${process.env.VTEX_ACCOUNT}.vtexpayments.com.br/api/pub/transactions/${transactionId}/payments?orderId=${orderGroup}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VTEX-API-AppKey": VTEX_APP_KEY,
+      "X-VTEX-API-AppToken": VTEX_APP_TOKEN,
+    },
+    body: JSON.stringify(paymentInformation),
+  });
+
+  res.json({ status: response.status });
+});
+```
+
 ### Constraint: MUST NOT store raw card data
 
 The connector MUST NOT store the full card number (PAN), CVV/CSC, cardholder name, or any card token values in any persistent storage — database, file system, cache, session store, or any other durable medium. Card data must only exist in memory during the request lifecycle.
@@ -198,16 +314,20 @@ Storing raw card data violates PCI DSS Requirement 3. A data breach exposes cust
 If the code writes card number, CVV, cardholder name, or token values to a database, file, cache (Redis, VBase), or any persistent store, STOP immediately. Only `card.bin` (first 6 digits) and `card.numberLength` may be stored.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, secureProxyUrl } = req.body;
 
   // Only store non-sensitive card metadata
   await paymentStore.save(paymentId, {
     paymentId,
-    cardBin: card.bin,            // First 6 digits — safe to store
-    cardNumberLength: card.numberLength,  // Length — safe to store
-    cardExpMonth: card.expiration.month,  // Expiration — safe to store
+    cardBin: card.bin, // First 6 digits — safe to store
+    cardNumberLength: card.numberLength, // Length — safe to store
+    cardExpMonth: card.expiration.month, // Expiration — safe to store
     cardExpYear: card.expiration.year,
     // DO NOT store: card.numberToken, card.holderToken, card.cscToken
   });
@@ -221,15 +341,19 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card } = req.body;
 
   // CRITICAL PCI VIOLATION: Storing full card data in database
   await database.query(
     `INSERT INTO payments (payment_id, card_number, cvv, holder_name)
      VALUES ($1, $2, $3, $4)`,
-    [paymentId, card.number, card.csc, card.holder]
+    [paymentId, card.number, card.csc, card.holder],
   );
   // This single line can result in:
   // - $100K/month fines from card networks
@@ -250,8 +374,12 @@ Logs are typically stored in plaintext, retained for extended periods, and acces
 If the code contains `console.log`, `console.error`, `logger.info`, `logger.debug`, or any logging call that includes `card.number`, `card.csc`, `card.holder`, `card.numberToken`, `card.holderToken`, `card.cscToken`, or the full request body without redaction, STOP immediately. Redact or omit all sensitive fields before logging.
 
 **Correct**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   const { paymentId, card, paymentMethod, value } = req.body;
 
   // Safe logging — only non-sensitive fields
@@ -259,15 +387,17 @@ async function createPaymentHandler(req: Request, res: Response): Promise<void> 
     paymentId,
     paymentMethod,
     value,
-    cardBin: card?.bin,              // First 6 digits only — safe
-    cardNumberLength: card?.numberLength,  // Safe
+    cardBin: card?.bin, // First 6 digits only — safe
+    cardNumberLength: card?.numberLength, // Safe
   });
 
   // NEVER log the full request body for payment requests
   // It contains card tokens or raw card data
 }
 
-function redactSensitiveFields(body: Record<string, unknown>): Record<string, unknown> {
+function redactSensitiveFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const redacted = { ...body };
   if (redacted.card && typeof redacted.card === "object") {
     const card = redacted.card as Record<string, unknown>;
@@ -283,8 +413,12 @@ function redactSensitiveFields(body: Record<string, unknown>): Record<string, un
 ```
 
 **Wrong**
+
 ```typescript
-async function createPaymentHandler(req: Request, res: Response): Promise<void> {
+async function createPaymentHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
   // CRITICAL PCI VIOLATION: Logging the entire request body
   // This includes card number, CVV, holder name, and/or token values
   console.log("Payment request received:", JSON.stringify(req.body));
@@ -329,18 +463,18 @@ interface CreatePaymentRequest {
   currency: string;
   paymentMethod: string;
   card?: {
-    holder?: string;        // Raw (PCI) or absent (Secure Proxy)
-    holderToken?: string;   // Token (Secure Proxy only)
-    number?: string;        // Raw (PCI) or absent (Secure Proxy)
-    numberToken?: string;   // Token (Secure Proxy only)
-    bin: string;            // Always present — first 6 digits
-    numberLength: number;   // Always present
-    csc?: string;           // Raw (PCI) or absent (Secure Proxy)
-    cscToken?: string;      // Token (Secure Proxy only)
+    holder?: string; // Raw (PCI) or absent (Secure Proxy)
+    holderToken?: string; // Token (Secure Proxy only)
+    number?: string; // Raw (PCI) or absent (Secure Proxy)
+    numberToken?: string; // Token (Secure Proxy only)
+    bin: string; // Always present — first 6 digits
+    numberLength: number; // Always present
+    csc?: string; // Raw (PCI) or absent (Secure Proxy)
+    cscToken?: string; // Token (Secure Proxy only)
     expiration: { month: string; year: string };
   };
-  secureProxyUrl?: string;          // Present when Secure Proxy is active
-  secureProxyTokensURL?: string;    // For custom token operations
+  secureProxyUrl?: string; // Present when Secure Proxy is active
+  secureProxyTokensURL?: string; // For custom token operations
   callbackUrl: string;
   miniCart: Record<string, unknown>;
 }
@@ -375,12 +509,12 @@ Call acquirer through Secure Proxy with proper headers:
 ```typescript
 async function callAcquirerViaProxy(
   secureProxyUrl: string,
-  acquirerRequest: object
+  acquirerRequest: object,
 ): Promise<AcquirerResponse> {
   const response = await fetch(secureProxyUrl, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
       // X-PROVIDER-Forward-To tells the proxy where to send the request
       "X-PROVIDER-Forward-To": process.env.ACQUIRER_API_URL!,
@@ -393,21 +527,25 @@ async function callAcquirerViaProxy(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Secure Proxy call failed: ${response.status} ${errorText}`);
+    throw new Error(
+      `Secure Proxy call failed: ${response.status} ${errorText}`,
+    );
   }
 
   return response.json() as Promise<AcquirerResponse>;
 }
 
 // For PCI-certified environments, call acquirer directly
-async function callAcquirerDirect(acquirerRequest: object): Promise<AcquirerResponse> {
+async function callAcquirerDirect(
+  acquirerRequest: object,
+): Promise<AcquirerResponse> {
   const response = await fetch(process.env.ACQUIRER_API_URL!, {
     method: "POST",
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
-      "MerchantId": process.env.ACQUIRER_MERCHANT_ID!,
-      "MerchantKey": process.env.ACQUIRER_MERCHANT_KEY!,
+      MerchantId: process.env.ACQUIRER_MERCHANT_ID!,
+      MerchantKey: process.env.ACQUIRER_MERCHANT_KEY!,
     },
     body: JSON.stringify(acquirerRequest),
   });


### PR DESCRIPTION
## Summary

Closes a PCI-DSS gap in the AI guidance: previously the `headless-checkout-proxy` skill stated "**ALL** checkout operations MUST go through the BFF — no exceptions", which led AI agents using these skills to recommend proxying card data to `vtexpayments.com.br` through the merchant BFF. That puts the BFF inside the PCI cardholder data environment and is a hard PCI-DSS violation.

This PR adds a narrow PCI carve-out across the affected skills.

### Changes

- **`tracks/headless/skills/headless-checkout-proxy`**
  - Scope the "all through BFF" rule to `vtexcommercestable.com.br/api/checkout/...` calls only.
  - New decision rule and hard constraint: the **Send payments information** call to `https://{account}.vtexpayments.com.br/api/pub/transactions/{tid}/payments` MUST go directly from the browser/app whenever it carries card data; the merchant BFF MUST NOT be in the card-data path.
  - Rewrite the order-placement example to a 3-step flow:
    1. BFF places the order (Checkout API).
    2. Browser posts card data **directly** to `vtexpayments.com.br`.
    3. BFF processes the gateway callback (Checkout API).
  - Update common failure modes and the review checklist with detection patterns for server-side calls to `vtexpayments.com.br` and BFF handlers that touch card fields.

- **`tracks/payment/skills/payment-pci-security`**
  - Add a hard constraint reinforcing the same rule from the payment-connector perspective: headless storefront BFFs MUST NOT proxy card data to `vtexpayments.com.br`.

- **`exports/`**
  - Regenerated from the updated source skills via `bun run export`.

### Why this matters

VTEX Payment Gateway (`vtexpayments.com.br`) is PCI DSS Level 1 certified specifically so the merchant's infrastructure can stay out of scope. Routing card data through a non-certified BFF expands PCI scope to the merchant, breaks the Self-Assessment Questionnaire path most VTEX merchants rely on, and creates a real breach risk. This change makes the correct flow the explicit, hard-constrained pattern in the AI skills.

### Out of scope

- No changes to PR #73 (`docs/public-docs-sync-checklist`); this is a separate fix on its own branch off `main`.
- No changes outside the two skills above and their regenerated exports.

## Test plan

- [x] `bun run validate` — 39 passed, 1 pre-existing faststore warning (unrelated to this PR).
- [x] `bun run export` — exports regenerated and committed alongside source.
- [ ] Manually re-run the original failing prompt ("how do I place an order from a headless storefront") against an agent loaded with these skills and confirm it routes card data directly to `vtexpayments.com.br` from the browser, not through the BFF.
- [ ] Spot-check the rendered skill in at least one downstream export (Cursor, Claude, Copilot) to confirm the 3-step flow and PCI carve-out come through cleanly.

## Public docs sync

No public docs change needed — this is a skill-content fix only. No tracks added/removed/renamed, no change to skill counts, install commands, supported export platforms, or repository layout. The two pages cited in `AGENTS.md` (`developers.vtex.com/docs/guides/vtex-skills` and the VTEX Developer MCP release note) describe the catalog itself and are unaffected.