### PR TITLE
feat(sales-app): add static analysis to sales-app-extensibility skill

### DIFF
--- a/exports/agents-md/sales-app/AGENTS.md
+++ b/exports/agents-md/sales-app/AGENTS.md
@@ -428,6 +428,36 @@ body { font-size: 14px; }
 @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
 ```
 
+### Constraint: CSS must follow Sales App Design Guidelines
+
+Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
+
+**Why this matters**
+Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
+
+**Detection**
+Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
+
+**Correct**
+
+```css
+.container {
+  --sa-color-primary: #157BF4;
+  --sa-color-text-primary: #1F1F1F;
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.title { color: var(--sa-color-text-primary); font-size: 16px; }
+.buttonPrimary { background-color: var(--sa-color-primary); }
+```
+
+**Wrong**
+
+```css
+.container { font-family: Arial; }
+.title { color: #1a1a1a; font-size: 15px; }
+.buttonPrimary { background-color: #0066cc; }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -438,7 +468,7 @@ body { font-size: 14px; }
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-extensibility/references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-extensibility/references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-extensibility/references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-extensibility/references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-extensibility/references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-extensibility/references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-extensibility/references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -507,6 +537,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/discovery-and-use-cases.md](sales-app-extensibility/references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-extensibility/references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-extensibility/references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
+| [references/design-guidelines.md](sales-app-extensibility/references/design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
 
 ## Common failure modes
 
@@ -528,6 +559,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
 - **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
 - **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
+- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
+- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
+- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
+- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
 
 ## Review checklist
 
@@ -558,6 +593,11 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] No useLayoutEffect (use useEffect instead)?
 - [ ] No heavyweight library imports (lodash, moment)?
 - [ ] Components under 200 lines?
+- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
+- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/agents-md/sales-app/AGENTS.md
+++ b/exports/agents-md/sales-app/AGENTS.md
@@ -63,7 +63,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
-| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 3 | Code Generation & Validation | Generate `Component.tsx` + `Component.css` (plain CSS, never `.module.css`) + `index.tsx` → validate |
 | 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
 | 5 | Local Testing | Provide dev commands and URLs |
 | 6 | Build & Deploy | Build command → deployment guide |
@@ -394,6 +394,32 @@ const fn = new Function('return 42');
 setTimeout('doSomething()', 1000);
 ```
 
+### Constraint: CSS files must use plain .css extension, never .module.css
+
+The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
+
+**Why this matters**
+A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
+
+**Detection**
+Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
+
+**Correct**
+
+```typescript
+import './CashbackWidget.css';
+// Use className strings directly
+<div className="container">
+```
+
+**Wrong**
+
+```typescript
+import styles from './CashbackWidget.module.css';
+// CSS modules object access
+<div className={styles.container}>
+```
+
 ### Constraint: CSS must use namespaced selectors — no global elements
 
 Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
@@ -407,7 +433,7 @@ Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@
 **Correct**
 
 ```css
-/* CSS Module — classes are auto-scoped by the bundler */
+/* Plain CSS — use namespace prefix to scope classes */
 .container { padding: 8px; }
 .title { font-size: 16px; }
 
@@ -466,9 +492,9 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](sales-app-extensibility/references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
-**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+**Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-extensibility/references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-extensibility/references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-extensibility/references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-extensibility/references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-extensibility/references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-extensibility/references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-extensibility/references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-extensibility/references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -477,7 +503,7 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
 4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
 5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS module file name and summary of key classes.
+6. **Styling** — CSS file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
    - **Source documentation:** URL or file path of the original API documentation, if provided.
    - **Generated types:** list of TypeScript interfaces generated from the API documentation.
@@ -506,7 +532,7 @@ Template for the documentation file:
 <Describe the component tree, key props, and internal state.>
 
 ## Styling
-- **File:** `<ComponentName>.module.css`
+- **File:** `<ComponentName>.css`
 - <Summary of key CSS classes and design decisions.>
 
 ## API integration
@@ -533,7 +559,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-extensibility/references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-extensibility/references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-extensibility/references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-extensibility/references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-extensibility/references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-extensibility/references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |

--- a/exports/agents-md/sales-app/AGENTS.md
+++ b/exports/agents-md/sales-app/AGENTS.md
@@ -56,7 +56,7 @@ Documentation: https://beta.fast.store/sales-app/setting-up
 
 ## Decision rules
 
-Follow the mandatory 6-step workflow in order. Do not skip steps.
+Follow the mandatory 7-step workflow (Steps 0–6) in order. Do not skip steps.
 
 | Step | Purpose | Gate |
 |------|---------|------|
@@ -184,55 +184,6 @@ const { item } = useCartItem();
 return <div>{item.name}</div>;
 ```
 
-### Constraint: Never expose authentication keys in frontend code
-
-API keys in `fetch` headers are visible in the browser network tab.
-
-**Why this matters**
-Leaked keys compromise the external service.
-
-**Detection**
-Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
-
-**Correct**
-
-```typescript
-const response = await fetch('/_v/my-api/data', {
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-**Wrong**
-
-```typescript
-const response = await fetch('https://api.example.com/data', {
-  headers: { 'x-api-key': 'sk-secret-key-12345' },
-});
-```
-
-### Constraint: IO Proxy must use relative paths only
-
-The Sales App internal proxy resolves the domain automatically.
-
-**Why this matters**
-A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
-
-**Detection**
-`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
-
-**Correct**
-
-```typescript
-await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
-```
-
-**Wrong**
-
-```typescript
-await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
-```
-
 ### Constraint: defineExtensions is required in index.tsx
 
 Entry point must use `defineExtensions` from `@vtex/sales-app`.
@@ -304,186 +255,6 @@ defineExtensions({ 'cart.cart-item.after': ItemWarranty });
 defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
 ```
 
-### Constraint: Always present execution plan and wait for approval
-
-Do not generate code until the user confirms the plan.
-
-**Why this matters**
-Generating without agreement wastes effort and may produce the wrong extension.
-
-**Detection**
-Jumping from discovery to code generation without presenting a plan.
-
-**Correct**
-Discovery → Requirements → Present plan → **User approves** → Generate code.
-
-**Wrong**
-Discovery → Generate code immediately.
-
-### Constraint: Never access DOM APIs directly
-
-Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
-
-**Why this matters**
-Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
-
-**Detection**
-Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
-
-**Correct**
-
-```typescript
-// Use React state, props, and Sales App hooks for data
-const { account } = useExtension();
-const cart = useCart();
-```
-
-**Wrong**
-
-```typescript
-const userId = localStorage.getItem('userId');
-const width = window.innerWidth;
-document.title = 'My Extension';
-```
-
-### Constraint: Never import restricted Node.js modules
-
-Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
-
-**Why this matters**
-Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
-
-**Detection**
-`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
-
-**Correct**
-
-```typescript
-import { useCart } from '@vtex/sales-app';
-import React, { useState, useEffect } from 'react';
-```
-
-**Wrong**
-
-```typescript
-import fs from 'fs';
-import crypto from 'crypto';
-```
-
-### Constraint: Never use eval or the Function constructor
-
-Arbitrary code execution is banned in the sandbox.
-
-**Why this matters**
-`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
-
-**Detection**
-Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
-
-**Correct**
-
-```typescript
-const result = computeValue(input); // deterministic logic only
-```
-
-**Wrong**
-
-```typescript
-eval('doSomething()');
-const fn = new Function('return 42');
-setTimeout('doSomething()', 1000);
-```
-
-### Constraint: CSS files must use plain .css extension, never .module.css
-
-The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
-
-**Why this matters**
-A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
-
-**Detection**
-Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
-
-**Correct**
-
-```typescript
-import './CashbackWidget.css';
-// Use className strings directly
-<div className="container">
-```
-
-**Wrong**
-
-```typescript
-import styles from './CashbackWidget.module.css';
-// CSS modules object access
-<div className={styles.container}>
-```
-
-### Constraint: CSS must use namespaced selectors — no global elements
-
-Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
-
-**Why this matters**
-Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
-
-**Detection**
-Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
-
-**Correct**
-
-```css
-/* Plain CSS — use namespace prefix to scope classes */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-
-@keyframes extension-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-```
-
-**Wrong**
-
-```css
-body { font-size: 14px; }
-* { box-sizing: border-box; }
-:root { --my-color: red; }
-@import './reset.css';
-.overlay { position: fixed; z-index: 9999; }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Constraint: CSS must follow Sales App Design Guidelines
-
-Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
-
-**Why this matters**
-Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
-
-**Detection**
-Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
-
-**Correct**
-
-```css
-.container {
-  --sa-color-primary: #157BF4;
-  --sa-color-text-primary: #1F1F1F;
-  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-}
-.title { color: var(--sa-color-text-primary); font-size: 16px; }
-.buttonPrimary { background-color: var(--sa-color-primary); }
-```
-
-**Wrong**
-
-```css
-.container { font-family: Arial; }
-.title { color: #1a1a1a; font-size: 15px; }
-.buttonPrimary { background-color: #0066cc; }
-```
-
 ## Preferred pattern
 
 ### Workflow overview
@@ -494,59 +265,17 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-extensibility/references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-extensibility/references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-extensibility/references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-extensibility/references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`.
 
-**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
+Required references for this step (load before generating):
+- [code-templates-and-patterns.md](sales-app-extensibility/references/code-templates-and-patterns.md) — all component templates, the CSS template (with the full Sales App design system inlined: tokens, typography, spacing, responsive), the `index.tsx` template, type generation rules, and the custom fetch hook pattern.
+- [extension-points-hooks-and-types.md](sales-app-extensibility/references/extension-points-hooks-and-types.md) — hook return types and TypeScript definitions.
+- [static-analysis-rules.md](sales-app-extensibility/references/static-analysis-rules.md) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`. Run these checks on all generated files.
+- [design-guidelines.md](sales-app-extensibility/references/design-guidelines.md) — load when the extension renders any UI text (sentence case rule) or uses icons (Phosphor Icons).
 
-1. **Extension name** — title matching the component name.
-2. **Overview** — one-paragraph summary of what the extension does and why it was built.
-3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
-4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
-5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS file name and summary of key classes.
-7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
-   - **Source documentation:** URL or file path of the original API documentation, if provided.
-   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
-   - Note which fields are optional (`?`) vs required per the documentation.
-8. **How to test** — dev server command and URL to reach the extension.
-9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Validate against the 12-point checklist in code-templates-and-patterns.md. Fix all violations before presenting code; surface warnings to the user.
 
-Template for the documentation file:
-
-````markdown
-# <ExtensionName>
-
-## Overview
-<One-paragraph description of the extension purpose and value.>
-
-## Extension point
-- **Point:** `<extension.point.name>`
-- **Rationale:** <Why this extension point was selected.>
-
-## Hooks used
-| Hook | Purpose |
-|------|---------|
-| `useCart` | <What data it provides here> |
-
-## Component structure
-<Describe the component tree, key props, and internal state.>
-
-## Styling
-- **File:** `<ComponentName>.css`
-- <Summary of key CSS classes and design decisions.>
-
-## API integration
-- **Endpoint:** `/_v/...`
-- **Auth strategy:** IO Proxy / Direct / None
-- **Request/Response:** <Brief shape description.>
-
-## How to test
-Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
-
-## Known constraints
-- <Guard or limitation 1>
-- <Guard or limitation 2>
-````
+**Step 4** — Generate `docs/<ExtensionName>.md` inside the Sales App package (create the `docs/` folder if needed). Load the [documentation template reference](sales-app-extensibility/references/documentation-template.md) for the required 9-section structure and the markdown skeleton to fill in.
 
 **Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](sales-app-extensibility/references/local-dev-build-and-deploy.md).
 
@@ -559,73 +288,47 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-extensibility/references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-extensibility/references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-extensibility/references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; **CSS template with the full Sales App design system inlined (tokens, typography, spacing, responsive)**; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-extensibility/references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-extensibility/references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-extensibility/references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
-| [references/design-guidelines.md](sales-app-extensibility/references/design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
+| [references/design-guidelines.md](sales-app-extensibility/references/design-guidelines.md) | Writing UI text (sentence case rule) or using icons (Phosphor Icons). **CSS-related design rules — tokens, typography, spacing, responsive — are inlined directly in the CSS template inside code-templates-and-patterns.md, so this file is not needed for CSS generation.** |
+| [references/documentation-template.md](sales-app-extensibility/references/documentation-template.md) | Writing the `docs/<ExtensionName>.md` file in Step 4 — the 9-section structure and markdown skeleton |
 
 ## Common failure modes
 
-- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
-- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
-- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
-- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
-- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
-- **Placing code outside packages/sales-app/src/** — Not included in build.
-- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
-- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
-- **Not presenting plan** — User may want a different approach. Always confirm.
-- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
-- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed. Always confirm both before Step 1.
+- **Not presenting plan** — User may want a different approach. Always confirm at Step 2 before generating code.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Load documentation-template.md for the required structure.
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
-- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
-- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
-- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
-- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
-- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
-- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
-- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
-- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
+- **Placing code outside packages/sales-app/src/** — Files outside this path are not included in the build.
+
+> Code-level violations (DOM APIs, Node imports, eval, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and caught during Step 3 validation. See [static-analysis-rules.md](sales-app-extensibility/references/static-analysis-rules.md) and [design-guidelines.md](sales-app-extensibility/references/design-guidelines.md).
 
 ## Review checklist
 
+**Workflow gates**
 - [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
 - [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
 - [ ] Discovery completed and use case identified?
 - [ ] Execution plan approved by user?
 - [ ] Extension point is valid (from the 8-point reference)?
 - [ ] Hooks compatible with chosen extension point?
+- [ ] Documentation generated at `docs/<ExtensionName>.md` (9 sections, using documentation-template.md)?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+**TypeScript / runtime guards** (not caught by fsp-analyzer)
 - [ ] Component returns JSX.Element, never null?
 - [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
 - [ ] useCartItem().item checked for undefined?
-- [ ] No auth credentials exposed in frontend code?
-- [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
-- [ ] CSS file path matches component name?
-- [ ] Documentation generated at `docs/<ExtensionName>.md`?
-- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
-- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
-- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
-- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
-- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
-- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
-- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
-- [ ] No @import rules in CSS?
-- [ ] No position: fixed or z-index: 9999 in CSS?
-- [ ] @keyframes names prefixed with extension namespace?
-- [ ] No useLayoutEffect (use useEffect instead)?
-- [ ] No heavyweight library imports (lodash, moment)?
-- [ ] Components under 200 lines?
-- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
-- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
-- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
-- [ ] Build passes: `yarn fsp build {account} sales-app`?
-- [ ] Tested locally: `yarn fsp dev {account}`?
+
+> All other code-level rules (sandbox APIs, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and checked during Step 3. See [static-analysis-rules.md](sales-app-extensibility/references/static-analysis-rules.md) and [design-guidelines.md](sales-app-extensibility/references/design-guidelines.md).
 
 ## Related skills
 

--- a/exports/agents-md/sales-app/AGENTS.md
+++ b/exports/agents-md/sales-app/AGENTS.md
@@ -320,6 +320,114 @@ Discovery → Requirements → Present plan → **User approves** → Generate c
 **Wrong**
 Discovery → Generate code immediately.
 
+### Constraint: Never access DOM APIs directly
+
+Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
+
+**Why this matters**
+Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
+
+**Detection**
+Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
+
+**Correct**
+
+```typescript
+// Use React state, props, and Sales App hooks for data
+const { account } = useExtension();
+const cart = useCart();
+```
+
+**Wrong**
+
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+### Constraint: Never import restricted Node.js modules
+
+Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
+
+**Why this matters**
+Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
+
+**Detection**
+`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
+
+**Correct**
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+import React, { useState, useEffect } from 'react';
+```
+
+**Wrong**
+
+```typescript
+import fs from 'fs';
+import crypto from 'crypto';
+```
+
+### Constraint: Never use eval or the Function constructor
+
+Arbitrary code execution is banned in the sandbox.
+
+**Why this matters**
+`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
+
+**Detection**
+Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
+
+**Correct**
+
+```typescript
+const result = computeValue(input); // deterministic logic only
+```
+
+**Wrong**
+
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+### Constraint: CSS must use namespaced selectors — no global elements
+
+Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
+
+**Why this matters**
+Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
+
+**Detection**
+Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
+
+**Correct**
+
+```css
+/* CSS Module — classes are auto-scoped by the bundler */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+
+```css
+body { font-size: 14px; }
+* { box-sizing: border-box; }
+:root { --my-color: red; }
+@import './reset.css';
+.overlay { position: fixed; z-index: 9999; }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -330,7 +438,7 @@ Discovery → Generate code immediately.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-extensibility/references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](sales-app-extensibility/references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-extensibility/references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-extensibility/references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-extensibility/references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -398,6 +506,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/code-templates-and-patterns.md](sales-app-extensibility/references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-extensibility/references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-extensibility/references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/static-analysis-rules.md](sales-app-extensibility/references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
 
 ## Common failure modes
 
@@ -415,6 +524,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
+- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
+- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
+- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
+- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
 
 ## Review checklist
 
@@ -435,6 +548,16 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
 - [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
+- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
+- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
+- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
+- [ ] No @import rules in CSS?
+- [ ] No position: fixed or z-index: 9999 in CSS?
+- [ ] @keyframes names prefixed with extension namespace?
+- [ ] No useLayoutEffect (use useEffect instead)?
+- [ ] No heavyweight library imports (lodash, moment)?
+- [ ] Components under 200 lines?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/agents-md/sales-app/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/exports/agents-md/sales-app/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -1,6 +1,6 @@
 ---
 name: sales-app-code-templates
-description: Code generation templates for Sales App extensions — simple, hook-based, API (no auth), IO Proxy (secure), Direct Auth (insecure), CSS module, and index.tsx with defineExtensions. Use when generating or scaffolding extension code.
+description: Code generation templates for Sales App extensions — simple, hook-based, API (no auth), IO Proxy (secure), Direct Auth (insecure), CSS stylesheet, and index.tsx with defineExtensions. Use when generating or scaffolding extension code.
 metadata:
   version: "1.0"
 ---
@@ -331,9 +331,11 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 }
 ```
 
-## CSS Module
+## CSS Stylesheet
 
-All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+
+**CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
 
 ```css
 /**
@@ -486,7 +488,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/agents-md/sales-app/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/exports/agents-md/sales-app/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -333,82 +333,115 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Module
 
-All extensions use CSS modules with Admin UI design tokens.
+All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Admin UI patterns.
+ * Design tokens follow Sales App Design Guidelines.
+ * Reference: references/design-guidelines.md
+ * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
-.container { padding: 16px; background-color: #ffffff; }
-.content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: #1a1a1a; margin: 0; }
-.subtitle { font-size: 14px; color: #666666; margin: 0; }
-.text { font-size: 14px; color: #333333; line-height: 1.5; }
+.container {
+  /* Sales App design tokens — do not replace with hardcoded hex values */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+  --sa-color-bg:        #FFFFFF;
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
-/* Loading State */
+  padding: 16px;
+  background-color: var(--sa-color-bg);
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.content { display: flex; flex-direction: column; gap: 12px; }
+.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
+.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
+.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+
+/* Loading state */
 .loading {
   display: flex; align-items: center; justify-content: center;
-  gap: 8px; padding: 24px; color: #666666;
+  gap: 8px; padding: 24px; color: var(--sa-color-text-secondary);
 }
 .spinner {
   width: 20px; height: 20px;
-  border: 2px solid #e0e0e0; border-top-color: #0066cc;
-  border-radius: 50%; animation: spin 1s linear infinite;
+  border: 2px solid var(--sa-color-border); border-top-color: var(--sa-color-primary);
+  border-radius: 50%; animation: ${COMPONENT_NAME}-spin 1s linear infinite;
 }
-@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes ${COMPONENT_NAME}-spin { to { transform: rotate(360deg); } }
 
-/* Error State */
+/* Error state */
 .error {
-  padding: 16px; background-color: #fff5f5;
-  border: 1px solid #ffcccc; border-radius: 8px;
-  color: #cc0000; font-size: 14px;
+  padding: 16px; background-color: var(--sa-color-error-bg);
+  border: 1px solid var(--sa-color-error-border); border-radius: 8px;
+  color: var(--sa-color-error-text); font-size: 14px;
 }
 
-/* Button Styles */
+/* Button styles */
 .button {
   display: inline-flex; align-items: center; justify-content: center;
-  padding: 10px 16px; font-size: 14px; font-weight: 500;
+  padding: 12px 16px; font-size: 14px; font-weight: 500;
   border: none; border-radius: 6px; cursor: pointer;
   transition: background-color 0.2s ease;
 }
-.buttonPrimary { background-color: #0066cc; color: #ffffff; }
-.buttonPrimary:hover { background-color: #0052a3; }
-.buttonSecondary { background-color: #f0f0f0; color: #333333; }
-.buttonSecondary:hover { background-color: #e0e0e0; }
+.buttonPrimary { background-color: var(--sa-color-primary); color: #FFFFFF; }
+.buttonPrimary:hover { background-color: var(--sa-color-primary-hover); }
+.buttonSecondary { background-color: var(--sa-color-bg-muted); color: var(--sa-color-text-tertiary); }
+.buttonSecondary:hover { background-color: var(--sa-color-border); }
 
-/* Card Styles */
+/* Card */
 .card {
-  padding: 16px; background-color: #f9f9f9;
-  border-radius: 8px; border: 1px solid #e0e0e0;
+  padding: 16px; background-color: var(--sa-color-bg-subtle);
+  border-radius: 8px; border: 1px solid var(--sa-color-border);
 }
 
-/* Badge Styles */
+/* Badges */
 .badge {
   display: inline-block; padding: 4px 8px;
   font-size: 12px; font-weight: 500; border-radius: 4px;
 }
-.badgeSuccess { background-color: #e6f4ea; color: #137333; }
-.badgeWarning { background-color: #fef7e0; color: #b06000; }
-.badgeInfo { background-color: #e8f0fe; color: #1a73e8; }
+.badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
+.badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
+.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
 
-/* Input Styles */
+/* Input */
 .input {
-  width: 100%; padding: 10px 12px; font-size: 14px;
-  border: 1px solid #d0d0d0; border-radius: 6px;
+  width: 100%; padding: 12px; font-size: 14px;
+  border: 1px solid var(--sa-color-border-input); border-radius: 6px;
   outline: none; transition: border-color 0.2s ease;
 }
-.input:focus { border-color: #0066cc; }
+.input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/Flex Helpers */
+/* Row/flex helpers */
 .row { display: flex; align-items: center; gap: 12px; }
 .spaceBetween { justify-content: space-between; }
 
-/* Price Display */
-.price { font-size: 18px; font-weight: 600; color: #1a1a1a; }
-.priceOld { font-size: 14px; color: #999999; text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: #137333; font-weight: 500; }
+/* Price display */
+.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+
+/* Responsive — Sales App breakpoints */
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
 ```
 
 ## index.tsx with defineExtensions
@@ -453,6 +486,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
+12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/agents-md/sales-app/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/exports/agents-md/sales-app/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -452,6 +452,7 @@ After generating code, validate for these issues:
 8. **API call handling** — loading state and error handling must be present for any `fetch()` call
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
+11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
 
 ## API Type Generation from Documentation
 

--- a/exports/agents-md/sales-app/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/exports/agents-md/sales-app/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -333,38 +333,73 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Stylesheet
 
-All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules). The full Sales App design system for CSS — tokens, typography, spacing grid, responsive breakpoints, and structure — is inlined below. **Use this template as the single source of truth for any CSS generation.**
 
 **CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
+
+### Design system rules baked into this template
+
+These rules apply to **every** generated extension CSS. The template below already complies — keep it that way.
+
+| Topic | Rule |
+|-------|------|
+| Tokens | All colors must reference `--sa-color-*` tokens declared on `.container`. **Never** use hardcoded hex values anywhere else. |
+| Font family | `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif` on `.container`, inherited by descendants. |
+| Font weights | Only Regular (400), Medium (500), Semibold (600), Bold (700). |
+| Font sizes (px) | Allowed scale only: **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**. Never `13`, `15`, `17`, etc. |
+| Typography roles | Section title = 16px/600 · Subtitle/label = 14px/500 · Body = 14px/400 · Caption = 12px/400 · Price = 18px/600. |
+| Spacing | Multiples of **4px** only (4, 8, 12, 16, 20, 24, 32, 40…). Never `10`, `14`, `18`, `22`. Applies to `padding`, `margin`, `gap`, `height`. |
+| Containment | No `position: fixed`, no `z-index: 9999`, no `:host`, no `:global`, no `@import`. `position: relative` and `sticky` are safe. |
+| Selectors | Use the unprefixed utility class names from this template (`.container`, `.content`, `.row`, `.title`, `.button`, etc.). The Sales App `fsp-analyzer` runs with `transformNonCompliant: true`, so unprefixed selectors emit a `CSS_TRANSFORMED` warning rather than a `CSS_NAMESPACE_REQUIRED` violation. Never use `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` — those are caught by `CSS_GLOBAL_SELECTOR` and remain blocking. |
+| Keyframes | Prefix with `${COMPONENT_NAME}-` (e.g., `${COMPONENT_NAME}-spin`). This raises a `CSS_TRANSFORMED` warning (build still passes) — use `sales-app-extension-${COMPONENT_NAME}-spin` if you want a clean run. |
+| `!important` | Never. |
+| Responsive | Use the breakpoint at `(max-width: 743px)` for mobile overrides. Sales App shell handles the rest. |
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Sales App Design Guidelines.
- * Reference: references/design-guidelines.md
+ * Sales App design system (tokens + typography + spacing + responsive) is fully inlined.
  * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
 .container {
-  /* Sales App design tokens — do not replace with hardcoded hex values */
+  /* === Sales App design tokens — single source of truth ===
+     Always declare these on .container. Reference via var(--sa-color-*) in all other rules.
+     Never use hardcoded hex values in CSS rules. */
+
+  /* Primary action */
   --sa-color-primary:       #157BF4;   /* Light Blue 800 */
   --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-  --sa-color-bg:        #FFFFFF;
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 — high emphasis */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600  — medium emphasis */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500  — low emphasis */
+  --sa-color-text-muted:     #999999;  /* Neutral 700  — disabled / hint */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
   --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
   --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
   --sa-color-border:       #E0E0E0;    /* Neutral 300 */
   --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
   --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
   --sa-color-error-border: #FFDFD9;    /* Red 200 */
   --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
   --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
   --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow / Orange scale) */
   --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
   --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
   --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
   --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
@@ -372,10 +407,16 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
   background-color: var(--sa-color-bg);
   font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
 }
+
+/* Layout */
 .content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
-.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
-.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+.row { display: flex; align-items: center; gap: 12px; }
+.spaceBetween { justify-content: space-between; }
+
+/* Typography — uses approved size scale (10, 12, 14, 16, 18, 20, 22, 24...) */
+.title    { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary);   margin: 0; }
+.subtitle { font-size: 14px; font-weight: 500; color: var(--sa-color-text-secondary); margin: 0; }
+.text     { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
 
 /* Loading state */
 .loading {
@@ -421,7 +462,7 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
 .badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
-.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
+.badgeInfo    { background-color: var(--sa-color-info-bg);    color: var(--sa-color-info-text); }
 
 /* Input */
 .input {
@@ -431,20 +472,33 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/flex helpers */
-.row { display: flex; align-items: center; gap: 12px; }
-.spaceBetween { justify-content: space-between; }
-
 /* Price display */
-.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
-.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+.price          { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld       { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount  { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
 
-/* Responsive — Sales App breakpoints */
+/* Responsive — Sales App breakpoints
+   Small (mobile)  320–743px  → margin: 24px, no column grid
+   Medium (tablet) 744–1279px → host gutters: 16px (no override needed)
+   Large (desktop) 1280–1919px → host gutters: 20px (no override needed)
+   Extra large     1920px+    → host gutters: 20px (no override needed) */
 @media (max-width: 743px) {
   .container { padding: 12px; margin: 0 24px; }
 }
 ```
+
+### CSS file structure
+
+Every extension CSS must follow this order:
+
+1. **Token declarations** — `--sa-color-*` on `.container`
+2. **Layout helpers** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography** — `.title`, `.subtitle`, `.text`
+4. **State** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive** — `@media` queries at the bottom
+
+For UX writing rules (sentence case) and iconography (Phosphor Icons) used in `.tsx`, see [design-guidelines.md](design-guidelines.md).
 
 ## index.tsx with defineExtensions
 
@@ -488,7 +542,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design system compliance** — the CSS file must follow the rules table at the top of the "CSS Stylesheet" section above: `--sa-color-*` custom properties declared on `.container` and used in all rules, `'VTEX Trust'` font family, allowed font sizes (10, 12, 14, 16, 18, 20, 22, 24, 28, 32…), 4px-multiple spacing, scoped selectors, and the responsive override at `(max-width: 743px)`. For UI text (sentence case) and icons (Phosphor), see [design-guidelines.md](design-guidelines.md).
 
 ## API Type Generation from Documentation
 

--- a/exports/agents-md/sales-app/sales-app-extensibility/references/design-guidelines.md
+++ b/exports/agents-md/sales-app/sales-app-extensibility/references/design-guidelines.md
@@ -1,0 +1,245 @@
+---
+name: sales-app-design-guidelines
+description: Design tokens, typography, iconography, color palette, UX writing rules, and responsive breakpoints for Sales App extensions. Load when generating CSS, choosing colors, typography, or icons for any extension component.
+metadata:
+  version: "1.0"
+---
+
+# Sales App Design Guidelines
+
+All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+
+---
+
+## 1. UX and Writing Rules
+
+Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+
+| Rule | Correct | Wrong |
+|------|---------|-------|
+| Sentence case | "Add to cart" | "ADD TO CART" |
+| Proper nouns | "VTEX account" | "vtex account" |
+| No all-caps | "Loyalty points" | "LOYALTY POINTS" |
+| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+
+These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
+
+---
+
+## 2. Design Tokens (CSS Custom Properties)
+
+Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
+
+```css
+.container {
+  /* Primary action */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow/Orange scale) */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
+}
+```
+
+### Token mapping reference
+
+| Semantic role | Token | Hex | Palette origin |
+|--------------|-------|-----|----------------|
+| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
+| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
+| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
+| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
+| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
+| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
+| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
+| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
+| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
+| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
+| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
+| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
+| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
+| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
+| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
+| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
+| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
+| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
+| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
+| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+
+---
+
+## 3. Typography
+
+### Typeface
+
+The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
+
+```css
+font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+```
+
+Set this on the root `.container` class so all descendant elements inherit it.
+
+### Weights
+
+Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
+
+### Allowed font sizes
+
+Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
+
+Do not use arbitrary sizes like 13px, 15px, or 17px.
+
+| Use case | Size | Weight |
+|----------|------|--------|
+| Section title | 16px | Semibold (600) |
+| Subtitle / label | 14px | Medium (500) |
+| Body text | 14px | Regular (400) |
+| Caption / hint | 12px | Regular (400) |
+| Price | 18px | Semibold (600) |
+
+---
+
+## 4. Iconography
+
+### Library
+
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Standard / default | 24px |
+| Compact / inline | 16px |
+| Large / featured | 32–48px |
+
+Always use sizes within the supported range: **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+
+### Installation
+
+```bash
+yarn add @phosphor-icons/react
+```
+
+### Usage example
+
+```typescript
+import { ShoppingCart, Star, Warning } from '@phosphor-icons/react';
+
+export function MyExtension(): JSX.Element {
+  return (
+    <div className="container">
+      <ShoppingCart size={24} />
+      <span>Cart items</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. Spacing and Baseline Grid
+
+All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+
+| Value | Baseline multiple |
+|-------|-----------------|
+| 4px | 1× |
+| 8px | 2× |
+| 12px | 3× |
+| 16px | 4× |
+| 20px | 5× |
+| 24px | 6× |
+| 32px | 8× |
+
+**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
+
+---
+
+## 6. Responsive Breakpoints
+
+Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
+
+| Breakpoint | Resolution range | Notes |
+|-----------|-----------------|-------|
+| Small (mobile) | 320–743px | Margin: 24px, no column grid |
+| Medium (tablet) | 744–1279px | Gutters: 16px |
+| Large (desktop) | 1280–1919px | Gutters: 20px |
+| Extra large (monitor) | 1920px+ | Gutters: 20px |
+
+Recommended mobile override (applied to the responsive section of the CSS module):
+
+```css
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
+```
+
+---
+
+## 7. CSS Module Structure
+
+Every extension CSS module must follow this structure:
+
+1. **Token declarations** — CSS custom properties on `.container`
+2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography classes** — `.title`, `.subtitle`, `.text`
+4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive overrides** — `@media` queries at the bottom
+
+### Critical CSS rules
+
+- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
+- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
+- No `@import`, `position: fixed`, or `z-index: 9999`.
+- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
+
+---
+
+## 8. Quick Compliance Checklist
+
+Before presenting generated CSS to the user, verify:
+
+- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
+- [ ] No hardcoded hex values outside the token declarations block?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
+- [ ] All spacing multiples of 4px?
+- [ ] All icons from Phosphor Icons?
+- [ ] All UI text in sentence case (no ALL-CAPS)?
+- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?

--- a/exports/agents-md/sales-app/sales-app-extensibility/references/design-guidelines.md
+++ b/exports/agents-md/sales-app/sales-app-extensibility/references/design-guidelines.md
@@ -1,159 +1,62 @@
 ---
 name: sales-app-design-guidelines
-description: Design tokens, typography, iconography, color palette, UX writing rules, and responsive breakpoints for Sales App extensions. Load when generating CSS, choosing colors, typography, or icons for any extension component.
+description: UX writing rules (sentence case) and Phosphor Icons usage for Sales App extensions. Load when writing JSX text content or when an extension needs icons. CSS-related design rules (tokens, typography, spacing, responsive) are inlined directly in the CSS template — see code-templates-and-patterns.md.
 metadata:
-  version: "1.0"
+  version: "2.0"
 ---
 
-# Sales App Design Guidelines
+# Sales App Design Guidelines (non-CSS)
 
-All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+This reference covers two topics that apply to **TSX content**, not CSS:
+
+1. **UX writing rules** — for any text rendered in JSX
+2. **Iconography** — when the extension uses icons
+
+> **For CSS:** all design tokens, typography scale, spacing grid, and responsive breakpoints are inlined directly in the CSS template at [code-templates-and-patterns.md](code-templates-and-patterns.md) §"CSS Stylesheet". That template is the single source of truth for any CSS generation. Do not invent or duplicate token values here.
 
 ---
 
-## 1. UX and Writing Rules
+## 1. UX Writing Rules
 
-Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+Apply to every string that appears in the UI (labels, buttons, messages, placeholders, alt text).
 
 | Rule | Correct | Wrong |
 |------|---------|-------|
 | Sentence case | "Add to cart" | "ADD TO CART" |
-| Proper nouns | "VTEX account" | "vtex account" |
+| Proper nouns capitalized | "VTEX account" | "vtex account" |
 | No all-caps | "Loyalty points" | "LOYALTY POINTS" |
-| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+| No system-style placeholders | "Your email" | "EMAIL ADDRESS" |
+| No CSS uppercase transforms | (omit `text-transform: uppercase`) | `text-transform: uppercase` |
 
-These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
-
----
-
-## 2. Design Tokens (CSS Custom Properties)
-
-Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
-
-```css
-.container {
-  /* Primary action */
-  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
-  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-
-  /* Text */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-
-  /* Backgrounds */
-  --sa-color-bg:        #FFFFFF;       /* Neutral White */
-  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
-  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
-
-  /* Borders */
-  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
-  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
-
-  /* Error (Red scale) */
-  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
-  --sa-color-error-border: #FFDFD9;    /* Red 200 */
-  --sa-color-error-text:   #EC3727;    /* Red 800 */
-
-  /* Success (Green scale) */
-  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
-  --sa-color-success-text: #01905F;    /* Green 800 */
-
-  /* Warning (Yellow/Orange scale) */
-  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
-  --sa-color-warning-text: #E57001;    /* Orange 700 */
-
-  /* Info (Light Blue scale) */
-  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
-  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
-}
-```
-
-### Token mapping reference
-
-| Semantic role | Token | Hex | Palette origin |
-|--------------|-------|-----|----------------|
-| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
-| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
-| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
-| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
-| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
-| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
-| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
-| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
-| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
-| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
-| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
-| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
-| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
-| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
-| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
-| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
-| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
-| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
-| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
-| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+These rules derive from Google Material Design and Apple Human Interface Guidelines, adopted by VTEX.
 
 ---
 
-## 3. Typography
-
-### Typeface
-
-The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
-
-```css
-font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-```
-
-Set this on the root `.container` class so all descendant elements inherit it.
-
-### Weights
-
-Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
-
-### Allowed font sizes
-
-Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
-
-Do not use arbitrary sizes like 13px, 15px, or 17px.
-
-| Use case | Size | Weight |
-|----------|------|--------|
-| Section title | 16px | Semibold (600) |
-| Subtitle / label | 14px | Medium (500) |
-| Body text | 14px | Regular (400) |
-| Caption / hint | 12px | Regular (400) |
-| Price | 18px | Semibold (600) |
-
----
-
-## 4. Iconography
+## 2. Iconography
 
 ### Library
 
-All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
-
-### Sizes
-
-| Usage | Size |
-|-------|------|
-| Standard / default | 24px |
-| Compact / inline | 16px |
-| Large / featured | 32–48px |
-
-Always use sizes within the supported range: **16px to 48px**.
-
-### Weights
-
-Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use Material Icons, Font Awesome, Heroicons, or any other library.
 
 ### Installation
 
 ```bash
 yarn add @phosphor-icons/react
 ```
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Compact / inline | 16px |
+| Standard / default | 24px |
+| Large / featured | 32–48px |
+
+Always use sizes within **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
 
 ### Usage example
 
@@ -172,74 +75,13 @@ export function MyExtension(): JSX.Element {
 
 ---
 
-## 5. Spacing and Baseline Grid
+## 3. Quick checklist
 
-All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+Before presenting generated `.tsx` to the user, verify:
 
-| Value | Baseline multiple |
-|-------|-----------------|
-| 4px | 1× |
-| 8px | 2× |
-| 12px | 3× |
-| 16px | 4× |
-| 20px | 5× |
-| 24px | 6× |
-| 32px | 8× |
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-style placeholders)?
+- [ ] All icons imported from `@phosphor-icons/react`?
+- [ ] Icon sizes between 16px and 48px (24px default)?
+- [ ] Icon weights consistent within the component?
 
-**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
-
----
-
-## 6. Responsive Breakpoints
-
-Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
-
-| Breakpoint | Resolution range | Notes |
-|-----------|-----------------|-------|
-| Small (mobile) | 320–743px | Margin: 24px, no column grid |
-| Medium (tablet) | 744–1279px | Gutters: 16px |
-| Large (desktop) | 1280–1919px | Gutters: 20px |
-| Extra large (monitor) | 1920px+ | Gutters: 20px |
-
-Recommended mobile override (applied to the responsive section of the CSS file):
-
-```css
-@media (max-width: 743px) {
-  .container { padding: 12px; margin: 0 24px; }
-}
-```
-
----
-
-## 7. CSS File Structure
-
-Every extension CSS file must follow this structure:
-
-1. **Token declarations** — CSS custom properties on `.container`
-2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
-3. **Typography classes** — `.title`, `.subtitle`, `.text`
-4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
-5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
-6. **Responsive overrides** — `@media` queries at the bottom
-
-### Critical CSS rules
-
-- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
-- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
-- No `@import`, `position: fixed`, or `z-index: 9999`.
-- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
-
----
-
-## 8. Quick Compliance Checklist
-
-Before presenting generated CSS to the user, verify:
-
-- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
-- [ ] No hardcoded hex values outside the token declarations block?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
-- [ ] All spacing multiples of 4px?
-- [ ] All icons from Phosphor Icons?
-- [ ] All UI text in sentence case (no ALL-CAPS)?
-- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?
+For CSS verification (tokens, fonts, spacing, responsive), see [code-templates-and-patterns.md](code-templates-and-patterns.md) §"Design system rules baked into this template".

--- a/exports/agents-md/sales-app/sales-app-extensibility/references/design-guidelines.md
+++ b/exports/agents-md/sales-app/sales-app-extensibility/references/design-guidelines.md
@@ -201,7 +201,7 @@ Sales App extensions render within a host container that handles most layout res
 | Large (desktop) | 1280–1919px | Gutters: 20px |
 | Extra large (monitor) | 1920px+ | Gutters: 20px |
 
-Recommended mobile override (applied to the responsive section of the CSS module):
+Recommended mobile override (applied to the responsive section of the CSS file):
 
 ```css
 @media (max-width: 743px) {
@@ -211,9 +211,9 @@ Recommended mobile override (applied to the responsive section of the CSS module
 
 ---
 
-## 7. CSS Module Structure
+## 7. CSS File Structure
 
-Every extension CSS module must follow this structure:
+Every extension CSS file must follow this structure:
 
 1. **Token declarations** — CSS custom properties on `.container`
 2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`

--- a/exports/agents-md/sales-app/sales-app-extensibility/references/documentation-template.md
+++ b/exports/agents-md/sales-app/sales-app-extensibility/references/documentation-template.md
@@ -1,0 +1,60 @@
+---
+name: sales-app-documentation-template
+description: Markdown template for the docs/<ExtensionName>.md file generated in Step 4. Load when writing extension documentation to ensure all required sections are covered.
+metadata:
+  version: "1.0"
+---
+
+# Extension Documentation Template
+
+Generate `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist.
+
+The document must contain these 9 sections:
+
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+```markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+```

--- a/exports/agents-md/sales-app/sales-app-extensibility/references/static-analysis-rules.md
+++ b/exports/agents-md/sales-app/sales-app-extensibility/references/static-analysis-rules.md
@@ -1,0 +1,915 @@
+---
+name: sales-app-static-analysis-rules
+description: fsp-analyzer rule catalog for Sales App extension validation. Load during Step 3 (Code Generation & Validation) to check generated TypeScript/CSS against sandbox security, CSS containment, and React performance rules enforced at build time.
+metadata:
+  version: "1.0"
+---
+
+# Static Analysis Rules (fsp-analyzer)
+
+Sales App extensions run inside a sandboxed environment enforced by `@vtex/fsp-analyzer`. These rules are checked at `preBuild` and `preDev` hook time. The AI must validate all generated code against these rules before presenting it to the user.
+
+Rule IDs match the `ViolationKind`, `ReactViolationKind`, `WarningKind`, and `ReactWarningKind` types from `@vtex/fsp-analyzer` so developers can cross-reference with real build output.
+
+---
+
+## How to apply these rules
+
+After generating a component, CSS file, and `index.tsx`, check each generated file against the **violation** rules (block generation — fix before presenting) and the **warning** rules (flag to the user with a suggestion). Do not present code that has unresolved violations.
+
+---
+
+## 1. Sandbox Security Rules
+
+Applied to `.ts` and `.tsx` files by `FastStoreSandboxAnalyzer`.
+
+### `RESTRICTED_API` — DOM API access banned
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted identifiers: `document`, `window`, `localStorage`, `sessionStorage`, `navigator`.
+
+**Detection:** Any use of these identifiers as a value (not as a type import).
+
+**Correct**
+```typescript
+// Use React state and props for data; use useExtension() for account context
+const { account } = useExtension();
+```
+
+**Wrong**
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+---
+
+### `VARIABLE_ALIASING` — Aliasing restricted APIs
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Assigning a restricted API to a variable to circumvent detection.
+
+**Detection:** `const x = document`, `const [w, d] = [window, document]`, or any destructuring that aliases a restricted API.
+
+**Correct**
+```typescript
+// Pass data via props or React context, not via aliased globals
+```
+
+**Wrong**
+```typescript
+const doc = document;
+const [w, d] = [window, document];
+doc.querySelector('.item');
+```
+
+---
+
+### `GLOBAL_MANIPULATION` — Global object manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted member expressions: `window.location`, `window.history`.
+
+**Detection:** Member expressions on `window` to access `location` or `history`.
+
+**Correct**
+```typescript
+// Navigation is managed by Sales App shell; do not manipulate location
+```
+
+**Wrong**
+```typescript
+window.location.href = '/new-path';
+window.location.reload();
+```
+
+---
+
+### `HISTORY_MANIPULATION` — Browser history manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `window.history.pushState`, `window.history.replaceState`, `history.pushState`, `history.replaceState`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Let the Sales App shell handle routing
+```
+
+**Wrong**
+```typescript
+history.pushState({}, '', '/cart');
+window.history.replaceState(null, '', '/pdp');
+```
+
+---
+
+### `DYNAMIC_SCRIPT_CREATION` — Dynamic script creation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `document.createElement`, `document.write`, `document.writeln`, `document.body.appendChild`, `document.head.appendChild`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Render UI via JSX; never inject scripts dynamically
+```
+
+**Wrong**
+```typescript
+const script = document.createElement('script');
+script.src = 'https://cdn.example.com/lib.js';
+document.body.appendChild(script);
+```
+
+---
+
+### `CODE_EXECUTION` — Arbitrary code execution
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `eval`, `Function` (as constructor), `setTimeout` (string form), `setInterval` (string form), `new Function`.
+
+**Detection:** Any call or instantiation of these identifiers.
+
+> **Note on `setTimeout`/`setInterval`:** These are restricted in the sandbox to prevent arbitrary code injection. Use `useEffect` with `AbortController` or cleanup functions for timing-based logic:
+
+**Correct**
+```typescript
+useEffect(() => {
+  const id = window.setTimeout(() => { /* logic */ }, 500);
+  return () => window.clearTimeout(id);
+}, []);
+// Note: even this should be reviewed; prefer event-driven patterns
+```
+
+**Wrong**
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+---
+
+### `RESTRICTED_IMPORT` — Restricted Node.js module imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted modules: `fs`, `path`, `child_process`, `crypto`.
+
+**Detection:** Any `import` statement importing from these module names.
+
+**Correct**
+```typescript
+// Extensions are browser-only React components; do not import Node.js modules
+import { useCart } from '@vtex/sales-app';
+```
+
+**Wrong**
+```typescript
+import fs from 'fs';
+import { resolve } from 'path';
+import crypto from 'crypto';
+```
+
+---
+
+### `RESTRICTED_IMPORT_SOURCE` — Direct node_modules path imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Import paths containing `node_modules/`.
+
+**Wrong**
+```typescript
+import something from 'node_modules/lodash/get';
+```
+
+---
+
+### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+
+**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+
+> **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
+
+**Correct**
+```typescript
+// Always use IO Proxy relative path
+const response = await fetch('/_v/my-loyalty-api/points', {
+  credentials: 'include',
+});
+```
+
+**Wrong**
+```typescript
+const response = await fetch('https://api.example.com/data');
+const xhr = new XMLHttpRequest();
+```
+
+---
+
+### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
+
+**Detection:** `fetch()` first argument literal containing one of these domains.
+
+**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
+
+---
+
+### `QUERY_SELECTOR_USAGE` — DOM query selectors
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Use React refs for direct DOM access when absolutely needed
+const ref = useRef<HTMLDivElement>(null);
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.my-class');
+document.getElementById('cart-container');
+```
+
+---
+
+### `STYLE_MANIPULATION` — Direct style manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
+
+**Detection:** Any member expression matching these patterns.
+
+**Correct**
+```typescript
+// Use CSS modules and conditional class application
+import styles from './MyExtension.module.css';
+
+return <div className={isActive ? styles.active : styles.inactive} />;
+```
+
+**Wrong**
+```typescript
+element.style.color = 'red';
+element.classList.add('active');
+element.setAttribute('style', 'display: none');
+```
+
+---
+
+### `INFINITE_LOOP` — Infinite loops
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+
+**Wrong**
+```typescript
+while (true) {
+  processItem();
+}
+```
+
+---
+
+### `MEMORY_LEAK` — Memory leak patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  window.addEventListener('resize', handler);
+  // Missing cleanup — memory leak
+}, []);
+```
+
+---
+
+### `EXCESSIVE_API_CALLS` — Excessive API call patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+
+**Wrong**
+```typescript
+// fetch inside render — fires on every re-render
+const data = await fetch('/_v/api/data');
+
+// fetch inside loop — excessive calls
+for (const item of items) {
+  await fetch(`/_v/api/item/${item.id}`);
+}
+```
+
+---
+
+### `LARGE_BUNDLE_SIZE_IMPACT` — Bundle size impacts
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:**
+- String literals longer than 1,000 characters
+- Object literals with more than 100 properties
+- Imports from heavyweight libraries: `lodash`, `moment`
+
+**Action:** Warn the user and suggest alternatives (`date-fns` instead of `moment`, native array methods instead of `lodash`).
+
+**Correct**
+```typescript
+import { format } from 'date-fns';
+const formattedDate = format(new Date(), 'yyyy-MM-dd');
+```
+
+**Wrong**
+```typescript
+import moment from 'moment';
+import _ from 'lodash';
+```
+
+---
+
+## 2. CSS Containment Rules
+
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+
+### `CSS_GLOBAL_SELECTOR` — Global element selectors
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
+
+**Detection:** Any CSS rule whose selector matches or contains these elements at the top level.
+
+**Correct**
+```css
+/* Scope all rules inside the extension container */
+.extension-container {
+  font-size: 14px;
+}
+
+.extension-container .title {
+  font-weight: bold;
+}
+```
+
+**Wrong**
+```css
+body {
+  font-size: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --my-color: red;
+}
+```
+
+---
+
+### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
+
+**Detection:** Any rule or declaration matching these patterns.
+
+> **Note on positioning:** `position: relative` and `position: sticky` within the extension container are generally safe. Avoid `fixed` and unbounded `absolute` that escape the extension boundary.
+
+**Correct**
+```css
+.extension-container {
+  position: relative; /* safe — contained */
+}
+```
+
+**Wrong**
+```css
+.overlay {
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+}
+
+:host {
+  display: block;
+}
+```
+
+---
+
+### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+
+**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+
+**Correct**
+```css
+/* CSS Module — all classes are auto-scoped */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+```css
+/* Plain CSS — must namespace manually */
+.extension-container { padding: 8px; }
+.extension-title { font-size: 16px; }
+```
+
+**Wrong**
+```css
+/* Plain CSS — no namespace — pollutes global styles */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+---
+
+### `CSS_GLOBAL_IMPORT` — CSS @import rules
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@import` pulls external stylesheets that affect global styles and bypass containment.
+
+**Detection:** Any `@import` at-rule anywhere in the CSS file.
+
+**Correct**
+```css
+/* Import a local CSS variable file via bundler config, not @import */
+```
+
+**Wrong**
+```css
+@import url('https://fonts.googleapis.com/css2?family=Roboto');
+@import './reset.css';
+```
+
+---
+
+### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+
+**Correct**
+```css
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+```css
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+---
+
+### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
+
+**Detection:** Declarations using restricted property names (e.g., properties that set global layout hints).
+
+**Action:** If detected, remove or scope the declaration appropriately.
+
+---
+
+### `CSS_RESTRICTED_VALUE` — Restricted CSS values
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
+
+**Detection:** `!important` in any declaration, or values targeting global layout tokens.
+
+**Correct**
+```css
+.extension-button {
+  color: var(--vtex-color-primary);
+}
+```
+
+**Wrong**
+```css
+.extension-button {
+  color: red !important;
+}
+```
+
+---
+
+## 3. React Performance Rules
+
+Applied to `.tsx` files by `ReactPerformanceAnalyzer`. Violations block presentation; warnings are flagged to the user.
+
+### `REACT_UNNECESSARY_RERENDER` — State update inside loop
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+State setter calls inside `for` or `while` loops trigger a re-render on every iteration.
+
+**Detection:** A `setState` / `set*` call whose parent node is a `for` or `while` statement.
+
+**Correct**
+```typescript
+// Compute derived value, then set once
+const updatedItems = items.map(transform);
+setItems(updatedItems);
+```
+
+**Wrong**
+```typescript
+for (const item of items) {
+  setCount((c) => c + 1); // re-renders on every iteration
+}
+```
+
+---
+
+### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
+
+**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
+
+**Correct**
+```typescript
+const filteredItems = useMemo(() => items.filter(isActive), [items]);
+
+return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
+  </ul>
+);
+```
+
+---
+
+### `REACT_ANONYMOUS_COMPONENT` — Anonymous (lowercase) component
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Components assigned to variables starting with lowercase are treated as HTML tags by React and cannot be used in JSX.
+
+**Detection:** Arrow function or function expression assigned to a variable that does not start with an uppercase letter.
+
+**Correct**
+```typescript
+export function LoyaltyPoints(): JSX.Element { ... }
+export const WarrantyBadge = (): JSX.Element => { ... };
+```
+
+**Wrong**
+```typescript
+const loyaltyPoints = (): JSX.Element => { ... };
+const warrantyBadge = function() { ... };
+```
+
+---
+
+### `REACT_DIRECT_DOM_MANIPULATION` — Direct DOM manipulation in React
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Bypasses the React virtual DOM and causes unpredictable behavior.
+
+**Detection:** Calls to `document.querySelector` or `document.getElementById` inside a React component.
+
+**Correct**
+```typescript
+const containerRef = useRef<HTMLDivElement>(null);
+// Access DOM via containerRef.current
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.cart-list');
+el.style.display = 'none'; // bypasses React
+```
+
+---
+
+### `REACT_LAYOUT_EFFECT_MISUSE` — useLayoutEffect usage
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`useLayoutEffect` blocks the browser paint and can cause performance issues in a sandboxed extension.
+
+**Detection:** Any call to `useLayoutEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  // DOM reading/writing after paint
+}, []);
+```
+
+**Wrong**
+```typescript
+useLayoutEffect(() => {
+  // blocks paint
+}, []);
+```
+
+---
+
+### `REACT_MISSING_DEPS` — Missing dependency array
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useEffect`, `useCallback`, or `useMemo` without a second argument re-runs on every render.
+
+**Detection:** A call to one of these hooks with fewer than 2 arguments, or with a non-array second argument.
+
+**Correct**
+```typescript
+useEffect(() => {
+  fetchData();
+}, [productId]); // explicit deps
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  fetchData(); // runs on every render
+});
+```
+
+---
+
+### `REACT_INLINE_FUNCTION` — Inline functions in JSX props
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Arrow functions defined directly in JSX attributes create a new function reference on every render, preventing child memoization.
+
+**Detection:** Function expression or arrow function expression whose parent is a JSX expression container or prop.
+
+**Correct**
+```typescript
+const handleClick = useCallback(() => {
+  doSomething();
+}, []);
+
+return <button onClick={handleClick}>Click</button>;
+```
+
+**Wrong**
+```typescript
+return <button onClick={() => doSomething()}>Click</button>;
+```
+
+---
+
+### `REACT_LARGE_COMPONENT` — Component over 200 lines
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Large components are harder to maintain and test. Threshold: **200 lines**.
+
+**Detection:** A function/arrow function with start/end line difference > 200.
+
+**Action:** Suggest splitting into smaller sub-components or extracting logic into custom hooks.
+
+---
+
+### `REACT_MANY_USESTATE` — More than 5 useState calls
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Many `useState` calls in a single component indicate complex local state. Threshold: **5 calls**.
+
+**Detection:** More than 5 calls to `useState` (or `React.useState`) within a single function component.
+
+**Action:** Suggest consolidating related state into a single `useState` with an object, or extracting to a custom hook.
+
+**Correct**
+```typescript
+const [formState, setFormState] = useState({
+  name: '',
+  email: '',
+  quantity: 1,
+});
+```
+
+**Wrong**
+```typescript
+const [name, setName] = useState('');
+const [email, setEmail] = useState('');
+const [quantity, setQuantity] = useState(1);
+const [loading, setLoading] = useState(false);
+const [error, setError] = useState<string | null>(null);
+const [submitted, setSubmitted] = useState(false); // 6th useState — flagged
+```
+
+---
+
+### `REACT_CONDITIONAL_HOOK` — Hook called conditionally
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a hook inside an `if`, `switch`, or ternary expression violates the Rules of Hooks.
+
+**Detection:** A hook call (useEffect, useState, useMemo, useCallback, useLayoutEffect) whose ancestor is an `IfStatement`, `SwitchStatement`, or `ConditionalExpression`.
+
+**Correct**
+```typescript
+const cart = useCart(); // always called unconditionally
+
+if (!cart) return <></>;
+```
+
+**Wrong**
+```typescript
+if (isEnabled) {
+  const cart = useCart(); // conditional hook call — violates Rules of Hooks
+}
+```
+
+---
+
+### `REACT_COMPLEX_JSX` — Deep JSX nesting
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Deep JSX trees are harder to read and may indicate a need to extract sub-components. Threshold: **5 levels deep**.
+
+**Detection:** A JSX element whose JSX child tree exceeds 5 levels of nesting.
+
+**Action:** Extract inner JSX into a named sub-component.
+
+---
+
+### `REACT_UNOPTIMIZED_LIST` — List rendering without key or large list
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Missing `key` props in list rendering causes React reconciliation issues. Lists over 50 items may need virtualization.
+
+**Detection:**
+- `map()` producing JSX without a `key` attribute on the root element
+- List size exceeding 50 items
+
+**Correct**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li key={item.id}>{item.name}</li>
+    ))}
+  </ul>
+);
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li>{item.name}</li> // missing key
+    ))}
+  </ul>
+);
+```
+
+---
+
+### `REACT_COMPLEX_STATE` — useState with complex object
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useState` initialized with an object having more than 5 properties suggests a need for `useReducer`. Threshold: **5 properties**.
+
+**Detection:** `useState(obj)` where `obj` is an object literal with > 5 properties.
+
+**Action:** Suggest converting to `useReducer` for complex state.
+
+---
+
+### `REACT_NESTED_UPDATE` — Nested state updates
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a state setter from within another state setter's callback can cause unexpected re-renders.
+
+**Detection:** A `set*` call whose ancestor is another `set*` call expression.
+
+---
+
+## Validation Output Format
+
+When reporting issues after code review, group by file and severity:
+
+```
+### Static Analysis Results
+
+**Violations (must fix before completing Step 3):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Fix: <suggested fix>
+
+**Warnings (review with user):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Suggestion: <improvement>
+
+✅ No violations found. N warnings flagged.
+```
+
+Do not proceed with Step 4 (Documentation) until all violations are resolved.

--- a/exports/agents-md/sales-app/sales-app-extensibility/references/static-analysis-rules.md
+++ b/exports/agents-md/sales-app/sales-app-extensibility/references/static-analysis-rules.md
@@ -204,20 +204,33 @@ import something from 'node_modules/lodash/get';
 
 ---
 
+### `NON_APPROVED_PACKAGE` — Import from non-approved package
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Any import whose source starts with `@` or contains `/`, unless it is `react` or a `node_modules/` direct path. Fires for every `@vtex/*` scoped package and every relative import (`./foo`, `../bar`).
+
+> **Note:** This warning is noisy — it fires for all legitimate Sales App imports (`@vtex/sales-app`, `@phosphor-icons/react`, relative component paths). Do not surface to the user when the import is from `@vtex/*` or a relative path. Investigate only when the import is from an unexpected third-party package.
+
+**Detection:** `import { … } from 'source'` where `source.startsWith('@')` or `source.includes('/')`, and source is not `'react'` or a `node_modules/` path.
+
+---
+
 ### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+Two detection paths:
 
-**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+1. **Direct API use:** `fetch`, `XMLHttpRequest`, `script.src`, `link.href` used as member expressions.
+2. **Known CDN domains in string literal:** `fetch('https://cdn.jsdelivr.net/...')` or any URL containing `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`, `api.example.com`, or ending with `.js`.
 
 > **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
 
 **Correct**
 ```typescript
-// Always use IO Proxy relative path
 const response = await fetch('/_v/my-loyalty-api/points', {
   credentials: 'include',
 });
@@ -226,6 +239,7 @@ const response = await fetch('/_v/my-loyalty-api/points', {
 **Wrong**
 ```typescript
 const response = await fetch('https://api.example.com/data');
+const response = await fetch('https://cdn.jsdelivr.net/npm/lodash.js'); // CDN — also Violation
 const xhr = new XMLHttpRequest();
 ```
 
@@ -233,14 +247,14 @@ const xhr = new XMLHttpRequest();
 
 ### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
 
-**Severity:** Warning (flag)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. CDN domain fetches are actually reported as `EXTERNAL_RESOURCE_LOADING` (Violation, block) — not as this Warning. Treat any fetch to a CDN domain as a **build-blocking Violation**, not a soft warning.
+
+**Severity:** Warning (flag) — *see note above; actual enforcement is via `EXTERNAL_RESOURCE_LOADING`*  
 **Files:** `.ts`, `.tsx`
 
 Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
 
 **Detection:** `fetch()` first argument literal containing one of these domains.
-
-**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
 
 ---
 
@@ -251,7 +265,7 @@ Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.co
 
 Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
 
-**Detection:** Any call to these methods.
+**Detection:** Any call where the callee matches `document.querySelector`, `document.getElementById`, etc. (the variable must be literally named `document`). Calls via a ref object — e.g. `containerRef.current.querySelector(...)` — are **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
@@ -274,14 +288,14 @@ document.getElementById('cart-container');
 
 Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
 
-**Detection:** Any member expression matching these patterns.
+**Detection:** Matches only when the object is literally named `element` (e.g. `element.style`). Equivalent access through other variable names — e.g. `divRef.current.style`, `el.className` — is **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
-// Use plain CSS with namespaced class names
+// Use plain CSS classes from the component stylesheet
 import './MyExtension.css';
 
-return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
+return <div className={isActive ? 'active' : 'inactive'} />;
 ```
 
 **Wrong**
@@ -298,7 +312,7 @@ element.setAttribute('style', 'display: none');
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+**Detection:** `while(true)` or `do...while(true)` with literal `true` condition.
 
 **Wrong**
 ```typescript
@@ -309,9 +323,22 @@ while (true) {
 
 ---
 
+### `POTENTIAL_INFINITE_LOOP` — Incomplete for-loop
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `for` statement with no `update` expression AND no `test` expression (e.g. `for (let i = 0;;) { … }`).
+
+**Action:** Warn the user and ensure the loop has a proper termination condition.
+
+---
+
 ### `MEMORY_LEAK` — Memory leak patterns
 
-**Severity:** Violation (block)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. The active rule is `POTENTIAL_MEMORY_LEAK` (Warning) below. Event listeners without cleanup **will not block the build**, but remain a Hard Constraint — always add a cleanup return in `useEffect`.
+
+**Severity:** Violation (block) — *see note above; not currently enforced at build time*  
 **Files:** `.ts`, `.tsx`
 
 **Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
@@ -335,23 +362,58 @@ useEffect(() => {
 
 ---
 
+### `POTENTIAL_MEMORY_LEAK` — Likely memory leak patterns
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Three triggers:
+1. Any `addEventListener` call — the analyzer warns regardless of whether a corresponding `removeEventListener` exists in cleanup.
+2. Recursive function call where the callee name matches the parent `FunctionDeclaration` identifier.
+3. `Array.push` inside a `for` or `while` loop.
+
+**Action:** Verify the component has a proper cleanup return in `useEffect` for any event listener, and that recursive functions have a clear base case.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+---
+
 ### `EXCESSIVE_API_CALLS` — Excessive API call patterns
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+**Detection:** `fetch` or `XMLHttpRequest` calls whose parent is a `for` or `while` loop.
 
 **Wrong**
 ```typescript
-// fetch inside render — fires on every re-render
-const data = await fetch('/_v/api/data');
-
 // fetch inside loop — excessive calls
 for (const item of items) {
   await fetch(`/_v/api/item/${item.id}`);
 }
 ```
+
+---
+
+### `FREQUENT_API_CALLS` — API call outside loop / rapid setInterval
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Two triggers:
+1. `fetch` or `XMLHttpRequest` call **outside** a loop (i.e. anywhere else in the component). Fires for every fetch — ensure calls are wrapped in `useEffect` with proper deps and are rate-limited or cached.
+2. `setInterval` with a numeric delay argument below 1000 ms.
+
+> **Note:** Trigger 1 is intentionally broad — it flags every `fetch()` call as a reminder to verify it is not running unintentionally on every render. It does **not** mean every fetch is wrong. Only surface this to the user when the fetch is genuinely outside a `useEffect` or appears to run on each render.
+
+**Action:** Warn the user and suggest wrapping fetches in `useEffect`, using caching, or increasing the polling interval.
 
 ---
 
@@ -383,7 +445,25 @@ import _ from 'lodash';
 
 ## 2. CSS Containment Rules
 
-Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`.
+
+**Sales App analyzer configuration** (from `@vtex/sales-app` build/dev hook):
+
+```typescript
+cssOptions: {
+  allowedNamespaces: ['sales-app-extension-'],
+  defaultNamespace: 'sales-app-extension-',
+  transformNonCompliant: true,
+  overwriteTransformed: true,
+}
+```
+
+Two consequences for the rules below:
+
+1. The configured namespace is **`sales-app-extension-`**, not the analyzer's bare default of `extension-`. Any rule that talks about "the allowed namespace" means `sales-app-extension-` in this project.
+2. `transformNonCompliant: true` softens the namespace rules: when a selector or `@keyframes` name is not prefixed, the analyzer auto-rewrites it into a sibling `*.transformed.css` file and emits a `CSS_TRANSFORMED` **warning** instead of a `CSS_NAMESPACE_REQUIRED` / `CSS_GLOBAL_KEYFRAMES` **violation**. The original `.css` (and the `className` strings in JSX) are left untouched, so the build does not break. This is why the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) ships unprefixed selectors like `.container`, `.title`, `.row` — they are valid in this project.
+
+The other CSS rules (`CSS_GLOBAL_SELECTOR`, `CSS_CONTAINMENT_BREAKOUT`, `CSS_GLOBAL_IMPORT`, `CSS_RESTRICTED_PROPERTY`, `CSS_RESTRICTED_VALUE`, and the inline-style rules) are **not** softened by `transformNonCompliant` — they remain build-blocking violations.
 
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
@@ -396,12 +476,12 @@ Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#_
 
 **Correct**
 ```css
-/* Scope all rules inside the extension container */
-.extension-container {
+/* Scope rules inside the extension container — never target global elements */
+.container {
   font-size: 14px;
 }
 
-.extension-container .title {
+.container .title {
   font-weight: bold;
 }
 ```
@@ -436,7 +516,7 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 **Correct**
 ```css
-.extension-container {
+.container {
   position: relative; /* safe — contained */
 }
 ```
@@ -459,26 +539,27 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
+All CSS selectors should be scoped under an allowed namespace prefix. In the Sales App, that prefix is `sales-app-extension-`. Because the project sets `transformNonCompliant: true`, an unprefixed selector does **not** block the build: the analyzer rewrites it inside a sibling `Component.transformed.css` and emits a `CSS_TRANSFORMED` warning instead of `CSS_NAMESPACE_REQUIRED`. The original `Component.css` (which is what gets bundled) keeps the unprefixed class, so the JSX `className="container"` continues to match.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
+**Detection:** A selector that does not include any value from `allowedNamespaces` (substring check on `.namespace`, `#namespace`, or `[class*="namespace"]`).
 
-**Correct**
+**Correct (and matches the CSS template)**
 ```css
-/* Plain CSS — namespace all classes */
-.extension-container { padding: 8px; }
-.extension-title { font-size: 16px; }
-```
-
-**Wrong**
-```css
-/* Plain CSS — no namespace — pollutes global styles */
+/* Unprefixed top-level classes are accepted because transformNonCompliant=true. */
 .container { padding: 8px; }
-.title { font-size: 16px; }
+.title     { font-size: 16px; }
 ```
+
+**Also correct (explicit prefix, never warns)**
+```css
+.sales-app-extension-container { padding: 8px; }
+.sales-app-extension-title     { font-size: 16px; }
+```
+
+> Prefer the unprefixed form to match the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) and the JSX in the component templates. The `CSS_TRANSFORMED` warning that fires for these is informational only.
 
 ---
 
@@ -506,26 +587,27 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell. As with `CSS_NAMESPACE_REQUIRED`, `transformNonCompliant: true` rewrites the name in `*.transformed.css` and emits `CSS_TRANSFORMED` instead of blocking.
 
-**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix (`sales-app-extension-` in this project).
 
-**Correct**
+The CSS template prefixes keyframes with `${COMPONENT_NAME}-` (e.g. `LoyaltyPoints-spin`). That prefix does **not** start with `sales-app-extension-`, so it triggers a `CSS_TRANSFORMED` warning — the build still succeeds, but the transformed file will rename it to `sales-app-extension-LoyaltyPoints-spin`. Either form is acceptable.
+
+**Correct (no warning)**
 ```css
-@keyframes extension-fade-in {
+@keyframes sales-app-extension-fade-in {
   from { opacity: 0; }
   to   { opacity: 1; }
 }
 ```
 
-**Wrong**
+**Also correct (CSS_TRANSFORMED warning, build passes)**
 ```css
-@keyframes fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+@keyframes LoyaltyPoints-spin {
+  to { transform: rotate(360deg); }
 }
 ```
 
@@ -555,16 +637,59 @@ Certain CSS values (e.g., `!important`) override the cascade and break containme
 
 **Correct**
 ```css
-.extension-button {
-  color: var(--vtex-color-primary);
+.button {
+  color: var(--sa-color-primary);
 }
 ```
 
 **Wrong**
 ```css
-.extension-button {
+.button {
   color: red !important;
 }
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_PROPERTY` — Restricted property in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props in JSX may not use properties that affect layout or containment.
+
+Restricted properties: `position`, `z-index`, `top`, `left`, `right`, `bottom`, `all`, `contain`, `content`, `isolation`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted property names.
+
+**Correct**
+```typescript
+// Use CSS classes for layout properties
+return <div className="overlay" />;
+```
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed', top: 0 }} />;
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_VALUE` — Restricted value in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props may not use values that break containment or cascade.
+
+Restricted values: `fixed`, `absolute`, `!important`, `inherit`, `initial`, `unset`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted values.
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed' }} />;
+return <div style={{ display: 'inherit' }} />;
 ```
 
 ---
@@ -594,33 +719,6 @@ setItems(updatedItems);
 for (const item of items) {
   setCount((c) => c + 1); // re-renders on every iteration
 }
-```
-
----
-
-### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
-
-**Severity:** Violation (block)  
-**Files:** `.tsx`
-
-`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
-
-**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
-
-**Correct**
-```typescript
-const filteredItems = useMemo(() => items.filter(isActive), [items]);
-
-return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
-```
-
-**Wrong**
-```typescript
-return (
-  <ul>
-    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
-  </ul>
-);
 ```
 
 ---

--- a/exports/agents-md/sales-app/sales-app-extensibility/references/static-analysis-rules.md
+++ b/exports/agents-md/sales-app/sales-app-extensibility/references/static-analysis-rules.md
@@ -278,10 +278,10 @@ Restricted expressions: `element.style`, `element.className`, `element.classList
 
 **Correct**
 ```typescript
-// Use CSS modules and conditional class application
-import styles from './MyExtension.module.css';
+// Use plain CSS with namespaced class names
+import './MyExtension.css';
 
-return <div className={isActive ? styles.active : styles.inactive} />;
+return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
 ```
 
 **Wrong**
@@ -388,7 +388,7 @@ Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
 
@@ -426,7 +426,7 @@ body {
 ### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
 
@@ -460,21 +460,15 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
 
 **Correct**
 ```css
-/* CSS Module — all classes are auto-scoped */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-```
-
-```css
-/* Plain CSS — must namespace manually */
+/* Plain CSS — namespace all classes */
 .extension-container { padding: 8px; }
 .extension-title { font-size: 16px; }
 ```
@@ -491,7 +485,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_IMPORT` — CSS @import rules
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@import` pulls external stylesheets that affect global styles and bypass containment.
 
@@ -513,7 +507,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
 
@@ -540,7 +534,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
 
@@ -553,7 +547,7 @@ Certain properties affect layout or rendering globally and are restricted to pre
 ### `CSS_RESTRICTED_VALUE` — Restricted CSS values
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
 

--- a/exports/claude/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/claude/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -326,82 +326,115 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Module
 
-All extensions use CSS modules with Admin UI design tokens.
+All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Admin UI patterns.
+ * Design tokens follow Sales App Design Guidelines.
+ * Reference: references/design-guidelines.md
+ * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
-.container { padding: 16px; background-color: #ffffff; }
-.content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: #1a1a1a; margin: 0; }
-.subtitle { font-size: 14px; color: #666666; margin: 0; }
-.text { font-size: 14px; color: #333333; line-height: 1.5; }
+.container {
+  /* Sales App design tokens — do not replace with hardcoded hex values */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+  --sa-color-bg:        #FFFFFF;
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
-/* Loading State */
+  padding: 16px;
+  background-color: var(--sa-color-bg);
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.content { display: flex; flex-direction: column; gap: 12px; }
+.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
+.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
+.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+
+/* Loading state */
 .loading {
   display: flex; align-items: center; justify-content: center;
-  gap: 8px; padding: 24px; color: #666666;
+  gap: 8px; padding: 24px; color: var(--sa-color-text-secondary);
 }
 .spinner {
   width: 20px; height: 20px;
-  border: 2px solid #e0e0e0; border-top-color: #0066cc;
-  border-radius: 50%; animation: spin 1s linear infinite;
+  border: 2px solid var(--sa-color-border); border-top-color: var(--sa-color-primary);
+  border-radius: 50%; animation: ${COMPONENT_NAME}-spin 1s linear infinite;
 }
-@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes ${COMPONENT_NAME}-spin { to { transform: rotate(360deg); } }
 
-/* Error State */
+/* Error state */
 .error {
-  padding: 16px; background-color: #fff5f5;
-  border: 1px solid #ffcccc; border-radius: 8px;
-  color: #cc0000; font-size: 14px;
+  padding: 16px; background-color: var(--sa-color-error-bg);
+  border: 1px solid var(--sa-color-error-border); border-radius: 8px;
+  color: var(--sa-color-error-text); font-size: 14px;
 }
 
-/* Button Styles */
+/* Button styles */
 .button {
   display: inline-flex; align-items: center; justify-content: center;
-  padding: 10px 16px; font-size: 14px; font-weight: 500;
+  padding: 12px 16px; font-size: 14px; font-weight: 500;
   border: none; border-radius: 6px; cursor: pointer;
   transition: background-color 0.2s ease;
 }
-.buttonPrimary { background-color: #0066cc; color: #ffffff; }
-.buttonPrimary:hover { background-color: #0052a3; }
-.buttonSecondary { background-color: #f0f0f0; color: #333333; }
-.buttonSecondary:hover { background-color: #e0e0e0; }
+.buttonPrimary { background-color: var(--sa-color-primary); color: #FFFFFF; }
+.buttonPrimary:hover { background-color: var(--sa-color-primary-hover); }
+.buttonSecondary { background-color: var(--sa-color-bg-muted); color: var(--sa-color-text-tertiary); }
+.buttonSecondary:hover { background-color: var(--sa-color-border); }
 
-/* Card Styles */
+/* Card */
 .card {
-  padding: 16px; background-color: #f9f9f9;
-  border-radius: 8px; border: 1px solid #e0e0e0;
+  padding: 16px; background-color: var(--sa-color-bg-subtle);
+  border-radius: 8px; border: 1px solid var(--sa-color-border);
 }
 
-/* Badge Styles */
+/* Badges */
 .badge {
   display: inline-block; padding: 4px 8px;
   font-size: 12px; font-weight: 500; border-radius: 4px;
 }
-.badgeSuccess { background-color: #e6f4ea; color: #137333; }
-.badgeWarning { background-color: #fef7e0; color: #b06000; }
-.badgeInfo { background-color: #e8f0fe; color: #1a73e8; }
+.badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
+.badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
+.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
 
-/* Input Styles */
+/* Input */
 .input {
-  width: 100%; padding: 10px 12px; font-size: 14px;
-  border: 1px solid #d0d0d0; border-radius: 6px;
+  width: 100%; padding: 12px; font-size: 14px;
+  border: 1px solid var(--sa-color-border-input); border-radius: 6px;
   outline: none; transition: border-color 0.2s ease;
 }
-.input:focus { border-color: #0066cc; }
+.input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/Flex Helpers */
+/* Row/flex helpers */
 .row { display: flex; align-items: center; gap: 12px; }
 .spaceBetween { justify-content: space-between; }
 
-/* Price Display */
-.price { font-size: 18px; font-weight: 600; color: #1a1a1a; }
-.priceOld { font-size: 14px; color: #999999; text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: #137333; font-weight: 500; }
+/* Price display */
+.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+
+/* Responsive — Sales App breakpoints */
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
 ```
 
 ## index.tsx with defineExtensions
@@ -446,6 +479,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
+12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/claude/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/claude/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -326,38 +326,73 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Stylesheet
 
-All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules). The full Sales App design system for CSS — tokens, typography, spacing grid, responsive breakpoints, and structure — is inlined below. **Use this template as the single source of truth for any CSS generation.**
 
 **CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
+
+### Design system rules baked into this template
+
+These rules apply to **every** generated extension CSS. The template below already complies — keep it that way.
+
+| Topic | Rule |
+|-------|------|
+| Tokens | All colors must reference `--sa-color-*` tokens declared on `.container`. **Never** use hardcoded hex values anywhere else. |
+| Font family | `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif` on `.container`, inherited by descendants. |
+| Font weights | Only Regular (400), Medium (500), Semibold (600), Bold (700). |
+| Font sizes (px) | Allowed scale only: **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**. Never `13`, `15`, `17`, etc. |
+| Typography roles | Section title = 16px/600 · Subtitle/label = 14px/500 · Body = 14px/400 · Caption = 12px/400 · Price = 18px/600. |
+| Spacing | Multiples of **4px** only (4, 8, 12, 16, 20, 24, 32, 40…). Never `10`, `14`, `18`, `22`. Applies to `padding`, `margin`, `gap`, `height`. |
+| Containment | No `position: fixed`, no `z-index: 9999`, no `:host`, no `:global`, no `@import`. `position: relative` and `sticky` are safe. |
+| Selectors | Use the unprefixed utility class names from this template (`.container`, `.content`, `.row`, `.title`, `.button`, etc.). The Sales App `fsp-analyzer` runs with `transformNonCompliant: true`, so unprefixed selectors emit a `CSS_TRANSFORMED` warning rather than a `CSS_NAMESPACE_REQUIRED` violation. Never use `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` — those are caught by `CSS_GLOBAL_SELECTOR` and remain blocking. |
+| Keyframes | Prefix with `${COMPONENT_NAME}-` (e.g., `${COMPONENT_NAME}-spin`). This raises a `CSS_TRANSFORMED` warning (build still passes) — use `sales-app-extension-${COMPONENT_NAME}-spin` if you want a clean run. |
+| `!important` | Never. |
+| Responsive | Use the breakpoint at `(max-width: 743px)` for mobile overrides. Sales App shell handles the rest. |
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Sales App Design Guidelines.
- * Reference: references/design-guidelines.md
+ * Sales App design system (tokens + typography + spacing + responsive) is fully inlined.
  * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
 .container {
-  /* Sales App design tokens — do not replace with hardcoded hex values */
+  /* === Sales App design tokens — single source of truth ===
+     Always declare these on .container. Reference via var(--sa-color-*) in all other rules.
+     Never use hardcoded hex values in CSS rules. */
+
+  /* Primary action */
   --sa-color-primary:       #157BF4;   /* Light Blue 800 */
   --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-  --sa-color-bg:        #FFFFFF;
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 — high emphasis */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600  — medium emphasis */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500  — low emphasis */
+  --sa-color-text-muted:     #999999;  /* Neutral 700  — disabled / hint */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
   --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
   --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
   --sa-color-border:       #E0E0E0;    /* Neutral 300 */
   --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
   --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
   --sa-color-error-border: #FFDFD9;    /* Red 200 */
   --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
   --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
   --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow / Orange scale) */
   --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
   --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
   --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
   --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
@@ -365,10 +400,16 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
   background-color: var(--sa-color-bg);
   font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
 }
+
+/* Layout */
 .content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
-.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
-.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+.row { display: flex; align-items: center; gap: 12px; }
+.spaceBetween { justify-content: space-between; }
+
+/* Typography — uses approved size scale (10, 12, 14, 16, 18, 20, 22, 24...) */
+.title    { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary);   margin: 0; }
+.subtitle { font-size: 14px; font-weight: 500; color: var(--sa-color-text-secondary); margin: 0; }
+.text     { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
 
 /* Loading state */
 .loading {
@@ -414,7 +455,7 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
 .badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
-.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
+.badgeInfo    { background-color: var(--sa-color-info-bg);    color: var(--sa-color-info-text); }
 
 /* Input */
 .input {
@@ -424,20 +465,33 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/flex helpers */
-.row { display: flex; align-items: center; gap: 12px; }
-.spaceBetween { justify-content: space-between; }
-
 /* Price display */
-.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
-.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+.price          { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld       { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount  { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
 
-/* Responsive — Sales App breakpoints */
+/* Responsive — Sales App breakpoints
+   Small (mobile)  320–743px  → margin: 24px, no column grid
+   Medium (tablet) 744–1279px → host gutters: 16px (no override needed)
+   Large (desktop) 1280–1919px → host gutters: 20px (no override needed)
+   Extra large     1920px+    → host gutters: 20px (no override needed) */
 @media (max-width: 743px) {
   .container { padding: 12px; margin: 0 24px; }
 }
 ```
+
+### CSS file structure
+
+Every extension CSS must follow this order:
+
+1. **Token declarations** — `--sa-color-*` on `.container`
+2. **Layout helpers** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography** — `.title`, `.subtitle`, `.text`
+4. **State** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive** — `@media` queries at the bottom
+
+For UX writing rules (sentence case) and iconography (Phosphor Icons) used in `.tsx`, see [design-guidelines.md](design-guidelines.md).
 
 ## index.tsx with defineExtensions
 
@@ -481,7 +535,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design system compliance** — the CSS file must follow the rules table at the top of the "CSS Stylesheet" section above: `--sa-color-*` custom properties declared on `.container` and used in all rules, `'VTEX Trust'` font family, allowed font sizes (10, 12, 14, 16, 18, 20, 22, 24, 28, 32…), 4px-multiple spacing, scoped selectors, and the responsive override at `(max-width: 743px)`. For UI text (sentence case) and icons (Phosphor), see [design-guidelines.md](design-guidelines.md).
 
 ## API Type Generation from Documentation
 

--- a/exports/claude/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/claude/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -445,6 +445,7 @@ After generating code, validate for these issues:
 8. **API call handling** — loading state and error handling must be present for any `fetch()` call
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
+11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
 
 ## API Type Generation from Documentation
 

--- a/exports/claude/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/claude/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -324,9 +324,11 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 }
 ```
 
-## CSS Module
+## CSS Stylesheet
 
-All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+
+**CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
 
 ```css
 /**
@@ -479,7 +481,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/claude/sales-app-sales-app-extensibility-ref-design-guidelines.md
+++ b/exports/claude/sales-app-sales-app-extensibility-ref-design-guidelines.md
@@ -194,7 +194,7 @@ Sales App extensions render within a host container that handles most layout res
 | Large (desktop) | 1280–1919px | Gutters: 20px |
 | Extra large (monitor) | 1920px+ | Gutters: 20px |
 
-Recommended mobile override (applied to the responsive section of the CSS module):
+Recommended mobile override (applied to the responsive section of the CSS file):
 
 ```css
 @media (max-width: 743px) {
@@ -204,9 +204,9 @@ Recommended mobile override (applied to the responsive section of the CSS module
 
 ---
 
-## 7. CSS Module Structure
+## 7. CSS File Structure
 
-Every extension CSS module must follow this structure:
+Every extension CSS file must follow this structure:
 
 1. **Token declarations** — CSS custom properties on `.container`
 2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`

--- a/exports/claude/sales-app-sales-app-extensibility-ref-design-guidelines.md
+++ b/exports/claude/sales-app-sales-app-extensibility-ref-design-guidelines.md
@@ -1,0 +1,238 @@
+# Sales App Design Guidelines
+
+All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+
+---
+
+## 1. UX and Writing Rules
+
+Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+
+| Rule | Correct | Wrong |
+|------|---------|-------|
+| Sentence case | "Add to cart" | "ADD TO CART" |
+| Proper nouns | "VTEX account" | "vtex account" |
+| No all-caps | "Loyalty points" | "LOYALTY POINTS" |
+| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+
+These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
+
+---
+
+## 2. Design Tokens (CSS Custom Properties)
+
+Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
+
+```css
+.container {
+  /* Primary action */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow/Orange scale) */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
+}
+```
+
+### Token mapping reference
+
+| Semantic role | Token | Hex | Palette origin |
+|--------------|-------|-----|----------------|
+| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
+| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
+| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
+| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
+| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
+| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
+| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
+| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
+| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
+| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
+| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
+| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
+| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
+| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
+| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
+| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
+| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
+| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
+| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
+| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+
+---
+
+## 3. Typography
+
+### Typeface
+
+The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
+
+```css
+font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+```
+
+Set this on the root `.container` class so all descendant elements inherit it.
+
+### Weights
+
+Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
+
+### Allowed font sizes
+
+Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
+
+Do not use arbitrary sizes like 13px, 15px, or 17px.
+
+| Use case | Size | Weight |
+|----------|------|--------|
+| Section title | 16px | Semibold (600) |
+| Subtitle / label | 14px | Medium (500) |
+| Body text | 14px | Regular (400) |
+| Caption / hint | 12px | Regular (400) |
+| Price | 18px | Semibold (600) |
+
+---
+
+## 4. Iconography
+
+### Library
+
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Standard / default | 24px |
+| Compact / inline | 16px |
+| Large / featured | 32–48px |
+
+Always use sizes within the supported range: **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+
+### Installation
+
+```bash
+yarn add @phosphor-icons/react
+```
+
+### Usage example
+
+```typescript
+import { ShoppingCart, Star, Warning } from '@phosphor-icons/react';
+
+export function MyExtension(): JSX.Element {
+  return (
+    <div className="container">
+      <ShoppingCart size={24} />
+      <span>Cart items</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. Spacing and Baseline Grid
+
+All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+
+| Value | Baseline multiple |
+|-------|-----------------|
+| 4px | 1× |
+| 8px | 2× |
+| 12px | 3× |
+| 16px | 4× |
+| 20px | 5× |
+| 24px | 6× |
+| 32px | 8× |
+
+**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
+
+---
+
+## 6. Responsive Breakpoints
+
+Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
+
+| Breakpoint | Resolution range | Notes |
+|-----------|-----------------|-------|
+| Small (mobile) | 320–743px | Margin: 24px, no column grid |
+| Medium (tablet) | 744–1279px | Gutters: 16px |
+| Large (desktop) | 1280–1919px | Gutters: 20px |
+| Extra large (monitor) | 1920px+ | Gutters: 20px |
+
+Recommended mobile override (applied to the responsive section of the CSS module):
+
+```css
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
+```
+
+---
+
+## 7. CSS Module Structure
+
+Every extension CSS module must follow this structure:
+
+1. **Token declarations** — CSS custom properties on `.container`
+2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography classes** — `.title`, `.subtitle`, `.text`
+4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive overrides** — `@media` queries at the bottom
+
+### Critical CSS rules
+
+- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
+- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
+- No `@import`, `position: fixed`, or `z-index: 9999`.
+- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
+
+---
+
+## 8. Quick Compliance Checklist
+
+Before presenting generated CSS to the user, verify:
+
+- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
+- [ ] No hardcoded hex values outside the token declarations block?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
+- [ ] All spacing multiples of 4px?
+- [ ] All icons from Phosphor Icons?
+- [ ] All UI text in sentence case (no ALL-CAPS)?
+- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?

--- a/exports/claude/sales-app-sales-app-extensibility-ref-design-guidelines.md
+++ b/exports/claude/sales-app-sales-app-extensibility-ref-design-guidelines.md
@@ -1,152 +1,55 @@
-# Sales App Design Guidelines
+# Sales App Design Guidelines (non-CSS)
 
-All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+This reference covers two topics that apply to **TSX content**, not CSS:
+
+1. **UX writing rules** — for any text rendered in JSX
+2. **Iconography** — when the extension uses icons
+
+> **For CSS:** all design tokens, typography scale, spacing grid, and responsive breakpoints are inlined directly in the CSS template at [code-templates-and-patterns.md](code-templates-and-patterns.md) §"CSS Stylesheet". That template is the single source of truth for any CSS generation. Do not invent or duplicate token values here.
 
 ---
 
-## 1. UX and Writing Rules
+## 1. UX Writing Rules
 
-Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+Apply to every string that appears in the UI (labels, buttons, messages, placeholders, alt text).
 
 | Rule | Correct | Wrong |
 |------|---------|-------|
 | Sentence case | "Add to cart" | "ADD TO CART" |
-| Proper nouns | "VTEX account" | "vtex account" |
+| Proper nouns capitalized | "VTEX account" | "vtex account" |
 | No all-caps | "Loyalty points" | "LOYALTY POINTS" |
-| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+| No system-style placeholders | "Your email" | "EMAIL ADDRESS" |
+| No CSS uppercase transforms | (omit `text-transform: uppercase`) | `text-transform: uppercase` |
 
-These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
-
----
-
-## 2. Design Tokens (CSS Custom Properties)
-
-Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
-
-```css
-.container {
-  /* Primary action */
-  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
-  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-
-  /* Text */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-
-  /* Backgrounds */
-  --sa-color-bg:        #FFFFFF;       /* Neutral White */
-  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
-  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
-
-  /* Borders */
-  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
-  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
-
-  /* Error (Red scale) */
-  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
-  --sa-color-error-border: #FFDFD9;    /* Red 200 */
-  --sa-color-error-text:   #EC3727;    /* Red 800 */
-
-  /* Success (Green scale) */
-  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
-  --sa-color-success-text: #01905F;    /* Green 800 */
-
-  /* Warning (Yellow/Orange scale) */
-  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
-  --sa-color-warning-text: #E57001;    /* Orange 700 */
-
-  /* Info (Light Blue scale) */
-  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
-  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
-}
-```
-
-### Token mapping reference
-
-| Semantic role | Token | Hex | Palette origin |
-|--------------|-------|-----|----------------|
-| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
-| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
-| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
-| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
-| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
-| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
-| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
-| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
-| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
-| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
-| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
-| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
-| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
-| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
-| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
-| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
-| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
-| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
-| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
-| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+These rules derive from Google Material Design and Apple Human Interface Guidelines, adopted by VTEX.
 
 ---
 
-## 3. Typography
-
-### Typeface
-
-The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
-
-```css
-font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-```
-
-Set this on the root `.container` class so all descendant elements inherit it.
-
-### Weights
-
-Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
-
-### Allowed font sizes
-
-Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
-
-Do not use arbitrary sizes like 13px, 15px, or 17px.
-
-| Use case | Size | Weight |
-|----------|------|--------|
-| Section title | 16px | Semibold (600) |
-| Subtitle / label | 14px | Medium (500) |
-| Body text | 14px | Regular (400) |
-| Caption / hint | 12px | Regular (400) |
-| Price | 18px | Semibold (600) |
-
----
-
-## 4. Iconography
+## 2. Iconography
 
 ### Library
 
-All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
-
-### Sizes
-
-| Usage | Size |
-|-------|------|
-| Standard / default | 24px |
-| Compact / inline | 16px |
-| Large / featured | 32–48px |
-
-Always use sizes within the supported range: **16px to 48px**.
-
-### Weights
-
-Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use Material Icons, Font Awesome, Heroicons, or any other library.
 
 ### Installation
 
 ```bash
 yarn add @phosphor-icons/react
 ```
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Compact / inline | 16px |
+| Standard / default | 24px |
+| Large / featured | 32–48px |
+
+Always use sizes within **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
 
 ### Usage example
 
@@ -165,74 +68,13 @@ export function MyExtension(): JSX.Element {
 
 ---
 
-## 5. Spacing and Baseline Grid
+## 3. Quick checklist
 
-All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+Before presenting generated `.tsx` to the user, verify:
 
-| Value | Baseline multiple |
-|-------|-----------------|
-| 4px | 1× |
-| 8px | 2× |
-| 12px | 3× |
-| 16px | 4× |
-| 20px | 5× |
-| 24px | 6× |
-| 32px | 8× |
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-style placeholders)?
+- [ ] All icons imported from `@phosphor-icons/react`?
+- [ ] Icon sizes between 16px and 48px (24px default)?
+- [ ] Icon weights consistent within the component?
 
-**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
-
----
-
-## 6. Responsive Breakpoints
-
-Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
-
-| Breakpoint | Resolution range | Notes |
-|-----------|-----------------|-------|
-| Small (mobile) | 320–743px | Margin: 24px, no column grid |
-| Medium (tablet) | 744–1279px | Gutters: 16px |
-| Large (desktop) | 1280–1919px | Gutters: 20px |
-| Extra large (monitor) | 1920px+ | Gutters: 20px |
-
-Recommended mobile override (applied to the responsive section of the CSS file):
-
-```css
-@media (max-width: 743px) {
-  .container { padding: 12px; margin: 0 24px; }
-}
-```
-
----
-
-## 7. CSS File Structure
-
-Every extension CSS file must follow this structure:
-
-1. **Token declarations** — CSS custom properties on `.container`
-2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
-3. **Typography classes** — `.title`, `.subtitle`, `.text`
-4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
-5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
-6. **Responsive overrides** — `@media` queries at the bottom
-
-### Critical CSS rules
-
-- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
-- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
-- No `@import`, `position: fixed`, or `z-index: 9999`.
-- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
-
----
-
-## 8. Quick Compliance Checklist
-
-Before presenting generated CSS to the user, verify:
-
-- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
-- [ ] No hardcoded hex values outside the token declarations block?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
-- [ ] All spacing multiples of 4px?
-- [ ] All icons from Phosphor Icons?
-- [ ] All UI text in sentence case (no ALL-CAPS)?
-- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?
+For CSS verification (tokens, fonts, spacing, responsive), see [code-templates-and-patterns.md](code-templates-and-patterns.md) §"Design system rules baked into this template".

--- a/exports/claude/sales-app-sales-app-extensibility-ref-documentation-template.md
+++ b/exports/claude/sales-app-sales-app-extensibility-ref-documentation-template.md
@@ -1,0 +1,53 @@
+# Extension Documentation Template
+
+Generate `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist.
+
+The document must contain these 9 sections:
+
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+```markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+```

--- a/exports/claude/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
+++ b/exports/claude/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
@@ -1,0 +1,908 @@
+# Static Analysis Rules (fsp-analyzer)
+
+Sales App extensions run inside a sandboxed environment enforced by `@vtex/fsp-analyzer`. These rules are checked at `preBuild` and `preDev` hook time. The AI must validate all generated code against these rules before presenting it to the user.
+
+Rule IDs match the `ViolationKind`, `ReactViolationKind`, `WarningKind`, and `ReactWarningKind` types from `@vtex/fsp-analyzer` so developers can cross-reference with real build output.
+
+---
+
+## How to apply these rules
+
+After generating a component, CSS file, and `index.tsx`, check each generated file against the **violation** rules (block generation — fix before presenting) and the **warning** rules (flag to the user with a suggestion). Do not present code that has unresolved violations.
+
+---
+
+## 1. Sandbox Security Rules
+
+Applied to `.ts` and `.tsx` files by `FastStoreSandboxAnalyzer`.
+
+### `RESTRICTED_API` — DOM API access banned
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted identifiers: `document`, `window`, `localStorage`, `sessionStorage`, `navigator`.
+
+**Detection:** Any use of these identifiers as a value (not as a type import).
+
+**Correct**
+```typescript
+// Use React state and props for data; use useExtension() for account context
+const { account } = useExtension();
+```
+
+**Wrong**
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+---
+
+### `VARIABLE_ALIASING` — Aliasing restricted APIs
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Assigning a restricted API to a variable to circumvent detection.
+
+**Detection:** `const x = document`, `const [w, d] = [window, document]`, or any destructuring that aliases a restricted API.
+
+**Correct**
+```typescript
+// Pass data via props or React context, not via aliased globals
+```
+
+**Wrong**
+```typescript
+const doc = document;
+const [w, d] = [window, document];
+doc.querySelector('.item');
+```
+
+---
+
+### `GLOBAL_MANIPULATION` — Global object manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted member expressions: `window.location`, `window.history`.
+
+**Detection:** Member expressions on `window` to access `location` or `history`.
+
+**Correct**
+```typescript
+// Navigation is managed by Sales App shell; do not manipulate location
+```
+
+**Wrong**
+```typescript
+window.location.href = '/new-path';
+window.location.reload();
+```
+
+---
+
+### `HISTORY_MANIPULATION` — Browser history manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `window.history.pushState`, `window.history.replaceState`, `history.pushState`, `history.replaceState`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Let the Sales App shell handle routing
+```
+
+**Wrong**
+```typescript
+history.pushState({}, '', '/cart');
+window.history.replaceState(null, '', '/pdp');
+```
+
+---
+
+### `DYNAMIC_SCRIPT_CREATION` — Dynamic script creation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `document.createElement`, `document.write`, `document.writeln`, `document.body.appendChild`, `document.head.appendChild`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Render UI via JSX; never inject scripts dynamically
+```
+
+**Wrong**
+```typescript
+const script = document.createElement('script');
+script.src = 'https://cdn.example.com/lib.js';
+document.body.appendChild(script);
+```
+
+---
+
+### `CODE_EXECUTION` — Arbitrary code execution
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `eval`, `Function` (as constructor), `setTimeout` (string form), `setInterval` (string form), `new Function`.
+
+**Detection:** Any call or instantiation of these identifiers.
+
+> **Note on `setTimeout`/`setInterval`:** These are restricted in the sandbox to prevent arbitrary code injection. Use `useEffect` with `AbortController` or cleanup functions for timing-based logic:
+
+**Correct**
+```typescript
+useEffect(() => {
+  const id = window.setTimeout(() => { /* logic */ }, 500);
+  return () => window.clearTimeout(id);
+}, []);
+// Note: even this should be reviewed; prefer event-driven patterns
+```
+
+**Wrong**
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+---
+
+### `RESTRICTED_IMPORT` — Restricted Node.js module imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted modules: `fs`, `path`, `child_process`, `crypto`.
+
+**Detection:** Any `import` statement importing from these module names.
+
+**Correct**
+```typescript
+// Extensions are browser-only React components; do not import Node.js modules
+import { useCart } from '@vtex/sales-app';
+```
+
+**Wrong**
+```typescript
+import fs from 'fs';
+import { resolve } from 'path';
+import crypto from 'crypto';
+```
+
+---
+
+### `RESTRICTED_IMPORT_SOURCE` — Direct node_modules path imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Import paths containing `node_modules/`.
+
+**Wrong**
+```typescript
+import something from 'node_modules/lodash/get';
+```
+
+---
+
+### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+
+**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+
+> **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
+
+**Correct**
+```typescript
+// Always use IO Proxy relative path
+const response = await fetch('/_v/my-loyalty-api/points', {
+  credentials: 'include',
+});
+```
+
+**Wrong**
+```typescript
+const response = await fetch('https://api.example.com/data');
+const xhr = new XMLHttpRequest();
+```
+
+---
+
+### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
+
+**Detection:** `fetch()` first argument literal containing one of these domains.
+
+**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
+
+---
+
+### `QUERY_SELECTOR_USAGE` — DOM query selectors
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Use React refs for direct DOM access when absolutely needed
+const ref = useRef<HTMLDivElement>(null);
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.my-class');
+document.getElementById('cart-container');
+```
+
+---
+
+### `STYLE_MANIPULATION` — Direct style manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
+
+**Detection:** Any member expression matching these patterns.
+
+**Correct**
+```typescript
+// Use CSS modules and conditional class application
+import styles from './MyExtension.module.css';
+
+return <div className={isActive ? styles.active : styles.inactive} />;
+```
+
+**Wrong**
+```typescript
+element.style.color = 'red';
+element.classList.add('active');
+element.setAttribute('style', 'display: none');
+```
+
+---
+
+### `INFINITE_LOOP` — Infinite loops
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+
+**Wrong**
+```typescript
+while (true) {
+  processItem();
+}
+```
+
+---
+
+### `MEMORY_LEAK` — Memory leak patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  window.addEventListener('resize', handler);
+  // Missing cleanup — memory leak
+}, []);
+```
+
+---
+
+### `EXCESSIVE_API_CALLS` — Excessive API call patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+
+**Wrong**
+```typescript
+// fetch inside render — fires on every re-render
+const data = await fetch('/_v/api/data');
+
+// fetch inside loop — excessive calls
+for (const item of items) {
+  await fetch(`/_v/api/item/${item.id}`);
+}
+```
+
+---
+
+### `LARGE_BUNDLE_SIZE_IMPACT` — Bundle size impacts
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:**
+- String literals longer than 1,000 characters
+- Object literals with more than 100 properties
+- Imports from heavyweight libraries: `lodash`, `moment`
+
+**Action:** Warn the user and suggest alternatives (`date-fns` instead of `moment`, native array methods instead of `lodash`).
+
+**Correct**
+```typescript
+import { format } from 'date-fns';
+const formattedDate = format(new Date(), 'yyyy-MM-dd');
+```
+
+**Wrong**
+```typescript
+import moment from 'moment';
+import _ from 'lodash';
+```
+
+---
+
+## 2. CSS Containment Rules
+
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+
+### `CSS_GLOBAL_SELECTOR` — Global element selectors
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
+
+**Detection:** Any CSS rule whose selector matches or contains these elements at the top level.
+
+**Correct**
+```css
+/* Scope all rules inside the extension container */
+.extension-container {
+  font-size: 14px;
+}
+
+.extension-container .title {
+  font-weight: bold;
+}
+```
+
+**Wrong**
+```css
+body {
+  font-size: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --my-color: red;
+}
+```
+
+---
+
+### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
+
+**Detection:** Any rule or declaration matching these patterns.
+
+> **Note on positioning:** `position: relative` and `position: sticky` within the extension container are generally safe. Avoid `fixed` and unbounded `absolute` that escape the extension boundary.
+
+**Correct**
+```css
+.extension-container {
+  position: relative; /* safe — contained */
+}
+```
+
+**Wrong**
+```css
+.overlay {
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+}
+
+:host {
+  display: block;
+}
+```
+
+---
+
+### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+
+**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+
+**Correct**
+```css
+/* CSS Module — all classes are auto-scoped */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+```css
+/* Plain CSS — must namespace manually */
+.extension-container { padding: 8px; }
+.extension-title { font-size: 16px; }
+```
+
+**Wrong**
+```css
+/* Plain CSS — no namespace — pollutes global styles */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+---
+
+### `CSS_GLOBAL_IMPORT` — CSS @import rules
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@import` pulls external stylesheets that affect global styles and bypass containment.
+
+**Detection:** Any `@import` at-rule anywhere in the CSS file.
+
+**Correct**
+```css
+/* Import a local CSS variable file via bundler config, not @import */
+```
+
+**Wrong**
+```css
+@import url('https://fonts.googleapis.com/css2?family=Roboto');
+@import './reset.css';
+```
+
+---
+
+### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+
+**Correct**
+```css
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+```css
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+---
+
+### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
+
+**Detection:** Declarations using restricted property names (e.g., properties that set global layout hints).
+
+**Action:** If detected, remove or scope the declaration appropriately.
+
+---
+
+### `CSS_RESTRICTED_VALUE` — Restricted CSS values
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
+
+**Detection:** `!important` in any declaration, or values targeting global layout tokens.
+
+**Correct**
+```css
+.extension-button {
+  color: var(--vtex-color-primary);
+}
+```
+
+**Wrong**
+```css
+.extension-button {
+  color: red !important;
+}
+```
+
+---
+
+## 3. React Performance Rules
+
+Applied to `.tsx` files by `ReactPerformanceAnalyzer`. Violations block presentation; warnings are flagged to the user.
+
+### `REACT_UNNECESSARY_RERENDER` — State update inside loop
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+State setter calls inside `for` or `while` loops trigger a re-render on every iteration.
+
+**Detection:** A `setState` / `set*` call whose parent node is a `for` or `while` statement.
+
+**Correct**
+```typescript
+// Compute derived value, then set once
+const updatedItems = items.map(transform);
+setItems(updatedItems);
+```
+
+**Wrong**
+```typescript
+for (const item of items) {
+  setCount((c) => c + 1); // re-renders on every iteration
+}
+```
+
+---
+
+### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
+
+**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
+
+**Correct**
+```typescript
+const filteredItems = useMemo(() => items.filter(isActive), [items]);
+
+return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
+  </ul>
+);
+```
+
+---
+
+### `REACT_ANONYMOUS_COMPONENT` — Anonymous (lowercase) component
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Components assigned to variables starting with lowercase are treated as HTML tags by React and cannot be used in JSX.
+
+**Detection:** Arrow function or function expression assigned to a variable that does not start with an uppercase letter.
+
+**Correct**
+```typescript
+export function LoyaltyPoints(): JSX.Element { ... }
+export const WarrantyBadge = (): JSX.Element => { ... };
+```
+
+**Wrong**
+```typescript
+const loyaltyPoints = (): JSX.Element => { ... };
+const warrantyBadge = function() { ... };
+```
+
+---
+
+### `REACT_DIRECT_DOM_MANIPULATION` — Direct DOM manipulation in React
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Bypasses the React virtual DOM and causes unpredictable behavior.
+
+**Detection:** Calls to `document.querySelector` or `document.getElementById` inside a React component.
+
+**Correct**
+```typescript
+const containerRef = useRef<HTMLDivElement>(null);
+// Access DOM via containerRef.current
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.cart-list');
+el.style.display = 'none'; // bypasses React
+```
+
+---
+
+### `REACT_LAYOUT_EFFECT_MISUSE` — useLayoutEffect usage
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`useLayoutEffect` blocks the browser paint and can cause performance issues in a sandboxed extension.
+
+**Detection:** Any call to `useLayoutEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  // DOM reading/writing after paint
+}, []);
+```
+
+**Wrong**
+```typescript
+useLayoutEffect(() => {
+  // blocks paint
+}, []);
+```
+
+---
+
+### `REACT_MISSING_DEPS` — Missing dependency array
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useEffect`, `useCallback`, or `useMemo` without a second argument re-runs on every render.
+
+**Detection:** A call to one of these hooks with fewer than 2 arguments, or with a non-array second argument.
+
+**Correct**
+```typescript
+useEffect(() => {
+  fetchData();
+}, [productId]); // explicit deps
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  fetchData(); // runs on every render
+});
+```
+
+---
+
+### `REACT_INLINE_FUNCTION` — Inline functions in JSX props
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Arrow functions defined directly in JSX attributes create a new function reference on every render, preventing child memoization.
+
+**Detection:** Function expression or arrow function expression whose parent is a JSX expression container or prop.
+
+**Correct**
+```typescript
+const handleClick = useCallback(() => {
+  doSomething();
+}, []);
+
+return <button onClick={handleClick}>Click</button>;
+```
+
+**Wrong**
+```typescript
+return <button onClick={() => doSomething()}>Click</button>;
+```
+
+---
+
+### `REACT_LARGE_COMPONENT` — Component over 200 lines
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Large components are harder to maintain and test. Threshold: **200 lines**.
+
+**Detection:** A function/arrow function with start/end line difference > 200.
+
+**Action:** Suggest splitting into smaller sub-components or extracting logic into custom hooks.
+
+---
+
+### `REACT_MANY_USESTATE` — More than 5 useState calls
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Many `useState` calls in a single component indicate complex local state. Threshold: **5 calls**.
+
+**Detection:** More than 5 calls to `useState` (or `React.useState`) within a single function component.
+
+**Action:** Suggest consolidating related state into a single `useState` with an object, or extracting to a custom hook.
+
+**Correct**
+```typescript
+const [formState, setFormState] = useState({
+  name: '',
+  email: '',
+  quantity: 1,
+});
+```
+
+**Wrong**
+```typescript
+const [name, setName] = useState('');
+const [email, setEmail] = useState('');
+const [quantity, setQuantity] = useState(1);
+const [loading, setLoading] = useState(false);
+const [error, setError] = useState<string | null>(null);
+const [submitted, setSubmitted] = useState(false); // 6th useState — flagged
+```
+
+---
+
+### `REACT_CONDITIONAL_HOOK` — Hook called conditionally
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a hook inside an `if`, `switch`, or ternary expression violates the Rules of Hooks.
+
+**Detection:** A hook call (useEffect, useState, useMemo, useCallback, useLayoutEffect) whose ancestor is an `IfStatement`, `SwitchStatement`, or `ConditionalExpression`.
+
+**Correct**
+```typescript
+const cart = useCart(); // always called unconditionally
+
+if (!cart) return <></>;
+```
+
+**Wrong**
+```typescript
+if (isEnabled) {
+  const cart = useCart(); // conditional hook call — violates Rules of Hooks
+}
+```
+
+---
+
+### `REACT_COMPLEX_JSX` — Deep JSX nesting
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Deep JSX trees are harder to read and may indicate a need to extract sub-components. Threshold: **5 levels deep**.
+
+**Detection:** A JSX element whose JSX child tree exceeds 5 levels of nesting.
+
+**Action:** Extract inner JSX into a named sub-component.
+
+---
+
+### `REACT_UNOPTIMIZED_LIST` — List rendering without key or large list
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Missing `key` props in list rendering causes React reconciliation issues. Lists over 50 items may need virtualization.
+
+**Detection:**
+- `map()` producing JSX without a `key` attribute on the root element
+- List size exceeding 50 items
+
+**Correct**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li key={item.id}>{item.name}</li>
+    ))}
+  </ul>
+);
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li>{item.name}</li> // missing key
+    ))}
+  </ul>
+);
+```
+
+---
+
+### `REACT_COMPLEX_STATE` — useState with complex object
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useState` initialized with an object having more than 5 properties suggests a need for `useReducer`. Threshold: **5 properties**.
+
+**Detection:** `useState(obj)` where `obj` is an object literal with > 5 properties.
+
+**Action:** Suggest converting to `useReducer` for complex state.
+
+---
+
+### `REACT_NESTED_UPDATE` — Nested state updates
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a state setter from within another state setter's callback can cause unexpected re-renders.
+
+**Detection:** A `set*` call whose ancestor is another `set*` call expression.
+
+---
+
+## Validation Output Format
+
+When reporting issues after code review, group by file and severity:
+
+```
+### Static Analysis Results
+
+**Violations (must fix before completing Step 3):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Fix: <suggested fix>
+
+**Warnings (review with user):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Suggestion: <improvement>
+
+✅ No violations found. N warnings flagged.
+```
+
+Do not proceed with Step 4 (Documentation) until all violations are resolved.

--- a/exports/claude/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
+++ b/exports/claude/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
@@ -197,20 +197,33 @@ import something from 'node_modules/lodash/get';
 
 ---
 
+### `NON_APPROVED_PACKAGE` — Import from non-approved package
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Any import whose source starts with `@` or contains `/`, unless it is `react` or a `node_modules/` direct path. Fires for every `@vtex/*` scoped package and every relative import (`./foo`, `../bar`).
+
+> **Note:** This warning is noisy — it fires for all legitimate Sales App imports (`@vtex/sales-app`, `@phosphor-icons/react`, relative component paths). Do not surface to the user when the import is from `@vtex/*` or a relative path. Investigate only when the import is from an unexpected third-party package.
+
+**Detection:** `import { … } from 'source'` where `source.startsWith('@')` or `source.includes('/')`, and source is not `'react'` or a `node_modules/` path.
+
+---
+
 ### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+Two detection paths:
 
-**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+1. **Direct API use:** `fetch`, `XMLHttpRequest`, `script.src`, `link.href` used as member expressions.
+2. **Known CDN domains in string literal:** `fetch('https://cdn.jsdelivr.net/...')` or any URL containing `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`, `api.example.com`, or ending with `.js`.
 
 > **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
 
 **Correct**
 ```typescript
-// Always use IO Proxy relative path
 const response = await fetch('/_v/my-loyalty-api/points', {
   credentials: 'include',
 });
@@ -219,6 +232,7 @@ const response = await fetch('/_v/my-loyalty-api/points', {
 **Wrong**
 ```typescript
 const response = await fetch('https://api.example.com/data');
+const response = await fetch('https://cdn.jsdelivr.net/npm/lodash.js'); // CDN — also Violation
 const xhr = new XMLHttpRequest();
 ```
 
@@ -226,14 +240,14 @@ const xhr = new XMLHttpRequest();
 
 ### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
 
-**Severity:** Warning (flag)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. CDN domain fetches are actually reported as `EXTERNAL_RESOURCE_LOADING` (Violation, block) — not as this Warning. Treat any fetch to a CDN domain as a **build-blocking Violation**, not a soft warning.
+
+**Severity:** Warning (flag) — *see note above; actual enforcement is via `EXTERNAL_RESOURCE_LOADING`*  
 **Files:** `.ts`, `.tsx`
 
 Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
 
 **Detection:** `fetch()` first argument literal containing one of these domains.
-
-**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
 
 ---
 
@@ -244,7 +258,7 @@ Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.co
 
 Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
 
-**Detection:** Any call to these methods.
+**Detection:** Any call where the callee matches `document.querySelector`, `document.getElementById`, etc. (the variable must be literally named `document`). Calls via a ref object — e.g. `containerRef.current.querySelector(...)` — are **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
@@ -267,14 +281,14 @@ document.getElementById('cart-container');
 
 Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
 
-**Detection:** Any member expression matching these patterns.
+**Detection:** Matches only when the object is literally named `element` (e.g. `element.style`). Equivalent access through other variable names — e.g. `divRef.current.style`, `el.className` — is **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
-// Use plain CSS with namespaced class names
+// Use plain CSS classes from the component stylesheet
 import './MyExtension.css';
 
-return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
+return <div className={isActive ? 'active' : 'inactive'} />;
 ```
 
 **Wrong**
@@ -291,7 +305,7 @@ element.setAttribute('style', 'display: none');
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+**Detection:** `while(true)` or `do...while(true)` with literal `true` condition.
 
 **Wrong**
 ```typescript
@@ -302,9 +316,22 @@ while (true) {
 
 ---
 
+### `POTENTIAL_INFINITE_LOOP` — Incomplete for-loop
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `for` statement with no `update` expression AND no `test` expression (e.g. `for (let i = 0;;) { … }`).
+
+**Action:** Warn the user and ensure the loop has a proper termination condition.
+
+---
+
 ### `MEMORY_LEAK` — Memory leak patterns
 
-**Severity:** Violation (block)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. The active rule is `POTENTIAL_MEMORY_LEAK` (Warning) below. Event listeners without cleanup **will not block the build**, but remain a Hard Constraint — always add a cleanup return in `useEffect`.
+
+**Severity:** Violation (block) — *see note above; not currently enforced at build time*  
 **Files:** `.ts`, `.tsx`
 
 **Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
@@ -328,23 +355,58 @@ useEffect(() => {
 
 ---
 
+### `POTENTIAL_MEMORY_LEAK` — Likely memory leak patterns
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Three triggers:
+1. Any `addEventListener` call — the analyzer warns regardless of whether a corresponding `removeEventListener` exists in cleanup.
+2. Recursive function call where the callee name matches the parent `FunctionDeclaration` identifier.
+3. `Array.push` inside a `for` or `while` loop.
+
+**Action:** Verify the component has a proper cleanup return in `useEffect` for any event listener, and that recursive functions have a clear base case.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+---
+
 ### `EXCESSIVE_API_CALLS` — Excessive API call patterns
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+**Detection:** `fetch` or `XMLHttpRequest` calls whose parent is a `for` or `while` loop.
 
 **Wrong**
 ```typescript
-// fetch inside render — fires on every re-render
-const data = await fetch('/_v/api/data');
-
 // fetch inside loop — excessive calls
 for (const item of items) {
   await fetch(`/_v/api/item/${item.id}`);
 }
 ```
+
+---
+
+### `FREQUENT_API_CALLS` — API call outside loop / rapid setInterval
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Two triggers:
+1. `fetch` or `XMLHttpRequest` call **outside** a loop (i.e. anywhere else in the component). Fires for every fetch — ensure calls are wrapped in `useEffect` with proper deps and are rate-limited or cached.
+2. `setInterval` with a numeric delay argument below 1000 ms.
+
+> **Note:** Trigger 1 is intentionally broad — it flags every `fetch()` call as a reminder to verify it is not running unintentionally on every render. It does **not** mean every fetch is wrong. Only surface this to the user when the fetch is genuinely outside a `useEffect` or appears to run on each render.
+
+**Action:** Warn the user and suggest wrapping fetches in `useEffect`, using caching, or increasing the polling interval.
 
 ---
 
@@ -376,7 +438,25 @@ import _ from 'lodash';
 
 ## 2. CSS Containment Rules
 
-Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`.
+
+**Sales App analyzer configuration** (from `@vtex/sales-app` build/dev hook):
+
+```typescript
+cssOptions: {
+  allowedNamespaces: ['sales-app-extension-'],
+  defaultNamespace: 'sales-app-extension-',
+  transformNonCompliant: true,
+  overwriteTransformed: true,
+}
+```
+
+Two consequences for the rules below:
+
+1. The configured namespace is **`sales-app-extension-`**, not the analyzer's bare default of `extension-`. Any rule that talks about "the allowed namespace" means `sales-app-extension-` in this project.
+2. `transformNonCompliant: true` softens the namespace rules: when a selector or `@keyframes` name is not prefixed, the analyzer auto-rewrites it into a sibling `*.transformed.css` file and emits a `CSS_TRANSFORMED` **warning** instead of a `CSS_NAMESPACE_REQUIRED` / `CSS_GLOBAL_KEYFRAMES` **violation**. The original `.css` (and the `className` strings in JSX) are left untouched, so the build does not break. This is why the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) ships unprefixed selectors like `.container`, `.title`, `.row` — they are valid in this project.
+
+The other CSS rules (`CSS_GLOBAL_SELECTOR`, `CSS_CONTAINMENT_BREAKOUT`, `CSS_GLOBAL_IMPORT`, `CSS_RESTRICTED_PROPERTY`, `CSS_RESTRICTED_VALUE`, and the inline-style rules) are **not** softened by `transformNonCompliant` — they remain build-blocking violations.
 
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
@@ -389,12 +469,12 @@ Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#_
 
 **Correct**
 ```css
-/* Scope all rules inside the extension container */
-.extension-container {
+/* Scope rules inside the extension container — never target global elements */
+.container {
   font-size: 14px;
 }
 
-.extension-container .title {
+.container .title {
   font-weight: bold;
 }
 ```
@@ -429,7 +509,7 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 **Correct**
 ```css
-.extension-container {
+.container {
   position: relative; /* safe — contained */
 }
 ```
@@ -452,26 +532,27 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
+All CSS selectors should be scoped under an allowed namespace prefix. In the Sales App, that prefix is `sales-app-extension-`. Because the project sets `transformNonCompliant: true`, an unprefixed selector does **not** block the build: the analyzer rewrites it inside a sibling `Component.transformed.css` and emits a `CSS_TRANSFORMED` warning instead of `CSS_NAMESPACE_REQUIRED`. The original `Component.css` (which is what gets bundled) keeps the unprefixed class, so the JSX `className="container"` continues to match.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
+**Detection:** A selector that does not include any value from `allowedNamespaces` (substring check on `.namespace`, `#namespace`, or `[class*="namespace"]`).
 
-**Correct**
+**Correct (and matches the CSS template)**
 ```css
-/* Plain CSS — namespace all classes */
-.extension-container { padding: 8px; }
-.extension-title { font-size: 16px; }
-```
-
-**Wrong**
-```css
-/* Plain CSS — no namespace — pollutes global styles */
+/* Unprefixed top-level classes are accepted because transformNonCompliant=true. */
 .container { padding: 8px; }
-.title { font-size: 16px; }
+.title     { font-size: 16px; }
 ```
+
+**Also correct (explicit prefix, never warns)**
+```css
+.sales-app-extension-container { padding: 8px; }
+.sales-app-extension-title     { font-size: 16px; }
+```
+
+> Prefer the unprefixed form to match the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) and the JSX in the component templates. The `CSS_TRANSFORMED` warning that fires for these is informational only.
 
 ---
 
@@ -499,26 +580,27 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell. As with `CSS_NAMESPACE_REQUIRED`, `transformNonCompliant: true` rewrites the name in `*.transformed.css` and emits `CSS_TRANSFORMED` instead of blocking.
 
-**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix (`sales-app-extension-` in this project).
 
-**Correct**
+The CSS template prefixes keyframes with `${COMPONENT_NAME}-` (e.g. `LoyaltyPoints-spin`). That prefix does **not** start with `sales-app-extension-`, so it triggers a `CSS_TRANSFORMED` warning — the build still succeeds, but the transformed file will rename it to `sales-app-extension-LoyaltyPoints-spin`. Either form is acceptable.
+
+**Correct (no warning)**
 ```css
-@keyframes extension-fade-in {
+@keyframes sales-app-extension-fade-in {
   from { opacity: 0; }
   to   { opacity: 1; }
 }
 ```
 
-**Wrong**
+**Also correct (CSS_TRANSFORMED warning, build passes)**
 ```css
-@keyframes fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+@keyframes LoyaltyPoints-spin {
+  to { transform: rotate(360deg); }
 }
 ```
 
@@ -548,16 +630,59 @@ Certain CSS values (e.g., `!important`) override the cascade and break containme
 
 **Correct**
 ```css
-.extension-button {
-  color: var(--vtex-color-primary);
+.button {
+  color: var(--sa-color-primary);
 }
 ```
 
 **Wrong**
 ```css
-.extension-button {
+.button {
   color: red !important;
 }
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_PROPERTY` — Restricted property in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props in JSX may not use properties that affect layout or containment.
+
+Restricted properties: `position`, `z-index`, `top`, `left`, `right`, `bottom`, `all`, `contain`, `content`, `isolation`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted property names.
+
+**Correct**
+```typescript
+// Use CSS classes for layout properties
+return <div className="overlay" />;
+```
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed', top: 0 }} />;
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_VALUE` — Restricted value in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props may not use values that break containment or cascade.
+
+Restricted values: `fixed`, `absolute`, `!important`, `inherit`, `initial`, `unset`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted values.
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed' }} />;
+return <div style={{ display: 'inherit' }} />;
 ```
 
 ---
@@ -587,33 +712,6 @@ setItems(updatedItems);
 for (const item of items) {
   setCount((c) => c + 1); // re-renders on every iteration
 }
-```
-
----
-
-### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
-
-**Severity:** Violation (block)  
-**Files:** `.tsx`
-
-`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
-
-**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
-
-**Correct**
-```typescript
-const filteredItems = useMemo(() => items.filter(isActive), [items]);
-
-return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
-```
-
-**Wrong**
-```typescript
-return (
-  <ul>
-    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
-  </ul>
-);
 ```
 
 ---

--- a/exports/claude/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
+++ b/exports/claude/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
@@ -271,10 +271,10 @@ Restricted expressions: `element.style`, `element.className`, `element.classList
 
 **Correct**
 ```typescript
-// Use CSS modules and conditional class application
-import styles from './MyExtension.module.css';
+// Use plain CSS with namespaced class names
+import './MyExtension.css';
 
-return <div className={isActive ? styles.active : styles.inactive} />;
+return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
 ```
 
 **Wrong**
@@ -381,7 +381,7 @@ Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
 
@@ -419,7 +419,7 @@ body {
 ### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
 
@@ -453,21 +453,15 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
 
 **Correct**
 ```css
-/* CSS Module — all classes are auto-scoped */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-```
-
-```css
-/* Plain CSS — must namespace manually */
+/* Plain CSS — namespace all classes */
 .extension-container { padding: 8px; }
 .extension-title { font-size: 16px; }
 ```
@@ -484,7 +478,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_IMPORT` — CSS @import rules
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@import` pulls external stylesheets that affect global styles and bypass containment.
 
@@ -506,7 +500,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
 
@@ -533,7 +527,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
 
@@ -546,7 +540,7 @@ Certain properties affect layout or rendering globally and are restricted to pre
 ### `CSS_RESTRICTED_VALUE` — Restricted CSS values
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
 

--- a/exports/claude/sales-app-sales-app-extensibility.md
+++ b/exports/claude/sales-app-sales-app-extensibility.md
@@ -49,7 +49,7 @@ Documentation: https://beta.fast.store/sales-app/setting-up
 
 ## Decision rules
 
-Follow the mandatory 6-step workflow in order. Do not skip steps.
+Follow the mandatory 7-step workflow (Steps 0–6) in order. Do not skip steps.
 
 | Step | Purpose | Gate |
 |------|---------|------|
@@ -177,55 +177,6 @@ const { item } = useCartItem();
 return <div>{item.name}</div>;
 ```
 
-### Constraint: Never expose authentication keys in frontend code
-
-API keys in `fetch` headers are visible in the browser network tab.
-
-**Why this matters**
-Leaked keys compromise the external service.
-
-**Detection**
-Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
-
-**Correct**
-
-```typescript
-const response = await fetch('/_v/my-api/data', {
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-**Wrong**
-
-```typescript
-const response = await fetch('https://api.example.com/data', {
-  headers: { 'x-api-key': 'sk-secret-key-12345' },
-});
-```
-
-### Constraint: IO Proxy must use relative paths only
-
-The Sales App internal proxy resolves the domain automatically.
-
-**Why this matters**
-A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
-
-**Detection**
-`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
-
-**Correct**
-
-```typescript
-await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
-```
-
-**Wrong**
-
-```typescript
-await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
-```
-
 ### Constraint: defineExtensions is required in index.tsx
 
 Entry point must use `defineExtensions` from `@vtex/sales-app`.
@@ -297,186 +248,6 @@ defineExtensions({ 'cart.cart-item.after': ItemWarranty });
 defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
 ```
 
-### Constraint: Always present execution plan and wait for approval
-
-Do not generate code until the user confirms the plan.
-
-**Why this matters**
-Generating without agreement wastes effort and may produce the wrong extension.
-
-**Detection**
-Jumping from discovery to code generation without presenting a plan.
-
-**Correct**
-Discovery → Requirements → Present plan → **User approves** → Generate code.
-
-**Wrong**
-Discovery → Generate code immediately.
-
-### Constraint: Never access DOM APIs directly
-
-Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
-
-**Why this matters**
-Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
-
-**Detection**
-Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
-
-**Correct**
-
-```typescript
-// Use React state, props, and Sales App hooks for data
-const { account } = useExtension();
-const cart = useCart();
-```
-
-**Wrong**
-
-```typescript
-const userId = localStorage.getItem('userId');
-const width = window.innerWidth;
-document.title = 'My Extension';
-```
-
-### Constraint: Never import restricted Node.js modules
-
-Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
-
-**Why this matters**
-Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
-
-**Detection**
-`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
-
-**Correct**
-
-```typescript
-import { useCart } from '@vtex/sales-app';
-import React, { useState, useEffect } from 'react';
-```
-
-**Wrong**
-
-```typescript
-import fs from 'fs';
-import crypto from 'crypto';
-```
-
-### Constraint: Never use eval or the Function constructor
-
-Arbitrary code execution is banned in the sandbox.
-
-**Why this matters**
-`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
-
-**Detection**
-Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
-
-**Correct**
-
-```typescript
-const result = computeValue(input); // deterministic logic only
-```
-
-**Wrong**
-
-```typescript
-eval('doSomething()');
-const fn = new Function('return 42');
-setTimeout('doSomething()', 1000);
-```
-
-### Constraint: CSS files must use plain .css extension, never .module.css
-
-The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
-
-**Why this matters**
-A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
-
-**Detection**
-Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
-
-**Correct**
-
-```typescript
-import './CashbackWidget.css';
-// Use className strings directly
-<div className="container">
-```
-
-**Wrong**
-
-```typescript
-import styles from './CashbackWidget.module.css';
-// CSS modules object access
-<div className={styles.container}>
-```
-
-### Constraint: CSS must use namespaced selectors — no global elements
-
-Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
-
-**Why this matters**
-Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
-
-**Detection**
-Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
-
-**Correct**
-
-```css
-/* Plain CSS — use namespace prefix to scope classes */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-
-@keyframes extension-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-```
-
-**Wrong**
-
-```css
-body { font-size: 14px; }
-* { box-sizing: border-box; }
-:root { --my-color: red; }
-@import './reset.css';
-.overlay { position: fixed; z-index: 9999; }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Constraint: CSS must follow Sales App Design Guidelines
-
-Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
-
-**Why this matters**
-Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
-
-**Detection**
-Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
-
-**Correct**
-
-```css
-.container {
-  --sa-color-primary: #157BF4;
-  --sa-color-text-primary: #1F1F1F;
-  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-}
-.title { color: var(--sa-color-text-primary); font-size: 16px; }
-.buttonPrimary { background-color: var(--sa-color-primary); }
-```
-
-**Wrong**
-
-```css
-.container { font-family: Arial; }
-.title { color: #1a1a1a; font-size: 15px; }
-.buttonPrimary { background-color: #0066cc; }
-```
-
 ## Preferred pattern
 
 ### Workflow overview
@@ -487,59 +258,17 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`.
 
-**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
+Required references for this step (load before generating):
+- [code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) — all component templates, the CSS template (with the full Sales App design system inlined: tokens, typography, spacing, responsive), the `index.tsx` template, type generation rules, and the custom fetch hook pattern.
+- [extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) — hook return types and TypeScript definitions.
+- [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`. Run these checks on all generated files.
+- [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) — load when the extension renders any UI text (sentence case rule) or uses icons (Phosphor Icons).
 
-1. **Extension name** — title matching the component name.
-2. **Overview** — one-paragraph summary of what the extension does and why it was built.
-3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
-4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
-5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS file name and summary of key classes.
-7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
-   - **Source documentation:** URL or file path of the original API documentation, if provided.
-   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
-   - Note which fields are optional (`?`) vs required per the documentation.
-8. **How to test** — dev server command and URL to reach the extension.
-9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Validate against the 12-point checklist in code-templates-and-patterns.md. Fix all violations before presenting code; surface warnings to the user.
 
-Template for the documentation file:
-
-````markdown
-# <ExtensionName>
-
-## Overview
-<One-paragraph description of the extension purpose and value.>
-
-## Extension point
-- **Point:** `<extension.point.name>`
-- **Rationale:** <Why this extension point was selected.>
-
-## Hooks used
-| Hook | Purpose |
-|------|---------|
-| `useCart` | <What data it provides here> |
-
-## Component structure
-<Describe the component tree, key props, and internal state.>
-
-## Styling
-- **File:** `<ComponentName>.css`
-- <Summary of key CSS classes and design decisions.>
-
-## API integration
-- **Endpoint:** `/_v/...`
-- **Auth strategy:** IO Proxy / Direct / None
-- **Request/Response:** <Brief shape description.>
-
-## How to test
-Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
-
-## Known constraints
-- <Guard or limitation 1>
-- <Guard or limitation 2>
-````
+**Step 4** — Generate `docs/<ExtensionName>.md` inside the Sales App package (create the `docs/` folder if needed). Load the [documentation template reference](sales-app-sales-app-extensibility-ref-documentation-template.md) for the required 9-section structure and the markdown skeleton to fill in.
 
 **Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md).
 
@@ -552,73 +281,47 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; **CSS template with the full Sales App design system inlined (tokens, typography, spacing, responsive)**; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
-| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Writing UI text (sentence case rule) or using icons (Phosphor Icons). **CSS-related design rules — tokens, typography, spacing, responsive — are inlined directly in the CSS template inside code-templates-and-patterns.md, so this file is not needed for CSS generation.** |
+| [references/documentation-template.md](sales-app-sales-app-extensibility-ref-documentation-template.md) | Writing the `docs/<ExtensionName>.md` file in Step 4 — the 9-section structure and markdown skeleton |
 
 ## Common failure modes
 
-- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
-- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
-- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
-- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
-- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
-- **Placing code outside packages/sales-app/src/** — Not included in build.
-- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
-- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
-- **Not presenting plan** — User may want a different approach. Always confirm.
-- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
-- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed. Always confirm both before Step 1.
+- **Not presenting plan** — User may want a different approach. Always confirm at Step 2 before generating code.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Load documentation-template.md for the required structure.
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
-- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
-- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
-- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
-- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
-- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
-- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
-- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
-- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
+- **Placing code outside packages/sales-app/src/** — Files outside this path are not included in the build.
+
+> Code-level violations (DOM APIs, Node imports, eval, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and caught during Step 3 validation. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Review checklist
 
+**Workflow gates**
 - [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
 - [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
 - [ ] Discovery completed and use case identified?
 - [ ] Execution plan approved by user?
 - [ ] Extension point is valid (from the 8-point reference)?
 - [ ] Hooks compatible with chosen extension point?
+- [ ] Documentation generated at `docs/<ExtensionName>.md` (9 sections, using documentation-template.md)?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+**TypeScript / runtime guards** (not caught by fsp-analyzer)
 - [ ] Component returns JSX.Element, never null?
 - [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
 - [ ] useCartItem().item checked for undefined?
-- [ ] No auth credentials exposed in frontend code?
-- [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
-- [ ] CSS file path matches component name?
-- [ ] Documentation generated at `docs/<ExtensionName>.md`?
-- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
-- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
-- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
-- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
-- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
-- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
-- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
-- [ ] No @import rules in CSS?
-- [ ] No position: fixed or z-index: 9999 in CSS?
-- [ ] @keyframes names prefixed with extension namespace?
-- [ ] No useLayoutEffect (use useEffect instead)?
-- [ ] No heavyweight library imports (lodash, moment)?
-- [ ] Components under 200 lines?
-- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
-- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
-- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
-- [ ] Build passes: `yarn fsp build {account} sales-app`?
-- [ ] Tested locally: `yarn fsp dev {account}`?
+
+> All other code-level rules (sandbox APIs, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and checked during Step 3. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Related skills
 

--- a/exports/claude/sales-app-sales-app-extensibility.md
+++ b/exports/claude/sales-app-sales-app-extensibility.md
@@ -421,6 +421,36 @@ body { font-size: 14px; }
 @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
 ```
 
+### Constraint: CSS must follow Sales App Design Guidelines
+
+Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
+
+**Why this matters**
+Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
+
+**Detection**
+Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
+
+**Correct**
+
+```css
+.container {
+  --sa-color-primary: #157BF4;
+  --sa-color-text-primary: #1F1F1F;
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.title { color: var(--sa-color-text-primary); font-size: 16px; }
+.buttonPrimary { background-color: var(--sa-color-primary); }
+```
+
+**Wrong**
+
+```css
+.container { font-family: Arial; }
+.title { color: #1a1a1a; font-size: 15px; }
+.buttonPrimary { background-color: #0066cc; }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -431,7 +461,7 @@ body { font-size: 14px; }
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -500,6 +530,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
 
 ## Common failure modes
 
@@ -521,6 +552,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
 - **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
 - **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
+- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
+- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
+- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
+- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
 
 ## Review checklist
 
@@ -551,6 +586,11 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] No useLayoutEffect (use useEffect instead)?
 - [ ] No heavyweight library imports (lodash, moment)?
 - [ ] Components under 200 lines?
+- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
+- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/claude/sales-app-sales-app-extensibility.md
+++ b/exports/claude/sales-app-sales-app-extensibility.md
@@ -56,7 +56,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
-| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 3 | Code Generation & Validation | Generate `Component.tsx` + `Component.css` (plain CSS, never `.module.css`) + `index.tsx` → validate |
 | 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
 | 5 | Local Testing | Provide dev commands and URLs |
 | 6 | Build & Deploy | Build command → deployment guide |
@@ -387,6 +387,32 @@ const fn = new Function('return 42');
 setTimeout('doSomething()', 1000);
 ```
 
+### Constraint: CSS files must use plain .css extension, never .module.css
+
+The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
+
+**Why this matters**
+A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
+
+**Detection**
+Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
+
+**Correct**
+
+```typescript
+import './CashbackWidget.css';
+// Use className strings directly
+<div className="container">
+```
+
+**Wrong**
+
+```typescript
+import styles from './CashbackWidget.module.css';
+// CSS modules object access
+<div className={styles.container}>
+```
+
 ### Constraint: CSS must use namespaced selectors — no global elements
 
 Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
@@ -400,7 +426,7 @@ Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@
 **Correct**
 
 ```css
-/* CSS Module — classes are auto-scoped by the bundler */
+/* Plain CSS — use namespace prefix to scope classes */
 .container { padding: 8px; }
 .title { font-size: 16px; }
 
@@ -459,9 +485,9 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
-**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+**Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -470,7 +496,7 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
 4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
 5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS module file name and summary of key classes.
+6. **Styling** — CSS file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
    - **Source documentation:** URL or file path of the original API documentation, if provided.
    - **Generated types:** list of TypeScript interfaces generated from the API documentation.
@@ -499,7 +525,7 @@ Template for the documentation file:
 <Describe the component tree, key props, and internal state.>
 
 ## Styling
-- **File:** `<ComponentName>.module.css`
+- **File:** `<ComponentName>.css`
 - <Summary of key CSS classes and design decisions.>
 
 ## API integration
@@ -526,7 +552,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |

--- a/exports/claude/sales-app-sales-app-extensibility.md
+++ b/exports/claude/sales-app-sales-app-extensibility.md
@@ -313,6 +313,114 @@ Discovery → Requirements → Present plan → **User approves** → Generate c
 **Wrong**
 Discovery → Generate code immediately.
 
+### Constraint: Never access DOM APIs directly
+
+Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
+
+**Why this matters**
+Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
+
+**Detection**
+Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
+
+**Correct**
+
+```typescript
+// Use React state, props, and Sales App hooks for data
+const { account } = useExtension();
+const cart = useCart();
+```
+
+**Wrong**
+
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+### Constraint: Never import restricted Node.js modules
+
+Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
+
+**Why this matters**
+Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
+
+**Detection**
+`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
+
+**Correct**
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+import React, { useState, useEffect } from 'react';
+```
+
+**Wrong**
+
+```typescript
+import fs from 'fs';
+import crypto from 'crypto';
+```
+
+### Constraint: Never use eval or the Function constructor
+
+Arbitrary code execution is banned in the sandbox.
+
+**Why this matters**
+`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
+
+**Detection**
+Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
+
+**Correct**
+
+```typescript
+const result = computeValue(input); // deterministic logic only
+```
+
+**Wrong**
+
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+### Constraint: CSS must use namespaced selectors — no global elements
+
+Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
+
+**Why this matters**
+Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
+
+**Detection**
+Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
+
+**Correct**
+
+```css
+/* CSS Module — classes are auto-scoped by the bundler */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+
+```css
+body { font-size: 14px; }
+* { box-sizing: border-box; }
+:root { --my-color: red; }
+@import './reset.css';
+.overlay { position: fixed; z-index: 9999; }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -323,7 +431,7 @@ Discovery → Generate code immediately.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -391,6 +499,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
 
 ## Common failure modes
 
@@ -408,6 +517,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
+- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
+- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
+- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
+- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
 
 ## Review checklist
 
@@ -428,6 +541,16 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
 - [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
+- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
+- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
+- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
+- [ ] No @import rules in CSS?
+- [ ] No position: fixed or z-index: 9999 in CSS?
+- [ ] @keyframes names prefixed with extension namespace?
+- [ ] No useLayoutEffect (use useEffect instead)?
+- [ ] No heavyweight library imports (lodash, moment)?
+- [ ] Components under 200 lines?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/claude/sales-app.md
+++ b/exports/claude/sales-app.md
@@ -49,7 +49,7 @@ Documentation: https://beta.fast.store/sales-app/setting-up
 
 ## Decision rules
 
-Follow the mandatory 6-step workflow in order. Do not skip steps.
+Follow the mandatory 7-step workflow (Steps 0–6) in order. Do not skip steps.
 
 | Step | Purpose | Gate |
 |------|---------|------|
@@ -177,55 +177,6 @@ const { item } = useCartItem();
 return <div>{item.name}</div>;
 ```
 
-### Constraint: Never expose authentication keys in frontend code
-
-API keys in `fetch` headers are visible in the browser network tab.
-
-**Why this matters**
-Leaked keys compromise the external service.
-
-**Detection**
-Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
-
-**Correct**
-
-```typescript
-const response = await fetch('/_v/my-api/data', {
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-**Wrong**
-
-```typescript
-const response = await fetch('https://api.example.com/data', {
-  headers: { 'x-api-key': 'sk-secret-key-12345' },
-});
-```
-
-### Constraint: IO Proxy must use relative paths only
-
-The Sales App internal proxy resolves the domain automatically.
-
-**Why this matters**
-A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
-
-**Detection**
-`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
-
-**Correct**
-
-```typescript
-await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
-```
-
-**Wrong**
-
-```typescript
-await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
-```
-
 ### Constraint: defineExtensions is required in index.tsx
 
 Entry point must use `defineExtensions` from `@vtex/sales-app`.
@@ -297,186 +248,6 @@ defineExtensions({ 'cart.cart-item.after': ItemWarranty });
 defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
 ```
 
-### Constraint: Always present execution plan and wait for approval
-
-Do not generate code until the user confirms the plan.
-
-**Why this matters**
-Generating without agreement wastes effort and may produce the wrong extension.
-
-**Detection**
-Jumping from discovery to code generation without presenting a plan.
-
-**Correct**
-Discovery → Requirements → Present plan → **User approves** → Generate code.
-
-**Wrong**
-Discovery → Generate code immediately.
-
-### Constraint: Never access DOM APIs directly
-
-Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
-
-**Why this matters**
-Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
-
-**Detection**
-Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
-
-**Correct**
-
-```typescript
-// Use React state, props, and Sales App hooks for data
-const { account } = useExtension();
-const cart = useCart();
-```
-
-**Wrong**
-
-```typescript
-const userId = localStorage.getItem('userId');
-const width = window.innerWidth;
-document.title = 'My Extension';
-```
-
-### Constraint: Never import restricted Node.js modules
-
-Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
-
-**Why this matters**
-Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
-
-**Detection**
-`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
-
-**Correct**
-
-```typescript
-import { useCart } from '@vtex/sales-app';
-import React, { useState, useEffect } from 'react';
-```
-
-**Wrong**
-
-```typescript
-import fs from 'fs';
-import crypto from 'crypto';
-```
-
-### Constraint: Never use eval or the Function constructor
-
-Arbitrary code execution is banned in the sandbox.
-
-**Why this matters**
-`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
-
-**Detection**
-Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
-
-**Correct**
-
-```typescript
-const result = computeValue(input); // deterministic logic only
-```
-
-**Wrong**
-
-```typescript
-eval('doSomething()');
-const fn = new Function('return 42');
-setTimeout('doSomething()', 1000);
-```
-
-### Constraint: CSS files must use plain .css extension, never .module.css
-
-The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
-
-**Why this matters**
-A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
-
-**Detection**
-Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
-
-**Correct**
-
-```typescript
-import './CashbackWidget.css';
-// Use className strings directly
-<div className="container">
-```
-
-**Wrong**
-
-```typescript
-import styles from './CashbackWidget.module.css';
-// CSS modules object access
-<div className={styles.container}>
-```
-
-### Constraint: CSS must use namespaced selectors — no global elements
-
-Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
-
-**Why this matters**
-Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
-
-**Detection**
-Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
-
-**Correct**
-
-```css
-/* Plain CSS — use namespace prefix to scope classes */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-
-@keyframes extension-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-```
-
-**Wrong**
-
-```css
-body { font-size: 14px; }
-* { box-sizing: border-box; }
-:root { --my-color: red; }
-@import './reset.css';
-.overlay { position: fixed; z-index: 9999; }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Constraint: CSS must follow Sales App Design Guidelines
-
-Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
-
-**Why this matters**
-Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
-
-**Detection**
-Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
-
-**Correct**
-
-```css
-.container {
-  --sa-color-primary: #157BF4;
-  --sa-color-text-primary: #1F1F1F;
-  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-}
-.title { color: var(--sa-color-text-primary); font-size: 16px; }
-.buttonPrimary { background-color: var(--sa-color-primary); }
-```
-
-**Wrong**
-
-```css
-.container { font-family: Arial; }
-.title { color: #1a1a1a; font-size: 15px; }
-.buttonPrimary { background-color: #0066cc; }
-```
-
 ## Preferred pattern
 
 ### Workflow overview
@@ -487,59 +258,17 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`.
 
-**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
+Required references for this step (load before generating):
+- [code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) — all component templates, the CSS template (with the full Sales App design system inlined: tokens, typography, spacing, responsive), the `index.tsx` template, type generation rules, and the custom fetch hook pattern.
+- [extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) — hook return types and TypeScript definitions.
+- [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`. Run these checks on all generated files.
+- [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) — load when the extension renders any UI text (sentence case rule) or uses icons (Phosphor Icons).
 
-1. **Extension name** — title matching the component name.
-2. **Overview** — one-paragraph summary of what the extension does and why it was built.
-3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
-4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
-5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS file name and summary of key classes.
-7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
-   - **Source documentation:** URL or file path of the original API documentation, if provided.
-   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
-   - Note which fields are optional (`?`) vs required per the documentation.
-8. **How to test** — dev server command and URL to reach the extension.
-9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Validate against the 12-point checklist in code-templates-and-patterns.md. Fix all violations before presenting code; surface warnings to the user.
 
-Template for the documentation file:
-
-````markdown
-# <ExtensionName>
-
-## Overview
-<One-paragraph description of the extension purpose and value.>
-
-## Extension point
-- **Point:** `<extension.point.name>`
-- **Rationale:** <Why this extension point was selected.>
-
-## Hooks used
-| Hook | Purpose |
-|------|---------|
-| `useCart` | <What data it provides here> |
-
-## Component structure
-<Describe the component tree, key props, and internal state.>
-
-## Styling
-- **File:** `<ComponentName>.css`
-- <Summary of key CSS classes and design decisions.>
-
-## API integration
-- **Endpoint:** `/_v/...`
-- **Auth strategy:** IO Proxy / Direct / None
-- **Request/Response:** <Brief shape description.>
-
-## How to test
-Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
-
-## Known constraints
-- <Guard or limitation 1>
-- <Guard or limitation 2>
-````
+**Step 4** — Generate `docs/<ExtensionName>.md` inside the Sales App package (create the `docs/` folder if needed). Load the [documentation template reference](sales-app-sales-app-extensibility-ref-documentation-template.md) for the required 9-section structure and the markdown skeleton to fill in.
 
 **Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md).
 
@@ -552,73 +281,47 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; **CSS template with the full Sales App design system inlined (tokens, typography, spacing, responsive)**; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
-| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Writing UI text (sentence case rule) or using icons (Phosphor Icons). **CSS-related design rules — tokens, typography, spacing, responsive — are inlined directly in the CSS template inside code-templates-and-patterns.md, so this file is not needed for CSS generation.** |
+| [references/documentation-template.md](sales-app-sales-app-extensibility-ref-documentation-template.md) | Writing the `docs/<ExtensionName>.md` file in Step 4 — the 9-section structure and markdown skeleton |
 
 ## Common failure modes
 
-- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
-- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
-- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
-- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
-- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
-- **Placing code outside packages/sales-app/src/** — Not included in build.
-- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
-- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
-- **Not presenting plan** — User may want a different approach. Always confirm.
-- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
-- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed. Always confirm both before Step 1.
+- **Not presenting plan** — User may want a different approach. Always confirm at Step 2 before generating code.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Load documentation-template.md for the required structure.
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
-- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
-- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
-- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
-- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
-- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
-- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
-- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
-- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
+- **Placing code outside packages/sales-app/src/** — Files outside this path are not included in the build.
+
+> Code-level violations (DOM APIs, Node imports, eval, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and caught during Step 3 validation. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Review checklist
 
+**Workflow gates**
 - [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
 - [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
 - [ ] Discovery completed and use case identified?
 - [ ] Execution plan approved by user?
 - [ ] Extension point is valid (from the 8-point reference)?
 - [ ] Hooks compatible with chosen extension point?
+- [ ] Documentation generated at `docs/<ExtensionName>.md` (9 sections, using documentation-template.md)?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+**TypeScript / runtime guards** (not caught by fsp-analyzer)
 - [ ] Component returns JSX.Element, never null?
 - [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
 - [ ] useCartItem().item checked for undefined?
-- [ ] No auth credentials exposed in frontend code?
-- [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
-- [ ] CSS file path matches component name?
-- [ ] Documentation generated at `docs/<ExtensionName>.md`?
-- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
-- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
-- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
-- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
-- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
-- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
-- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
-- [ ] No @import rules in CSS?
-- [ ] No position: fixed or z-index: 9999 in CSS?
-- [ ] @keyframes names prefixed with extension namespace?
-- [ ] No useLayoutEffect (use useEffect instead)?
-- [ ] No heavyweight library imports (lodash, moment)?
-- [ ] Components under 200 lines?
-- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
-- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
-- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
-- [ ] Build passes: `yarn fsp build {account} sales-app`?
-- [ ] Tested locally: `yarn fsp dev {account}`?
+
+> All other code-level rules (sandbox APIs, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and checked during Step 3. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Related skills
 

--- a/exports/claude/sales-app.md
+++ b/exports/claude/sales-app.md
@@ -421,6 +421,36 @@ body { font-size: 14px; }
 @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
 ```
 
+### Constraint: CSS must follow Sales App Design Guidelines
+
+Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
+
+**Why this matters**
+Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
+
+**Detection**
+Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
+
+**Correct**
+
+```css
+.container {
+  --sa-color-primary: #157BF4;
+  --sa-color-text-primary: #1F1F1F;
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.title { color: var(--sa-color-text-primary); font-size: 16px; }
+.buttonPrimary { background-color: var(--sa-color-primary); }
+```
+
+**Wrong**
+
+```css
+.container { font-family: Arial; }
+.title { color: #1a1a1a; font-size: 15px; }
+.buttonPrimary { background-color: #0066cc; }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -431,7 +461,7 @@ body { font-size: 14px; }
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -500,6 +530,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
 
 ## Common failure modes
 
@@ -521,6 +552,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
 - **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
 - **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
+- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
+- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
+- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
+- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
 
 ## Review checklist
 
@@ -551,6 +586,11 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] No useLayoutEffect (use useEffect instead)?
 - [ ] No heavyweight library imports (lodash, moment)?
 - [ ] Components under 200 lines?
+- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
+- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/claude/sales-app.md
+++ b/exports/claude/sales-app.md
@@ -56,7 +56,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
-| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 3 | Code Generation & Validation | Generate `Component.tsx` + `Component.css` (plain CSS, never `.module.css`) + `index.tsx` → validate |
 | 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
 | 5 | Local Testing | Provide dev commands and URLs |
 | 6 | Build & Deploy | Build command → deployment guide |
@@ -387,6 +387,32 @@ const fn = new Function('return 42');
 setTimeout('doSomething()', 1000);
 ```
 
+### Constraint: CSS files must use plain .css extension, never .module.css
+
+The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
+
+**Why this matters**
+A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
+
+**Detection**
+Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
+
+**Correct**
+
+```typescript
+import './CashbackWidget.css';
+// Use className strings directly
+<div className="container">
+```
+
+**Wrong**
+
+```typescript
+import styles from './CashbackWidget.module.css';
+// CSS modules object access
+<div className={styles.container}>
+```
+
 ### Constraint: CSS must use namespaced selectors — no global elements
 
 Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
@@ -400,7 +426,7 @@ Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@
 **Correct**
 
 ```css
-/* CSS Module — classes are auto-scoped by the bundler */
+/* Plain CSS — use namespace prefix to scope classes */
 .container { padding: 8px; }
 .title { font-size: 16px; }
 
@@ -459,9 +485,9 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
-**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+**Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -470,7 +496,7 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
 4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
 5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS module file name and summary of key classes.
+6. **Styling** — CSS file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
    - **Source documentation:** URL or file path of the original API documentation, if provided.
    - **Generated types:** list of TypeScript interfaces generated from the API documentation.
@@ -499,7 +525,7 @@ Template for the documentation file:
 <Describe the component tree, key props, and internal state.>
 
 ## Styling
-- **File:** `<ComponentName>.module.css`
+- **File:** `<ComponentName>.css`
 - <Summary of key CSS classes and design decisions.>
 
 ## API integration
@@ -526,7 +552,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |

--- a/exports/claude/sales-app.md
+++ b/exports/claude/sales-app.md
@@ -313,6 +313,114 @@ Discovery → Requirements → Present plan → **User approves** → Generate c
 **Wrong**
 Discovery → Generate code immediately.
 
+### Constraint: Never access DOM APIs directly
+
+Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
+
+**Why this matters**
+Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
+
+**Detection**
+Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
+
+**Correct**
+
+```typescript
+// Use React state, props, and Sales App hooks for data
+const { account } = useExtension();
+const cart = useCart();
+```
+
+**Wrong**
+
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+### Constraint: Never import restricted Node.js modules
+
+Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
+
+**Why this matters**
+Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
+
+**Detection**
+`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
+
+**Correct**
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+import React, { useState, useEffect } from 'react';
+```
+
+**Wrong**
+
+```typescript
+import fs from 'fs';
+import crypto from 'crypto';
+```
+
+### Constraint: Never use eval or the Function constructor
+
+Arbitrary code execution is banned in the sandbox.
+
+**Why this matters**
+`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
+
+**Detection**
+Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
+
+**Correct**
+
+```typescript
+const result = computeValue(input); // deterministic logic only
+```
+
+**Wrong**
+
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+### Constraint: CSS must use namespaced selectors — no global elements
+
+Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
+
+**Why this matters**
+Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
+
+**Detection**
+Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
+
+**Correct**
+
+```css
+/* CSS Module — classes are auto-scoped by the bundler */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+
+```css
+body { font-size: 14px; }
+* { box-sizing: border-box; }
+:root { --my-color: red; }
+@import './reset.css';
+.overlay { position: fixed; z-index: 9999; }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -323,7 +431,7 @@ Discovery → Generate code immediately.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -391,6 +499,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
 
 ## Common failure modes
 
@@ -408,6 +517,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
+- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
+- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
+- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
+- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
 
 ## Review checklist
 
@@ -428,6 +541,16 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
 - [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
+- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
+- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
+- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
+- [ ] No @import rules in CSS?
+- [ ] No position: fixed or z-index: 9999 in CSS?
+- [ ] @keyframes names prefixed with extension namespace?
+- [ ] No useLayoutEffect (use useEffect instead)?
+- [ ] No heavyweight library imports (lodash, moment)?
+- [ ] Components under 200 lines?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -9366,6 +9366,36 @@ body { font-size: 14px; }
 @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
 ```
 
+### Constraint: CSS must follow Sales App Design Guidelines
+
+Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
+
+**Why this matters**
+Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
+
+**Detection**
+Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
+
+**Correct**
+
+```css
+.container {
+  --sa-color-primary: #157BF4;
+  --sa-color-text-primary: #1F1F1F;
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.title { color: var(--sa-color-text-primary); font-size: 16px; }
+.buttonPrimary { background-color: var(--sa-color-primary); }
+```
+
+**Wrong**
+
+```css
+.container { font-family: Arial; }
+.title { color: #1a1a1a; font-size: 15px; }
+.buttonPrimary { background-color: #0066cc; }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -9376,7 +9406,7 @@ body { font-size: 14px; }
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -9445,6 +9475,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
 
 ## Common failure modes
 
@@ -9466,6 +9497,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
 - **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
 - **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
+- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
+- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
+- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
+- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
 
 ## Review checklist
 
@@ -9496,6 +9531,11 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] No useLayoutEffect (use useEffect instead)?
 - [ ] No heavyweight library imports (lodash, moment)?
 - [ ] Components under 200 lines?
+- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
+- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -9001,7 +9001,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
-| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 3 | Code Generation & Validation | Generate `Component.tsx` + `Component.css` (plain CSS, never `.module.css`) + `index.tsx` → validate |
 | 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
 | 5 | Local Testing | Provide dev commands and URLs |
 | 6 | Build & Deploy | Build command → deployment guide |
@@ -9332,6 +9332,32 @@ const fn = new Function('return 42');
 setTimeout('doSomething()', 1000);
 ```
 
+### Constraint: CSS files must use plain .css extension, never .module.css
+
+The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
+
+**Why this matters**
+A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
+
+**Detection**
+Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
+
+**Correct**
+
+```typescript
+import './CashbackWidget.css';
+// Use className strings directly
+<div className="container">
+```
+
+**Wrong**
+
+```typescript
+import styles from './CashbackWidget.module.css';
+// CSS modules object access
+<div className={styles.container}>
+```
+
 ### Constraint: CSS must use namespaced selectors — no global elements
 
 Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
@@ -9345,7 +9371,7 @@ Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@
 **Correct**
 
 ```css
-/* CSS Module — classes are auto-scoped by the bundler */
+/* Plain CSS — use namespace prefix to scope classes */
 .container { padding: 8px; }
 .title { font-size: 16px; }
 
@@ -9404,9 +9430,9 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
-**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+**Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -9415,7 +9441,7 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
 4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
 5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS module file name and summary of key classes.
+6. **Styling** — CSS file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
    - **Source documentation:** URL or file path of the original API documentation, if provided.
    - **Generated types:** list of TypeScript interfaces generated from the API documentation.
@@ -9444,7 +9470,7 @@ Template for the documentation file:
 <Describe the component tree, key props, and internal state.>
 
 ## Styling
-- **File:** `<ComponentName>.module.css`
+- **File:** `<ComponentName>.css`
 - <Summary of key CSS classes and design decisions.>
 
 ## API integration
@@ -9471,7 +9497,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -8994,7 +8994,7 @@ Documentation: https://beta.fast.store/sales-app/setting-up
 
 ## Decision rules
 
-Follow the mandatory 6-step workflow in order. Do not skip steps.
+Follow the mandatory 7-step workflow (Steps 0–6) in order. Do not skip steps.
 
 | Step | Purpose | Gate |
 |------|---------|------|
@@ -9122,55 +9122,6 @@ const { item } = useCartItem();
 return <div>{item.name}</div>;
 ```
 
-### Constraint: Never expose authentication keys in frontend code
-
-API keys in `fetch` headers are visible in the browser network tab.
-
-**Why this matters**
-Leaked keys compromise the external service.
-
-**Detection**
-Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
-
-**Correct**
-
-```typescript
-const response = await fetch('/_v/my-api/data', {
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-**Wrong**
-
-```typescript
-const response = await fetch('https://api.example.com/data', {
-  headers: { 'x-api-key': 'sk-secret-key-12345' },
-});
-```
-
-### Constraint: IO Proxy must use relative paths only
-
-The Sales App internal proxy resolves the domain automatically.
-
-**Why this matters**
-A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
-
-**Detection**
-`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
-
-**Correct**
-
-```typescript
-await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
-```
-
-**Wrong**
-
-```typescript
-await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
-```
-
 ### Constraint: defineExtensions is required in index.tsx
 
 Entry point must use `defineExtensions` from `@vtex/sales-app`.
@@ -9242,186 +9193,6 @@ defineExtensions({ 'cart.cart-item.after': ItemWarranty });
 defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
 ```
 
-### Constraint: Always present execution plan and wait for approval
-
-Do not generate code until the user confirms the plan.
-
-**Why this matters**
-Generating without agreement wastes effort and may produce the wrong extension.
-
-**Detection**
-Jumping from discovery to code generation without presenting a plan.
-
-**Correct**
-Discovery → Requirements → Present plan → **User approves** → Generate code.
-
-**Wrong**
-Discovery → Generate code immediately.
-
-### Constraint: Never access DOM APIs directly
-
-Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
-
-**Why this matters**
-Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
-
-**Detection**
-Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
-
-**Correct**
-
-```typescript
-// Use React state, props, and Sales App hooks for data
-const { account } = useExtension();
-const cart = useCart();
-```
-
-**Wrong**
-
-```typescript
-const userId = localStorage.getItem('userId');
-const width = window.innerWidth;
-document.title = 'My Extension';
-```
-
-### Constraint: Never import restricted Node.js modules
-
-Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
-
-**Why this matters**
-Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
-
-**Detection**
-`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
-
-**Correct**
-
-```typescript
-import { useCart } from '@vtex/sales-app';
-import React, { useState, useEffect } from 'react';
-```
-
-**Wrong**
-
-```typescript
-import fs from 'fs';
-import crypto from 'crypto';
-```
-
-### Constraint: Never use eval or the Function constructor
-
-Arbitrary code execution is banned in the sandbox.
-
-**Why this matters**
-`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
-
-**Detection**
-Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
-
-**Correct**
-
-```typescript
-const result = computeValue(input); // deterministic logic only
-```
-
-**Wrong**
-
-```typescript
-eval('doSomething()');
-const fn = new Function('return 42');
-setTimeout('doSomething()', 1000);
-```
-
-### Constraint: CSS files must use plain .css extension, never .module.css
-
-The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
-
-**Why this matters**
-A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
-
-**Detection**
-Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
-
-**Correct**
-
-```typescript
-import './CashbackWidget.css';
-// Use className strings directly
-<div className="container">
-```
-
-**Wrong**
-
-```typescript
-import styles from './CashbackWidget.module.css';
-// CSS modules object access
-<div className={styles.container}>
-```
-
-### Constraint: CSS must use namespaced selectors — no global elements
-
-Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
-
-**Why this matters**
-Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
-
-**Detection**
-Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
-
-**Correct**
-
-```css
-/* Plain CSS — use namespace prefix to scope classes */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-
-@keyframes extension-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-```
-
-**Wrong**
-
-```css
-body { font-size: 14px; }
-* { box-sizing: border-box; }
-:root { --my-color: red; }
-@import './reset.css';
-.overlay { position: fixed; z-index: 9999; }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Constraint: CSS must follow Sales App Design Guidelines
-
-Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
-
-**Why this matters**
-Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
-
-**Detection**
-Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
-
-**Correct**
-
-```css
-.container {
-  --sa-color-primary: #157BF4;
-  --sa-color-text-primary: #1F1F1F;
-  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-}
-.title { color: var(--sa-color-text-primary); font-size: 16px; }
-.buttonPrimary { background-color: var(--sa-color-primary); }
-```
-
-**Wrong**
-
-```css
-.container { font-family: Arial; }
-.title { color: #1a1a1a; font-size: 15px; }
-.buttonPrimary { background-color: #0066cc; }
-```
-
 ## Preferred pattern
 
 ### Workflow overview
@@ -9432,59 +9203,17 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`.
 
-**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
+Required references for this step (load before generating):
+- [code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) — all component templates, the CSS template (with the full Sales App design system inlined: tokens, typography, spacing, responsive), the `index.tsx` template, type generation rules, and the custom fetch hook pattern.
+- [extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) — hook return types and TypeScript definitions.
+- [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`. Run these checks on all generated files.
+- [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) — load when the extension renders any UI text (sentence case rule) or uses icons (Phosphor Icons).
 
-1. **Extension name** — title matching the component name.
-2. **Overview** — one-paragraph summary of what the extension does and why it was built.
-3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
-4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
-5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS file name and summary of key classes.
-7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
-   - **Source documentation:** URL or file path of the original API documentation, if provided.
-   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
-   - Note which fields are optional (`?`) vs required per the documentation.
-8. **How to test** — dev server command and URL to reach the extension.
-9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Validate against the 12-point checklist in code-templates-and-patterns.md. Fix all violations before presenting code; surface warnings to the user.
 
-Template for the documentation file:
-
-````markdown
-# <ExtensionName>
-
-## Overview
-<One-paragraph description of the extension purpose and value.>
-
-## Extension point
-- **Point:** `<extension.point.name>`
-- **Rationale:** <Why this extension point was selected.>
-
-## Hooks used
-| Hook | Purpose |
-|------|---------|
-| `useCart` | <What data it provides here> |
-
-## Component structure
-<Describe the component tree, key props, and internal state.>
-
-## Styling
-- **File:** `<ComponentName>.css`
-- <Summary of key CSS classes and design decisions.>
-
-## API integration
-- **Endpoint:** `/_v/...`
-- **Auth strategy:** IO Proxy / Direct / None
-- **Request/Response:** <Brief shape description.>
-
-## How to test
-Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
-
-## Known constraints
-- <Guard or limitation 1>
-- <Guard or limitation 2>
-````
+**Step 4** — Generate `docs/<ExtensionName>.md` inside the Sales App package (create the `docs/` folder if needed). Load the [documentation template reference](sales-app-sales-app-extensibility-ref-documentation-template.md) for the required 9-section structure and the markdown skeleton to fill in.
 
 **Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md).
 
@@ -9497,73 +9226,47 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; **CSS template with the full Sales App design system inlined (tokens, typography, spacing, responsive)**; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
-| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Writing UI text (sentence case rule) or using icons (Phosphor Icons). **CSS-related design rules — tokens, typography, spacing, responsive — are inlined directly in the CSS template inside code-templates-and-patterns.md, so this file is not needed for CSS generation.** |
+| [references/documentation-template.md](sales-app-sales-app-extensibility-ref-documentation-template.md) | Writing the `docs/<ExtensionName>.md` file in Step 4 — the 9-section structure and markdown skeleton |
 
 ## Common failure modes
 
-- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
-- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
-- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
-- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
-- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
-- **Placing code outside packages/sales-app/src/** — Not included in build.
-- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
-- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
-- **Not presenting plan** — User may want a different approach. Always confirm.
-- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
-- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed. Always confirm both before Step 1.
+- **Not presenting plan** — User may want a different approach. Always confirm at Step 2 before generating code.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Load documentation-template.md for the required structure.
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
-- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
-- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
-- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
-- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
-- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
-- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
-- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
-- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
+- **Placing code outside packages/sales-app/src/** — Files outside this path are not included in the build.
+
+> Code-level violations (DOM APIs, Node imports, eval, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and caught during Step 3 validation. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Review checklist
 
+**Workflow gates**
 - [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
 - [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
 - [ ] Discovery completed and use case identified?
 - [ ] Execution plan approved by user?
 - [ ] Extension point is valid (from the 8-point reference)?
 - [ ] Hooks compatible with chosen extension point?
+- [ ] Documentation generated at `docs/<ExtensionName>.md` (9 sections, using documentation-template.md)?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+**TypeScript / runtime guards** (not caught by fsp-analyzer)
 - [ ] Component returns JSX.Element, never null?
 - [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
 - [ ] useCartItem().item checked for undefined?
-- [ ] No auth credentials exposed in frontend code?
-- [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
-- [ ] CSS file path matches component name?
-- [ ] Documentation generated at `docs/<ExtensionName>.md`?
-- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
-- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
-- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
-- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
-- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
-- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
-- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
-- [ ] No @import rules in CSS?
-- [ ] No position: fixed or z-index: 9999 in CSS?
-- [ ] @keyframes names prefixed with extension namespace?
-- [ ] No useLayoutEffect (use useEffect instead)?
-- [ ] No heavyweight library imports (lodash, moment)?
-- [ ] Components under 200 lines?
-- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
-- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
-- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
-- [ ] Build passes: `yarn fsp build {account} sales-app`?
-- [ ] Tested locally: `yarn fsp dev {account}`?
+
+> All other code-level rules (sandbox APIs, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and checked during Step 3. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Related skills
 

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -9258,6 +9258,114 @@ Discovery → Requirements → Present plan → **User approves** → Generate c
 **Wrong**
 Discovery → Generate code immediately.
 
+### Constraint: Never access DOM APIs directly
+
+Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
+
+**Why this matters**
+Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
+
+**Detection**
+Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
+
+**Correct**
+
+```typescript
+// Use React state, props, and Sales App hooks for data
+const { account } = useExtension();
+const cart = useCart();
+```
+
+**Wrong**
+
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+### Constraint: Never import restricted Node.js modules
+
+Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
+
+**Why this matters**
+Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
+
+**Detection**
+`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
+
+**Correct**
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+import React, { useState, useEffect } from 'react';
+```
+
+**Wrong**
+
+```typescript
+import fs from 'fs';
+import crypto from 'crypto';
+```
+
+### Constraint: Never use eval or the Function constructor
+
+Arbitrary code execution is banned in the sandbox.
+
+**Why this matters**
+`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
+
+**Detection**
+Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
+
+**Correct**
+
+```typescript
+const result = computeValue(input); // deterministic logic only
+```
+
+**Wrong**
+
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+### Constraint: CSS must use namespaced selectors — no global elements
+
+Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
+
+**Why this matters**
+Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
+
+**Detection**
+Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
+
+**Correct**
+
+```css
+/* CSS Module — classes are auto-scoped by the bundler */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+
+```css
+body { font-size: 14px; }
+* { box-sizing: border-box; }
+:root { --my-color: red; }
+@import './reset.css';
+.overlay { position: fixed; z-index: 9999; }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -9268,7 +9376,7 @@ Discovery → Generate code immediately.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -9336,6 +9444,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
 
 ## Common failure modes
 
@@ -9353,6 +9462,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
+- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
+- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
+- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
+- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
 
 ## Review checklist
 
@@ -9373,6 +9486,16 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
 - [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
+- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
+- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
+- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
+- [ ] No @import rules in CSS?
+- [ ] No position: fixed or z-index: 9999 in CSS?
+- [ ] @keyframes names prefixed with extension namespace?
+- [ ] No useLayoutEffect (use useEffect instead)?
+- [ ] No heavyweight library imports (lodash, moment)?
+- [ ] Components under 200 lines?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/copilot/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/copilot/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -326,82 +326,115 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Module
 
-All extensions use CSS modules with Admin UI design tokens.
+All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Admin UI patterns.
+ * Design tokens follow Sales App Design Guidelines.
+ * Reference: references/design-guidelines.md
+ * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
-.container { padding: 16px; background-color: #ffffff; }
-.content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: #1a1a1a; margin: 0; }
-.subtitle { font-size: 14px; color: #666666; margin: 0; }
-.text { font-size: 14px; color: #333333; line-height: 1.5; }
+.container {
+  /* Sales App design tokens — do not replace with hardcoded hex values */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+  --sa-color-bg:        #FFFFFF;
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
-/* Loading State */
+  padding: 16px;
+  background-color: var(--sa-color-bg);
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.content { display: flex; flex-direction: column; gap: 12px; }
+.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
+.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
+.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+
+/* Loading state */
 .loading {
   display: flex; align-items: center; justify-content: center;
-  gap: 8px; padding: 24px; color: #666666;
+  gap: 8px; padding: 24px; color: var(--sa-color-text-secondary);
 }
 .spinner {
   width: 20px; height: 20px;
-  border: 2px solid #e0e0e0; border-top-color: #0066cc;
-  border-radius: 50%; animation: spin 1s linear infinite;
+  border: 2px solid var(--sa-color-border); border-top-color: var(--sa-color-primary);
+  border-radius: 50%; animation: ${COMPONENT_NAME}-spin 1s linear infinite;
 }
-@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes ${COMPONENT_NAME}-spin { to { transform: rotate(360deg); } }
 
-/* Error State */
+/* Error state */
 .error {
-  padding: 16px; background-color: #fff5f5;
-  border: 1px solid #ffcccc; border-radius: 8px;
-  color: #cc0000; font-size: 14px;
+  padding: 16px; background-color: var(--sa-color-error-bg);
+  border: 1px solid var(--sa-color-error-border); border-radius: 8px;
+  color: var(--sa-color-error-text); font-size: 14px;
 }
 
-/* Button Styles */
+/* Button styles */
 .button {
   display: inline-flex; align-items: center; justify-content: center;
-  padding: 10px 16px; font-size: 14px; font-weight: 500;
+  padding: 12px 16px; font-size: 14px; font-weight: 500;
   border: none; border-radius: 6px; cursor: pointer;
   transition: background-color 0.2s ease;
 }
-.buttonPrimary { background-color: #0066cc; color: #ffffff; }
-.buttonPrimary:hover { background-color: #0052a3; }
-.buttonSecondary { background-color: #f0f0f0; color: #333333; }
-.buttonSecondary:hover { background-color: #e0e0e0; }
+.buttonPrimary { background-color: var(--sa-color-primary); color: #FFFFFF; }
+.buttonPrimary:hover { background-color: var(--sa-color-primary-hover); }
+.buttonSecondary { background-color: var(--sa-color-bg-muted); color: var(--sa-color-text-tertiary); }
+.buttonSecondary:hover { background-color: var(--sa-color-border); }
 
-/* Card Styles */
+/* Card */
 .card {
-  padding: 16px; background-color: #f9f9f9;
-  border-radius: 8px; border: 1px solid #e0e0e0;
+  padding: 16px; background-color: var(--sa-color-bg-subtle);
+  border-radius: 8px; border: 1px solid var(--sa-color-border);
 }
 
-/* Badge Styles */
+/* Badges */
 .badge {
   display: inline-block; padding: 4px 8px;
   font-size: 12px; font-weight: 500; border-radius: 4px;
 }
-.badgeSuccess { background-color: #e6f4ea; color: #137333; }
-.badgeWarning { background-color: #fef7e0; color: #b06000; }
-.badgeInfo { background-color: #e8f0fe; color: #1a73e8; }
+.badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
+.badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
+.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
 
-/* Input Styles */
+/* Input */
 .input {
-  width: 100%; padding: 10px 12px; font-size: 14px;
-  border: 1px solid #d0d0d0; border-radius: 6px;
+  width: 100%; padding: 12px; font-size: 14px;
+  border: 1px solid var(--sa-color-border-input); border-radius: 6px;
   outline: none; transition: border-color 0.2s ease;
 }
-.input:focus { border-color: #0066cc; }
+.input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/Flex Helpers */
+/* Row/flex helpers */
 .row { display: flex; align-items: center; gap: 12px; }
 .spaceBetween { justify-content: space-between; }
 
-/* Price Display */
-.price { font-size: 18px; font-weight: 600; color: #1a1a1a; }
-.priceOld { font-size: 14px; color: #999999; text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: #137333; font-weight: 500; }
+/* Price display */
+.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+
+/* Responsive — Sales App breakpoints */
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
 ```
 
 ## index.tsx with defineExtensions
@@ -446,6 +479,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
+12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/copilot/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/copilot/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -326,38 +326,73 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Stylesheet
 
-All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules). The full Sales App design system for CSS — tokens, typography, spacing grid, responsive breakpoints, and structure — is inlined below. **Use this template as the single source of truth for any CSS generation.**
 
 **CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
+
+### Design system rules baked into this template
+
+These rules apply to **every** generated extension CSS. The template below already complies — keep it that way.
+
+| Topic | Rule |
+|-------|------|
+| Tokens | All colors must reference `--sa-color-*` tokens declared on `.container`. **Never** use hardcoded hex values anywhere else. |
+| Font family | `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif` on `.container`, inherited by descendants. |
+| Font weights | Only Regular (400), Medium (500), Semibold (600), Bold (700). |
+| Font sizes (px) | Allowed scale only: **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**. Never `13`, `15`, `17`, etc. |
+| Typography roles | Section title = 16px/600 · Subtitle/label = 14px/500 · Body = 14px/400 · Caption = 12px/400 · Price = 18px/600. |
+| Spacing | Multiples of **4px** only (4, 8, 12, 16, 20, 24, 32, 40…). Never `10`, `14`, `18`, `22`. Applies to `padding`, `margin`, `gap`, `height`. |
+| Containment | No `position: fixed`, no `z-index: 9999`, no `:host`, no `:global`, no `@import`. `position: relative` and `sticky` are safe. |
+| Selectors | Use the unprefixed utility class names from this template (`.container`, `.content`, `.row`, `.title`, `.button`, etc.). The Sales App `fsp-analyzer` runs with `transformNonCompliant: true`, so unprefixed selectors emit a `CSS_TRANSFORMED` warning rather than a `CSS_NAMESPACE_REQUIRED` violation. Never use `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` — those are caught by `CSS_GLOBAL_SELECTOR` and remain blocking. |
+| Keyframes | Prefix with `${COMPONENT_NAME}-` (e.g., `${COMPONENT_NAME}-spin`). This raises a `CSS_TRANSFORMED` warning (build still passes) — use `sales-app-extension-${COMPONENT_NAME}-spin` if you want a clean run. |
+| `!important` | Never. |
+| Responsive | Use the breakpoint at `(max-width: 743px)` for mobile overrides. Sales App shell handles the rest. |
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Sales App Design Guidelines.
- * Reference: references/design-guidelines.md
+ * Sales App design system (tokens + typography + spacing + responsive) is fully inlined.
  * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
 .container {
-  /* Sales App design tokens — do not replace with hardcoded hex values */
+  /* === Sales App design tokens — single source of truth ===
+     Always declare these on .container. Reference via var(--sa-color-*) in all other rules.
+     Never use hardcoded hex values in CSS rules. */
+
+  /* Primary action */
   --sa-color-primary:       #157BF4;   /* Light Blue 800 */
   --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-  --sa-color-bg:        #FFFFFF;
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 — high emphasis */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600  — medium emphasis */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500  — low emphasis */
+  --sa-color-text-muted:     #999999;  /* Neutral 700  — disabled / hint */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
   --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
   --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
   --sa-color-border:       #E0E0E0;    /* Neutral 300 */
   --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
   --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
   --sa-color-error-border: #FFDFD9;    /* Red 200 */
   --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
   --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
   --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow / Orange scale) */
   --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
   --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
   --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
   --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
@@ -365,10 +400,16 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
   background-color: var(--sa-color-bg);
   font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
 }
+
+/* Layout */
 .content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
-.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
-.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+.row { display: flex; align-items: center; gap: 12px; }
+.spaceBetween { justify-content: space-between; }
+
+/* Typography — uses approved size scale (10, 12, 14, 16, 18, 20, 22, 24...) */
+.title    { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary);   margin: 0; }
+.subtitle { font-size: 14px; font-weight: 500; color: var(--sa-color-text-secondary); margin: 0; }
+.text     { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
 
 /* Loading state */
 .loading {
@@ -414,7 +455,7 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
 .badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
-.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
+.badgeInfo    { background-color: var(--sa-color-info-bg);    color: var(--sa-color-info-text); }
 
 /* Input */
 .input {
@@ -424,20 +465,33 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/flex helpers */
-.row { display: flex; align-items: center; gap: 12px; }
-.spaceBetween { justify-content: space-between; }
-
 /* Price display */
-.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
-.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+.price          { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld       { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount  { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
 
-/* Responsive — Sales App breakpoints */
+/* Responsive — Sales App breakpoints
+   Small (mobile)  320–743px  → margin: 24px, no column grid
+   Medium (tablet) 744–1279px → host gutters: 16px (no override needed)
+   Large (desktop) 1280–1919px → host gutters: 20px (no override needed)
+   Extra large     1920px+    → host gutters: 20px (no override needed) */
 @media (max-width: 743px) {
   .container { padding: 12px; margin: 0 24px; }
 }
 ```
+
+### CSS file structure
+
+Every extension CSS must follow this order:
+
+1. **Token declarations** — `--sa-color-*` on `.container`
+2. **Layout helpers** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography** — `.title`, `.subtitle`, `.text`
+4. **State** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive** — `@media` queries at the bottom
+
+For UX writing rules (sentence case) and iconography (Phosphor Icons) used in `.tsx`, see [design-guidelines.md](design-guidelines.md).
 
 ## index.tsx with defineExtensions
 
@@ -481,7 +535,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design system compliance** — the CSS file must follow the rules table at the top of the "CSS Stylesheet" section above: `--sa-color-*` custom properties declared on `.container` and used in all rules, `'VTEX Trust'` font family, allowed font sizes (10, 12, 14, 16, 18, 20, 22, 24, 28, 32…), 4px-multiple spacing, scoped selectors, and the responsive override at `(max-width: 743px)`. For UI text (sentence case) and icons (Phosphor), see [design-guidelines.md](design-guidelines.md).
 
 ## API Type Generation from Documentation
 

--- a/exports/copilot/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/copilot/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -445,6 +445,7 @@ After generating code, validate for these issues:
 8. **API call handling** — loading state and error handling must be present for any `fetch()` call
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
+11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
 
 ## API Type Generation from Documentation
 

--- a/exports/copilot/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/copilot/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -324,9 +324,11 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 }
 ```
 
-## CSS Module
+## CSS Stylesheet
 
-All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+
+**CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
 
 ```css
 /**
@@ -479,7 +481,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/copilot/sales-app-sales-app-extensibility-ref-design-guidelines.md
+++ b/exports/copilot/sales-app-sales-app-extensibility-ref-design-guidelines.md
@@ -194,7 +194,7 @@ Sales App extensions render within a host container that handles most layout res
 | Large (desktop) | 1280–1919px | Gutters: 20px |
 | Extra large (monitor) | 1920px+ | Gutters: 20px |
 
-Recommended mobile override (applied to the responsive section of the CSS module):
+Recommended mobile override (applied to the responsive section of the CSS file):
 
 ```css
 @media (max-width: 743px) {
@@ -204,9 +204,9 @@ Recommended mobile override (applied to the responsive section of the CSS module
 
 ---
 
-## 7. CSS Module Structure
+## 7. CSS File Structure
 
-Every extension CSS module must follow this structure:
+Every extension CSS file must follow this structure:
 
 1. **Token declarations** — CSS custom properties on `.container`
 2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`

--- a/exports/copilot/sales-app-sales-app-extensibility-ref-design-guidelines.md
+++ b/exports/copilot/sales-app-sales-app-extensibility-ref-design-guidelines.md
@@ -1,0 +1,238 @@
+# Sales App Design Guidelines
+
+All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+
+---
+
+## 1. UX and Writing Rules
+
+Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+
+| Rule | Correct | Wrong |
+|------|---------|-------|
+| Sentence case | "Add to cart" | "ADD TO CART" |
+| Proper nouns | "VTEX account" | "vtex account" |
+| No all-caps | "Loyalty points" | "LOYALTY POINTS" |
+| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+
+These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
+
+---
+
+## 2. Design Tokens (CSS Custom Properties)
+
+Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
+
+```css
+.container {
+  /* Primary action */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow/Orange scale) */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
+}
+```
+
+### Token mapping reference
+
+| Semantic role | Token | Hex | Palette origin |
+|--------------|-------|-----|----------------|
+| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
+| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
+| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
+| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
+| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
+| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
+| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
+| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
+| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
+| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
+| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
+| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
+| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
+| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
+| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
+| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
+| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
+| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
+| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
+| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+
+---
+
+## 3. Typography
+
+### Typeface
+
+The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
+
+```css
+font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+```
+
+Set this on the root `.container` class so all descendant elements inherit it.
+
+### Weights
+
+Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
+
+### Allowed font sizes
+
+Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
+
+Do not use arbitrary sizes like 13px, 15px, or 17px.
+
+| Use case | Size | Weight |
+|----------|------|--------|
+| Section title | 16px | Semibold (600) |
+| Subtitle / label | 14px | Medium (500) |
+| Body text | 14px | Regular (400) |
+| Caption / hint | 12px | Regular (400) |
+| Price | 18px | Semibold (600) |
+
+---
+
+## 4. Iconography
+
+### Library
+
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Standard / default | 24px |
+| Compact / inline | 16px |
+| Large / featured | 32–48px |
+
+Always use sizes within the supported range: **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+
+### Installation
+
+```bash
+yarn add @phosphor-icons/react
+```
+
+### Usage example
+
+```typescript
+import { ShoppingCart, Star, Warning } from '@phosphor-icons/react';
+
+export function MyExtension(): JSX.Element {
+  return (
+    <div className="container">
+      <ShoppingCart size={24} />
+      <span>Cart items</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. Spacing and Baseline Grid
+
+All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+
+| Value | Baseline multiple |
+|-------|-----------------|
+| 4px | 1× |
+| 8px | 2× |
+| 12px | 3× |
+| 16px | 4× |
+| 20px | 5× |
+| 24px | 6× |
+| 32px | 8× |
+
+**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
+
+---
+
+## 6. Responsive Breakpoints
+
+Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
+
+| Breakpoint | Resolution range | Notes |
+|-----------|-----------------|-------|
+| Small (mobile) | 320–743px | Margin: 24px, no column grid |
+| Medium (tablet) | 744–1279px | Gutters: 16px |
+| Large (desktop) | 1280–1919px | Gutters: 20px |
+| Extra large (monitor) | 1920px+ | Gutters: 20px |
+
+Recommended mobile override (applied to the responsive section of the CSS module):
+
+```css
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
+```
+
+---
+
+## 7. CSS Module Structure
+
+Every extension CSS module must follow this structure:
+
+1. **Token declarations** — CSS custom properties on `.container`
+2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography classes** — `.title`, `.subtitle`, `.text`
+4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive overrides** — `@media` queries at the bottom
+
+### Critical CSS rules
+
+- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
+- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
+- No `@import`, `position: fixed`, or `z-index: 9999`.
+- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
+
+---
+
+## 8. Quick Compliance Checklist
+
+Before presenting generated CSS to the user, verify:
+
+- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
+- [ ] No hardcoded hex values outside the token declarations block?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
+- [ ] All spacing multiples of 4px?
+- [ ] All icons from Phosphor Icons?
+- [ ] All UI text in sentence case (no ALL-CAPS)?
+- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?

--- a/exports/copilot/sales-app-sales-app-extensibility-ref-design-guidelines.md
+++ b/exports/copilot/sales-app-sales-app-extensibility-ref-design-guidelines.md
@@ -1,152 +1,55 @@
-# Sales App Design Guidelines
+# Sales App Design Guidelines (non-CSS)
 
-All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+This reference covers two topics that apply to **TSX content**, not CSS:
+
+1. **UX writing rules** — for any text rendered in JSX
+2. **Iconography** — when the extension uses icons
+
+> **For CSS:** all design tokens, typography scale, spacing grid, and responsive breakpoints are inlined directly in the CSS template at [code-templates-and-patterns.md](code-templates-and-patterns.md) §"CSS Stylesheet". That template is the single source of truth for any CSS generation. Do not invent or duplicate token values here.
 
 ---
 
-## 1. UX and Writing Rules
+## 1. UX Writing Rules
 
-Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+Apply to every string that appears in the UI (labels, buttons, messages, placeholders, alt text).
 
 | Rule | Correct | Wrong |
 |------|---------|-------|
 | Sentence case | "Add to cart" | "ADD TO CART" |
-| Proper nouns | "VTEX account" | "vtex account" |
+| Proper nouns capitalized | "VTEX account" | "vtex account" |
 | No all-caps | "Loyalty points" | "LOYALTY POINTS" |
-| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+| No system-style placeholders | "Your email" | "EMAIL ADDRESS" |
+| No CSS uppercase transforms | (omit `text-transform: uppercase`) | `text-transform: uppercase` |
 
-These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
-
----
-
-## 2. Design Tokens (CSS Custom Properties)
-
-Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
-
-```css
-.container {
-  /* Primary action */
-  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
-  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-
-  /* Text */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-
-  /* Backgrounds */
-  --sa-color-bg:        #FFFFFF;       /* Neutral White */
-  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
-  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
-
-  /* Borders */
-  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
-  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
-
-  /* Error (Red scale) */
-  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
-  --sa-color-error-border: #FFDFD9;    /* Red 200 */
-  --sa-color-error-text:   #EC3727;    /* Red 800 */
-
-  /* Success (Green scale) */
-  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
-  --sa-color-success-text: #01905F;    /* Green 800 */
-
-  /* Warning (Yellow/Orange scale) */
-  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
-  --sa-color-warning-text: #E57001;    /* Orange 700 */
-
-  /* Info (Light Blue scale) */
-  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
-  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
-}
-```
-
-### Token mapping reference
-
-| Semantic role | Token | Hex | Palette origin |
-|--------------|-------|-----|----------------|
-| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
-| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
-| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
-| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
-| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
-| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
-| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
-| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
-| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
-| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
-| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
-| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
-| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
-| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
-| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
-| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
-| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
-| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
-| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
-| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+These rules derive from Google Material Design and Apple Human Interface Guidelines, adopted by VTEX.
 
 ---
 
-## 3. Typography
-
-### Typeface
-
-The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
-
-```css
-font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-```
-
-Set this on the root `.container` class so all descendant elements inherit it.
-
-### Weights
-
-Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
-
-### Allowed font sizes
-
-Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
-
-Do not use arbitrary sizes like 13px, 15px, or 17px.
-
-| Use case | Size | Weight |
-|----------|------|--------|
-| Section title | 16px | Semibold (600) |
-| Subtitle / label | 14px | Medium (500) |
-| Body text | 14px | Regular (400) |
-| Caption / hint | 12px | Regular (400) |
-| Price | 18px | Semibold (600) |
-
----
-
-## 4. Iconography
+## 2. Iconography
 
 ### Library
 
-All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
-
-### Sizes
-
-| Usage | Size |
-|-------|------|
-| Standard / default | 24px |
-| Compact / inline | 16px |
-| Large / featured | 32–48px |
-
-Always use sizes within the supported range: **16px to 48px**.
-
-### Weights
-
-Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use Material Icons, Font Awesome, Heroicons, or any other library.
 
 ### Installation
 
 ```bash
 yarn add @phosphor-icons/react
 ```
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Compact / inline | 16px |
+| Standard / default | 24px |
+| Large / featured | 32–48px |
+
+Always use sizes within **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
 
 ### Usage example
 
@@ -165,74 +68,13 @@ export function MyExtension(): JSX.Element {
 
 ---
 
-## 5. Spacing and Baseline Grid
+## 3. Quick checklist
 
-All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+Before presenting generated `.tsx` to the user, verify:
 
-| Value | Baseline multiple |
-|-------|-----------------|
-| 4px | 1× |
-| 8px | 2× |
-| 12px | 3× |
-| 16px | 4× |
-| 20px | 5× |
-| 24px | 6× |
-| 32px | 8× |
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-style placeholders)?
+- [ ] All icons imported from `@phosphor-icons/react`?
+- [ ] Icon sizes between 16px and 48px (24px default)?
+- [ ] Icon weights consistent within the component?
 
-**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
-
----
-
-## 6. Responsive Breakpoints
-
-Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
-
-| Breakpoint | Resolution range | Notes |
-|-----------|-----------------|-------|
-| Small (mobile) | 320–743px | Margin: 24px, no column grid |
-| Medium (tablet) | 744–1279px | Gutters: 16px |
-| Large (desktop) | 1280–1919px | Gutters: 20px |
-| Extra large (monitor) | 1920px+ | Gutters: 20px |
-
-Recommended mobile override (applied to the responsive section of the CSS file):
-
-```css
-@media (max-width: 743px) {
-  .container { padding: 12px; margin: 0 24px; }
-}
-```
-
----
-
-## 7. CSS File Structure
-
-Every extension CSS file must follow this structure:
-
-1. **Token declarations** — CSS custom properties on `.container`
-2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
-3. **Typography classes** — `.title`, `.subtitle`, `.text`
-4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
-5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
-6. **Responsive overrides** — `@media` queries at the bottom
-
-### Critical CSS rules
-
-- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
-- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
-- No `@import`, `position: fixed`, or `z-index: 9999`.
-- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
-
----
-
-## 8. Quick Compliance Checklist
-
-Before presenting generated CSS to the user, verify:
-
-- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
-- [ ] No hardcoded hex values outside the token declarations block?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
-- [ ] All spacing multiples of 4px?
-- [ ] All icons from Phosphor Icons?
-- [ ] All UI text in sentence case (no ALL-CAPS)?
-- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?
+For CSS verification (tokens, fonts, spacing, responsive), see [code-templates-and-patterns.md](code-templates-and-patterns.md) §"Design system rules baked into this template".

--- a/exports/copilot/sales-app-sales-app-extensibility-ref-documentation-template.md
+++ b/exports/copilot/sales-app-sales-app-extensibility-ref-documentation-template.md
@@ -1,0 +1,53 @@
+# Extension Documentation Template
+
+Generate `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist.
+
+The document must contain these 9 sections:
+
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+```markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+```

--- a/exports/copilot/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
+++ b/exports/copilot/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
@@ -1,0 +1,908 @@
+# Static Analysis Rules (fsp-analyzer)
+
+Sales App extensions run inside a sandboxed environment enforced by `@vtex/fsp-analyzer`. These rules are checked at `preBuild` and `preDev` hook time. The AI must validate all generated code against these rules before presenting it to the user.
+
+Rule IDs match the `ViolationKind`, `ReactViolationKind`, `WarningKind`, and `ReactWarningKind` types from `@vtex/fsp-analyzer` so developers can cross-reference with real build output.
+
+---
+
+## How to apply these rules
+
+After generating a component, CSS file, and `index.tsx`, check each generated file against the **violation** rules (block generation — fix before presenting) and the **warning** rules (flag to the user with a suggestion). Do not present code that has unresolved violations.
+
+---
+
+## 1. Sandbox Security Rules
+
+Applied to `.ts` and `.tsx` files by `FastStoreSandboxAnalyzer`.
+
+### `RESTRICTED_API` — DOM API access banned
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted identifiers: `document`, `window`, `localStorage`, `sessionStorage`, `navigator`.
+
+**Detection:** Any use of these identifiers as a value (not as a type import).
+
+**Correct**
+```typescript
+// Use React state and props for data; use useExtension() for account context
+const { account } = useExtension();
+```
+
+**Wrong**
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+---
+
+### `VARIABLE_ALIASING` — Aliasing restricted APIs
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Assigning a restricted API to a variable to circumvent detection.
+
+**Detection:** `const x = document`, `const [w, d] = [window, document]`, or any destructuring that aliases a restricted API.
+
+**Correct**
+```typescript
+// Pass data via props or React context, not via aliased globals
+```
+
+**Wrong**
+```typescript
+const doc = document;
+const [w, d] = [window, document];
+doc.querySelector('.item');
+```
+
+---
+
+### `GLOBAL_MANIPULATION` — Global object manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted member expressions: `window.location`, `window.history`.
+
+**Detection:** Member expressions on `window` to access `location` or `history`.
+
+**Correct**
+```typescript
+// Navigation is managed by Sales App shell; do not manipulate location
+```
+
+**Wrong**
+```typescript
+window.location.href = '/new-path';
+window.location.reload();
+```
+
+---
+
+### `HISTORY_MANIPULATION` — Browser history manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `window.history.pushState`, `window.history.replaceState`, `history.pushState`, `history.replaceState`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Let the Sales App shell handle routing
+```
+
+**Wrong**
+```typescript
+history.pushState({}, '', '/cart');
+window.history.replaceState(null, '', '/pdp');
+```
+
+---
+
+### `DYNAMIC_SCRIPT_CREATION` — Dynamic script creation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `document.createElement`, `document.write`, `document.writeln`, `document.body.appendChild`, `document.head.appendChild`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Render UI via JSX; never inject scripts dynamically
+```
+
+**Wrong**
+```typescript
+const script = document.createElement('script');
+script.src = 'https://cdn.example.com/lib.js';
+document.body.appendChild(script);
+```
+
+---
+
+### `CODE_EXECUTION` — Arbitrary code execution
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `eval`, `Function` (as constructor), `setTimeout` (string form), `setInterval` (string form), `new Function`.
+
+**Detection:** Any call or instantiation of these identifiers.
+
+> **Note on `setTimeout`/`setInterval`:** These are restricted in the sandbox to prevent arbitrary code injection. Use `useEffect` with `AbortController` or cleanup functions for timing-based logic:
+
+**Correct**
+```typescript
+useEffect(() => {
+  const id = window.setTimeout(() => { /* logic */ }, 500);
+  return () => window.clearTimeout(id);
+}, []);
+// Note: even this should be reviewed; prefer event-driven patterns
+```
+
+**Wrong**
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+---
+
+### `RESTRICTED_IMPORT` — Restricted Node.js module imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted modules: `fs`, `path`, `child_process`, `crypto`.
+
+**Detection:** Any `import` statement importing from these module names.
+
+**Correct**
+```typescript
+// Extensions are browser-only React components; do not import Node.js modules
+import { useCart } from '@vtex/sales-app';
+```
+
+**Wrong**
+```typescript
+import fs from 'fs';
+import { resolve } from 'path';
+import crypto from 'crypto';
+```
+
+---
+
+### `RESTRICTED_IMPORT_SOURCE` — Direct node_modules path imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Import paths containing `node_modules/`.
+
+**Wrong**
+```typescript
+import something from 'node_modules/lodash/get';
+```
+
+---
+
+### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+
+**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+
+> **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
+
+**Correct**
+```typescript
+// Always use IO Proxy relative path
+const response = await fetch('/_v/my-loyalty-api/points', {
+  credentials: 'include',
+});
+```
+
+**Wrong**
+```typescript
+const response = await fetch('https://api.example.com/data');
+const xhr = new XMLHttpRequest();
+```
+
+---
+
+### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
+
+**Detection:** `fetch()` first argument literal containing one of these domains.
+
+**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
+
+---
+
+### `QUERY_SELECTOR_USAGE` — DOM query selectors
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Use React refs for direct DOM access when absolutely needed
+const ref = useRef<HTMLDivElement>(null);
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.my-class');
+document.getElementById('cart-container');
+```
+
+---
+
+### `STYLE_MANIPULATION` — Direct style manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
+
+**Detection:** Any member expression matching these patterns.
+
+**Correct**
+```typescript
+// Use CSS modules and conditional class application
+import styles from './MyExtension.module.css';
+
+return <div className={isActive ? styles.active : styles.inactive} />;
+```
+
+**Wrong**
+```typescript
+element.style.color = 'red';
+element.classList.add('active');
+element.setAttribute('style', 'display: none');
+```
+
+---
+
+### `INFINITE_LOOP` — Infinite loops
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+
+**Wrong**
+```typescript
+while (true) {
+  processItem();
+}
+```
+
+---
+
+### `MEMORY_LEAK` — Memory leak patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  window.addEventListener('resize', handler);
+  // Missing cleanup — memory leak
+}, []);
+```
+
+---
+
+### `EXCESSIVE_API_CALLS` — Excessive API call patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+
+**Wrong**
+```typescript
+// fetch inside render — fires on every re-render
+const data = await fetch('/_v/api/data');
+
+// fetch inside loop — excessive calls
+for (const item of items) {
+  await fetch(`/_v/api/item/${item.id}`);
+}
+```
+
+---
+
+### `LARGE_BUNDLE_SIZE_IMPACT` — Bundle size impacts
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:**
+- String literals longer than 1,000 characters
+- Object literals with more than 100 properties
+- Imports from heavyweight libraries: `lodash`, `moment`
+
+**Action:** Warn the user and suggest alternatives (`date-fns` instead of `moment`, native array methods instead of `lodash`).
+
+**Correct**
+```typescript
+import { format } from 'date-fns';
+const formattedDate = format(new Date(), 'yyyy-MM-dd');
+```
+
+**Wrong**
+```typescript
+import moment from 'moment';
+import _ from 'lodash';
+```
+
+---
+
+## 2. CSS Containment Rules
+
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+
+### `CSS_GLOBAL_SELECTOR` — Global element selectors
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
+
+**Detection:** Any CSS rule whose selector matches or contains these elements at the top level.
+
+**Correct**
+```css
+/* Scope all rules inside the extension container */
+.extension-container {
+  font-size: 14px;
+}
+
+.extension-container .title {
+  font-weight: bold;
+}
+```
+
+**Wrong**
+```css
+body {
+  font-size: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --my-color: red;
+}
+```
+
+---
+
+### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
+
+**Detection:** Any rule or declaration matching these patterns.
+
+> **Note on positioning:** `position: relative` and `position: sticky` within the extension container are generally safe. Avoid `fixed` and unbounded `absolute` that escape the extension boundary.
+
+**Correct**
+```css
+.extension-container {
+  position: relative; /* safe — contained */
+}
+```
+
+**Wrong**
+```css
+.overlay {
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+}
+
+:host {
+  display: block;
+}
+```
+
+---
+
+### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+
+**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+
+**Correct**
+```css
+/* CSS Module — all classes are auto-scoped */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+```css
+/* Plain CSS — must namespace manually */
+.extension-container { padding: 8px; }
+.extension-title { font-size: 16px; }
+```
+
+**Wrong**
+```css
+/* Plain CSS — no namespace — pollutes global styles */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+---
+
+### `CSS_GLOBAL_IMPORT` — CSS @import rules
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@import` pulls external stylesheets that affect global styles and bypass containment.
+
+**Detection:** Any `@import` at-rule anywhere in the CSS file.
+
+**Correct**
+```css
+/* Import a local CSS variable file via bundler config, not @import */
+```
+
+**Wrong**
+```css
+@import url('https://fonts.googleapis.com/css2?family=Roboto');
+@import './reset.css';
+```
+
+---
+
+### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+
+**Correct**
+```css
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+```css
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+---
+
+### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
+
+**Detection:** Declarations using restricted property names (e.g., properties that set global layout hints).
+
+**Action:** If detected, remove or scope the declaration appropriately.
+
+---
+
+### `CSS_RESTRICTED_VALUE` — Restricted CSS values
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
+
+**Detection:** `!important` in any declaration, or values targeting global layout tokens.
+
+**Correct**
+```css
+.extension-button {
+  color: var(--vtex-color-primary);
+}
+```
+
+**Wrong**
+```css
+.extension-button {
+  color: red !important;
+}
+```
+
+---
+
+## 3. React Performance Rules
+
+Applied to `.tsx` files by `ReactPerformanceAnalyzer`. Violations block presentation; warnings are flagged to the user.
+
+### `REACT_UNNECESSARY_RERENDER` — State update inside loop
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+State setter calls inside `for` or `while` loops trigger a re-render on every iteration.
+
+**Detection:** A `setState` / `set*` call whose parent node is a `for` or `while` statement.
+
+**Correct**
+```typescript
+// Compute derived value, then set once
+const updatedItems = items.map(transform);
+setItems(updatedItems);
+```
+
+**Wrong**
+```typescript
+for (const item of items) {
+  setCount((c) => c + 1); // re-renders on every iteration
+}
+```
+
+---
+
+### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
+
+**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
+
+**Correct**
+```typescript
+const filteredItems = useMemo(() => items.filter(isActive), [items]);
+
+return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
+  </ul>
+);
+```
+
+---
+
+### `REACT_ANONYMOUS_COMPONENT` — Anonymous (lowercase) component
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Components assigned to variables starting with lowercase are treated as HTML tags by React and cannot be used in JSX.
+
+**Detection:** Arrow function or function expression assigned to a variable that does not start with an uppercase letter.
+
+**Correct**
+```typescript
+export function LoyaltyPoints(): JSX.Element { ... }
+export const WarrantyBadge = (): JSX.Element => { ... };
+```
+
+**Wrong**
+```typescript
+const loyaltyPoints = (): JSX.Element => { ... };
+const warrantyBadge = function() { ... };
+```
+
+---
+
+### `REACT_DIRECT_DOM_MANIPULATION` — Direct DOM manipulation in React
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Bypasses the React virtual DOM and causes unpredictable behavior.
+
+**Detection:** Calls to `document.querySelector` or `document.getElementById` inside a React component.
+
+**Correct**
+```typescript
+const containerRef = useRef<HTMLDivElement>(null);
+// Access DOM via containerRef.current
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.cart-list');
+el.style.display = 'none'; // bypasses React
+```
+
+---
+
+### `REACT_LAYOUT_EFFECT_MISUSE` — useLayoutEffect usage
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`useLayoutEffect` blocks the browser paint and can cause performance issues in a sandboxed extension.
+
+**Detection:** Any call to `useLayoutEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  // DOM reading/writing after paint
+}, []);
+```
+
+**Wrong**
+```typescript
+useLayoutEffect(() => {
+  // blocks paint
+}, []);
+```
+
+---
+
+### `REACT_MISSING_DEPS` — Missing dependency array
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useEffect`, `useCallback`, or `useMemo` without a second argument re-runs on every render.
+
+**Detection:** A call to one of these hooks with fewer than 2 arguments, or with a non-array second argument.
+
+**Correct**
+```typescript
+useEffect(() => {
+  fetchData();
+}, [productId]); // explicit deps
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  fetchData(); // runs on every render
+});
+```
+
+---
+
+### `REACT_INLINE_FUNCTION` — Inline functions in JSX props
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Arrow functions defined directly in JSX attributes create a new function reference on every render, preventing child memoization.
+
+**Detection:** Function expression or arrow function expression whose parent is a JSX expression container or prop.
+
+**Correct**
+```typescript
+const handleClick = useCallback(() => {
+  doSomething();
+}, []);
+
+return <button onClick={handleClick}>Click</button>;
+```
+
+**Wrong**
+```typescript
+return <button onClick={() => doSomething()}>Click</button>;
+```
+
+---
+
+### `REACT_LARGE_COMPONENT` — Component over 200 lines
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Large components are harder to maintain and test. Threshold: **200 lines**.
+
+**Detection:** A function/arrow function with start/end line difference > 200.
+
+**Action:** Suggest splitting into smaller sub-components or extracting logic into custom hooks.
+
+---
+
+### `REACT_MANY_USESTATE` — More than 5 useState calls
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Many `useState` calls in a single component indicate complex local state. Threshold: **5 calls**.
+
+**Detection:** More than 5 calls to `useState` (or `React.useState`) within a single function component.
+
+**Action:** Suggest consolidating related state into a single `useState` with an object, or extracting to a custom hook.
+
+**Correct**
+```typescript
+const [formState, setFormState] = useState({
+  name: '',
+  email: '',
+  quantity: 1,
+});
+```
+
+**Wrong**
+```typescript
+const [name, setName] = useState('');
+const [email, setEmail] = useState('');
+const [quantity, setQuantity] = useState(1);
+const [loading, setLoading] = useState(false);
+const [error, setError] = useState<string | null>(null);
+const [submitted, setSubmitted] = useState(false); // 6th useState — flagged
+```
+
+---
+
+### `REACT_CONDITIONAL_HOOK` — Hook called conditionally
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a hook inside an `if`, `switch`, or ternary expression violates the Rules of Hooks.
+
+**Detection:** A hook call (useEffect, useState, useMemo, useCallback, useLayoutEffect) whose ancestor is an `IfStatement`, `SwitchStatement`, or `ConditionalExpression`.
+
+**Correct**
+```typescript
+const cart = useCart(); // always called unconditionally
+
+if (!cart) return <></>;
+```
+
+**Wrong**
+```typescript
+if (isEnabled) {
+  const cart = useCart(); // conditional hook call — violates Rules of Hooks
+}
+```
+
+---
+
+### `REACT_COMPLEX_JSX` — Deep JSX nesting
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Deep JSX trees are harder to read and may indicate a need to extract sub-components. Threshold: **5 levels deep**.
+
+**Detection:** A JSX element whose JSX child tree exceeds 5 levels of nesting.
+
+**Action:** Extract inner JSX into a named sub-component.
+
+---
+
+### `REACT_UNOPTIMIZED_LIST` — List rendering without key or large list
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Missing `key` props in list rendering causes React reconciliation issues. Lists over 50 items may need virtualization.
+
+**Detection:**
+- `map()` producing JSX without a `key` attribute on the root element
+- List size exceeding 50 items
+
+**Correct**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li key={item.id}>{item.name}</li>
+    ))}
+  </ul>
+);
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li>{item.name}</li> // missing key
+    ))}
+  </ul>
+);
+```
+
+---
+
+### `REACT_COMPLEX_STATE` — useState with complex object
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useState` initialized with an object having more than 5 properties suggests a need for `useReducer`. Threshold: **5 properties**.
+
+**Detection:** `useState(obj)` where `obj` is an object literal with > 5 properties.
+
+**Action:** Suggest converting to `useReducer` for complex state.
+
+---
+
+### `REACT_NESTED_UPDATE` — Nested state updates
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a state setter from within another state setter's callback can cause unexpected re-renders.
+
+**Detection:** A `set*` call whose ancestor is another `set*` call expression.
+
+---
+
+## Validation Output Format
+
+When reporting issues after code review, group by file and severity:
+
+```
+### Static Analysis Results
+
+**Violations (must fix before completing Step 3):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Fix: <suggested fix>
+
+**Warnings (review with user):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Suggestion: <improvement>
+
+✅ No violations found. N warnings flagged.
+```
+
+Do not proceed with Step 4 (Documentation) until all violations are resolved.

--- a/exports/copilot/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
+++ b/exports/copilot/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
@@ -197,20 +197,33 @@ import something from 'node_modules/lodash/get';
 
 ---
 
+### `NON_APPROVED_PACKAGE` — Import from non-approved package
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Any import whose source starts with `@` or contains `/`, unless it is `react` or a `node_modules/` direct path. Fires for every `@vtex/*` scoped package and every relative import (`./foo`, `../bar`).
+
+> **Note:** This warning is noisy — it fires for all legitimate Sales App imports (`@vtex/sales-app`, `@phosphor-icons/react`, relative component paths). Do not surface to the user when the import is from `@vtex/*` or a relative path. Investigate only when the import is from an unexpected third-party package.
+
+**Detection:** `import { … } from 'source'` where `source.startsWith('@')` or `source.includes('/')`, and source is not `'react'` or a `node_modules/` path.
+
+---
+
 ### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+Two detection paths:
 
-**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+1. **Direct API use:** `fetch`, `XMLHttpRequest`, `script.src`, `link.href` used as member expressions.
+2. **Known CDN domains in string literal:** `fetch('https://cdn.jsdelivr.net/...')` or any URL containing `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`, `api.example.com`, or ending with `.js`.
 
 > **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
 
 **Correct**
 ```typescript
-// Always use IO Proxy relative path
 const response = await fetch('/_v/my-loyalty-api/points', {
   credentials: 'include',
 });
@@ -219,6 +232,7 @@ const response = await fetch('/_v/my-loyalty-api/points', {
 **Wrong**
 ```typescript
 const response = await fetch('https://api.example.com/data');
+const response = await fetch('https://cdn.jsdelivr.net/npm/lodash.js'); // CDN — also Violation
 const xhr = new XMLHttpRequest();
 ```
 
@@ -226,14 +240,14 @@ const xhr = new XMLHttpRequest();
 
 ### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
 
-**Severity:** Warning (flag)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. CDN domain fetches are actually reported as `EXTERNAL_RESOURCE_LOADING` (Violation, block) — not as this Warning. Treat any fetch to a CDN domain as a **build-blocking Violation**, not a soft warning.
+
+**Severity:** Warning (flag) — *see note above; actual enforcement is via `EXTERNAL_RESOURCE_LOADING`*  
 **Files:** `.ts`, `.tsx`
 
 Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
 
 **Detection:** `fetch()` first argument literal containing one of these domains.
-
-**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
 
 ---
 
@@ -244,7 +258,7 @@ Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.co
 
 Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
 
-**Detection:** Any call to these methods.
+**Detection:** Any call where the callee matches `document.querySelector`, `document.getElementById`, etc. (the variable must be literally named `document`). Calls via a ref object — e.g. `containerRef.current.querySelector(...)` — are **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
@@ -267,14 +281,14 @@ document.getElementById('cart-container');
 
 Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
 
-**Detection:** Any member expression matching these patterns.
+**Detection:** Matches only when the object is literally named `element` (e.g. `element.style`). Equivalent access through other variable names — e.g. `divRef.current.style`, `el.className` — is **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
-// Use plain CSS with namespaced class names
+// Use plain CSS classes from the component stylesheet
 import './MyExtension.css';
 
-return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
+return <div className={isActive ? 'active' : 'inactive'} />;
 ```
 
 **Wrong**
@@ -291,7 +305,7 @@ element.setAttribute('style', 'display: none');
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+**Detection:** `while(true)` or `do...while(true)` with literal `true` condition.
 
 **Wrong**
 ```typescript
@@ -302,9 +316,22 @@ while (true) {
 
 ---
 
+### `POTENTIAL_INFINITE_LOOP` — Incomplete for-loop
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `for` statement with no `update` expression AND no `test` expression (e.g. `for (let i = 0;;) { … }`).
+
+**Action:** Warn the user and ensure the loop has a proper termination condition.
+
+---
+
 ### `MEMORY_LEAK` — Memory leak patterns
 
-**Severity:** Violation (block)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. The active rule is `POTENTIAL_MEMORY_LEAK` (Warning) below. Event listeners without cleanup **will not block the build**, but remain a Hard Constraint — always add a cleanup return in `useEffect`.
+
+**Severity:** Violation (block) — *see note above; not currently enforced at build time*  
 **Files:** `.ts`, `.tsx`
 
 **Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
@@ -328,23 +355,58 @@ useEffect(() => {
 
 ---
 
+### `POTENTIAL_MEMORY_LEAK` — Likely memory leak patterns
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Three triggers:
+1. Any `addEventListener` call — the analyzer warns regardless of whether a corresponding `removeEventListener` exists in cleanup.
+2. Recursive function call where the callee name matches the parent `FunctionDeclaration` identifier.
+3. `Array.push` inside a `for` or `while` loop.
+
+**Action:** Verify the component has a proper cleanup return in `useEffect` for any event listener, and that recursive functions have a clear base case.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+---
+
 ### `EXCESSIVE_API_CALLS` — Excessive API call patterns
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+**Detection:** `fetch` or `XMLHttpRequest` calls whose parent is a `for` or `while` loop.
 
 **Wrong**
 ```typescript
-// fetch inside render — fires on every re-render
-const data = await fetch('/_v/api/data');
-
 // fetch inside loop — excessive calls
 for (const item of items) {
   await fetch(`/_v/api/item/${item.id}`);
 }
 ```
+
+---
+
+### `FREQUENT_API_CALLS` — API call outside loop / rapid setInterval
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Two triggers:
+1. `fetch` or `XMLHttpRequest` call **outside** a loop (i.e. anywhere else in the component). Fires for every fetch — ensure calls are wrapped in `useEffect` with proper deps and are rate-limited or cached.
+2. `setInterval` with a numeric delay argument below 1000 ms.
+
+> **Note:** Trigger 1 is intentionally broad — it flags every `fetch()` call as a reminder to verify it is not running unintentionally on every render. It does **not** mean every fetch is wrong. Only surface this to the user when the fetch is genuinely outside a `useEffect` or appears to run on each render.
+
+**Action:** Warn the user and suggest wrapping fetches in `useEffect`, using caching, or increasing the polling interval.
 
 ---
 
@@ -376,7 +438,25 @@ import _ from 'lodash';
 
 ## 2. CSS Containment Rules
 
-Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`.
+
+**Sales App analyzer configuration** (from `@vtex/sales-app` build/dev hook):
+
+```typescript
+cssOptions: {
+  allowedNamespaces: ['sales-app-extension-'],
+  defaultNamespace: 'sales-app-extension-',
+  transformNonCompliant: true,
+  overwriteTransformed: true,
+}
+```
+
+Two consequences for the rules below:
+
+1. The configured namespace is **`sales-app-extension-`**, not the analyzer's bare default of `extension-`. Any rule that talks about "the allowed namespace" means `sales-app-extension-` in this project.
+2. `transformNonCompliant: true` softens the namespace rules: when a selector or `@keyframes` name is not prefixed, the analyzer auto-rewrites it into a sibling `*.transformed.css` file and emits a `CSS_TRANSFORMED` **warning** instead of a `CSS_NAMESPACE_REQUIRED` / `CSS_GLOBAL_KEYFRAMES` **violation**. The original `.css` (and the `className` strings in JSX) are left untouched, so the build does not break. This is why the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) ships unprefixed selectors like `.container`, `.title`, `.row` — they are valid in this project.
+
+The other CSS rules (`CSS_GLOBAL_SELECTOR`, `CSS_CONTAINMENT_BREAKOUT`, `CSS_GLOBAL_IMPORT`, `CSS_RESTRICTED_PROPERTY`, `CSS_RESTRICTED_VALUE`, and the inline-style rules) are **not** softened by `transformNonCompliant` — they remain build-blocking violations.
 
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
@@ -389,12 +469,12 @@ Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#_
 
 **Correct**
 ```css
-/* Scope all rules inside the extension container */
-.extension-container {
+/* Scope rules inside the extension container — never target global elements */
+.container {
   font-size: 14px;
 }
 
-.extension-container .title {
+.container .title {
   font-weight: bold;
 }
 ```
@@ -429,7 +509,7 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 **Correct**
 ```css
-.extension-container {
+.container {
   position: relative; /* safe — contained */
 }
 ```
@@ -452,26 +532,27 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
+All CSS selectors should be scoped under an allowed namespace prefix. In the Sales App, that prefix is `sales-app-extension-`. Because the project sets `transformNonCompliant: true`, an unprefixed selector does **not** block the build: the analyzer rewrites it inside a sibling `Component.transformed.css` and emits a `CSS_TRANSFORMED` warning instead of `CSS_NAMESPACE_REQUIRED`. The original `Component.css` (which is what gets bundled) keeps the unprefixed class, so the JSX `className="container"` continues to match.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
+**Detection:** A selector that does not include any value from `allowedNamespaces` (substring check on `.namespace`, `#namespace`, or `[class*="namespace"]`).
 
-**Correct**
+**Correct (and matches the CSS template)**
 ```css
-/* Plain CSS — namespace all classes */
-.extension-container { padding: 8px; }
-.extension-title { font-size: 16px; }
-```
-
-**Wrong**
-```css
-/* Plain CSS — no namespace — pollutes global styles */
+/* Unprefixed top-level classes are accepted because transformNonCompliant=true. */
 .container { padding: 8px; }
-.title { font-size: 16px; }
+.title     { font-size: 16px; }
 ```
+
+**Also correct (explicit prefix, never warns)**
+```css
+.sales-app-extension-container { padding: 8px; }
+.sales-app-extension-title     { font-size: 16px; }
+```
+
+> Prefer the unprefixed form to match the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) and the JSX in the component templates. The `CSS_TRANSFORMED` warning that fires for these is informational only.
 
 ---
 
@@ -499,26 +580,27 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell. As with `CSS_NAMESPACE_REQUIRED`, `transformNonCompliant: true` rewrites the name in `*.transformed.css` and emits `CSS_TRANSFORMED` instead of blocking.
 
-**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix (`sales-app-extension-` in this project).
 
-**Correct**
+The CSS template prefixes keyframes with `${COMPONENT_NAME}-` (e.g. `LoyaltyPoints-spin`). That prefix does **not** start with `sales-app-extension-`, so it triggers a `CSS_TRANSFORMED` warning — the build still succeeds, but the transformed file will rename it to `sales-app-extension-LoyaltyPoints-spin`. Either form is acceptable.
+
+**Correct (no warning)**
 ```css
-@keyframes extension-fade-in {
+@keyframes sales-app-extension-fade-in {
   from { opacity: 0; }
   to   { opacity: 1; }
 }
 ```
 
-**Wrong**
+**Also correct (CSS_TRANSFORMED warning, build passes)**
 ```css
-@keyframes fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+@keyframes LoyaltyPoints-spin {
+  to { transform: rotate(360deg); }
 }
 ```
 
@@ -548,16 +630,59 @@ Certain CSS values (e.g., `!important`) override the cascade and break containme
 
 **Correct**
 ```css
-.extension-button {
-  color: var(--vtex-color-primary);
+.button {
+  color: var(--sa-color-primary);
 }
 ```
 
 **Wrong**
 ```css
-.extension-button {
+.button {
   color: red !important;
 }
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_PROPERTY` — Restricted property in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props in JSX may not use properties that affect layout or containment.
+
+Restricted properties: `position`, `z-index`, `top`, `left`, `right`, `bottom`, `all`, `contain`, `content`, `isolation`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted property names.
+
+**Correct**
+```typescript
+// Use CSS classes for layout properties
+return <div className="overlay" />;
+```
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed', top: 0 }} />;
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_VALUE` — Restricted value in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props may not use values that break containment or cascade.
+
+Restricted values: `fixed`, `absolute`, `!important`, `inherit`, `initial`, `unset`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted values.
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed' }} />;
+return <div style={{ display: 'inherit' }} />;
 ```
 
 ---
@@ -587,33 +712,6 @@ setItems(updatedItems);
 for (const item of items) {
   setCount((c) => c + 1); // re-renders on every iteration
 }
-```
-
----
-
-### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
-
-**Severity:** Violation (block)  
-**Files:** `.tsx`
-
-`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
-
-**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
-
-**Correct**
-```typescript
-const filteredItems = useMemo(() => items.filter(isActive), [items]);
-
-return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
-```
-
-**Wrong**
-```typescript
-return (
-  <ul>
-    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
-  </ul>
-);
 ```
 
 ---

--- a/exports/copilot/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
+++ b/exports/copilot/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
@@ -271,10 +271,10 @@ Restricted expressions: `element.style`, `element.className`, `element.classList
 
 **Correct**
 ```typescript
-// Use CSS modules and conditional class application
-import styles from './MyExtension.module.css';
+// Use plain CSS with namespaced class names
+import './MyExtension.css';
 
-return <div className={isActive ? styles.active : styles.inactive} />;
+return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
 ```
 
 **Wrong**
@@ -381,7 +381,7 @@ Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
 
@@ -419,7 +419,7 @@ body {
 ### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
 
@@ -453,21 +453,15 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
 
 **Correct**
 ```css
-/* CSS Module — all classes are auto-scoped */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-```
-
-```css
-/* Plain CSS — must namespace manually */
+/* Plain CSS — namespace all classes */
 .extension-container { padding: 8px; }
 .extension-title { font-size: 16px; }
 ```
@@ -484,7 +478,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_IMPORT` — CSS @import rules
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@import` pulls external stylesheets that affect global styles and bypass containment.
 
@@ -506,7 +500,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
 
@@ -533,7 +527,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
 
@@ -546,7 +540,7 @@ Certain properties affect layout or rendering globally and are restricted to pre
 ### `CSS_RESTRICTED_VALUE` — Restricted CSS values
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
 

--- a/exports/copilot/sales-app.md
+++ b/exports/copilot/sales-app.md
@@ -49,7 +49,7 @@ Documentation: https://beta.fast.store/sales-app/setting-up
 
 ## Decision rules
 
-Follow the mandatory 6-step workflow in order. Do not skip steps.
+Follow the mandatory 7-step workflow (Steps 0–6) in order. Do not skip steps.
 
 | Step | Purpose | Gate |
 |------|---------|------|
@@ -177,55 +177,6 @@ const { item } = useCartItem();
 return <div>{item.name}</div>;
 ```
 
-### Constraint: Never expose authentication keys in frontend code
-
-API keys in `fetch` headers are visible in the browser network tab.
-
-**Why this matters**
-Leaked keys compromise the external service.
-
-**Detection**
-Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
-
-**Correct**
-
-```typescript
-const response = await fetch('/_v/my-api/data', {
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-**Wrong**
-
-```typescript
-const response = await fetch('https://api.example.com/data', {
-  headers: { 'x-api-key': 'sk-secret-key-12345' },
-});
-```
-
-### Constraint: IO Proxy must use relative paths only
-
-The Sales App internal proxy resolves the domain automatically.
-
-**Why this matters**
-A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
-
-**Detection**
-`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
-
-**Correct**
-
-```typescript
-await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
-```
-
-**Wrong**
-
-```typescript
-await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
-```
-
 ### Constraint: defineExtensions is required in index.tsx
 
 Entry point must use `defineExtensions` from `@vtex/sales-app`.
@@ -297,186 +248,6 @@ defineExtensions({ 'cart.cart-item.after': ItemWarranty });
 defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
 ```
 
-### Constraint: Always present execution plan and wait for approval
-
-Do not generate code until the user confirms the plan.
-
-**Why this matters**
-Generating without agreement wastes effort and may produce the wrong extension.
-
-**Detection**
-Jumping from discovery to code generation without presenting a plan.
-
-**Correct**
-Discovery → Requirements → Present plan → **User approves** → Generate code.
-
-**Wrong**
-Discovery → Generate code immediately.
-
-### Constraint: Never access DOM APIs directly
-
-Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
-
-**Why this matters**
-Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
-
-**Detection**
-Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
-
-**Correct**
-
-```typescript
-// Use React state, props, and Sales App hooks for data
-const { account } = useExtension();
-const cart = useCart();
-```
-
-**Wrong**
-
-```typescript
-const userId = localStorage.getItem('userId');
-const width = window.innerWidth;
-document.title = 'My Extension';
-```
-
-### Constraint: Never import restricted Node.js modules
-
-Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
-
-**Why this matters**
-Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
-
-**Detection**
-`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
-
-**Correct**
-
-```typescript
-import { useCart } from '@vtex/sales-app';
-import React, { useState, useEffect } from 'react';
-```
-
-**Wrong**
-
-```typescript
-import fs from 'fs';
-import crypto from 'crypto';
-```
-
-### Constraint: Never use eval or the Function constructor
-
-Arbitrary code execution is banned in the sandbox.
-
-**Why this matters**
-`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
-
-**Detection**
-Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
-
-**Correct**
-
-```typescript
-const result = computeValue(input); // deterministic logic only
-```
-
-**Wrong**
-
-```typescript
-eval('doSomething()');
-const fn = new Function('return 42');
-setTimeout('doSomething()', 1000);
-```
-
-### Constraint: CSS files must use plain .css extension, never .module.css
-
-The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
-
-**Why this matters**
-A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
-
-**Detection**
-Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
-
-**Correct**
-
-```typescript
-import './CashbackWidget.css';
-// Use className strings directly
-<div className="container">
-```
-
-**Wrong**
-
-```typescript
-import styles from './CashbackWidget.module.css';
-// CSS modules object access
-<div className={styles.container}>
-```
-
-### Constraint: CSS must use namespaced selectors — no global elements
-
-Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
-
-**Why this matters**
-Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
-
-**Detection**
-Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
-
-**Correct**
-
-```css
-/* Plain CSS — use namespace prefix to scope classes */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-
-@keyframes extension-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-```
-
-**Wrong**
-
-```css
-body { font-size: 14px; }
-* { box-sizing: border-box; }
-:root { --my-color: red; }
-@import './reset.css';
-.overlay { position: fixed; z-index: 9999; }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Constraint: CSS must follow Sales App Design Guidelines
-
-Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
-
-**Why this matters**
-Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
-
-**Detection**
-Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
-
-**Correct**
-
-```css
-.container {
-  --sa-color-primary: #157BF4;
-  --sa-color-text-primary: #1F1F1F;
-  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-}
-.title { color: var(--sa-color-text-primary); font-size: 16px; }
-.buttonPrimary { background-color: var(--sa-color-primary); }
-```
-
-**Wrong**
-
-```css
-.container { font-family: Arial; }
-.title { color: #1a1a1a; font-size: 15px; }
-.buttonPrimary { background-color: #0066cc; }
-```
-
 ## Preferred pattern
 
 ### Workflow overview
@@ -487,59 +258,17 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`.
 
-**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
+Required references for this step (load before generating):
+- [code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) — all component templates, the CSS template (with the full Sales App design system inlined: tokens, typography, spacing, responsive), the `index.tsx` template, type generation rules, and the custom fetch hook pattern.
+- [extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) — hook return types and TypeScript definitions.
+- [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`. Run these checks on all generated files.
+- [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) — load when the extension renders any UI text (sentence case rule) or uses icons (Phosphor Icons).
 
-1. **Extension name** — title matching the component name.
-2. **Overview** — one-paragraph summary of what the extension does and why it was built.
-3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
-4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
-5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS file name and summary of key classes.
-7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
-   - **Source documentation:** URL or file path of the original API documentation, if provided.
-   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
-   - Note which fields are optional (`?`) vs required per the documentation.
-8. **How to test** — dev server command and URL to reach the extension.
-9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Validate against the 12-point checklist in code-templates-and-patterns.md. Fix all violations before presenting code; surface warnings to the user.
 
-Template for the documentation file:
-
-````markdown
-# <ExtensionName>
-
-## Overview
-<One-paragraph description of the extension purpose and value.>
-
-## Extension point
-- **Point:** `<extension.point.name>`
-- **Rationale:** <Why this extension point was selected.>
-
-## Hooks used
-| Hook | Purpose |
-|------|---------|
-| `useCart` | <What data it provides here> |
-
-## Component structure
-<Describe the component tree, key props, and internal state.>
-
-## Styling
-- **File:** `<ComponentName>.css`
-- <Summary of key CSS classes and design decisions.>
-
-## API integration
-- **Endpoint:** `/_v/...`
-- **Auth strategy:** IO Proxy / Direct / None
-- **Request/Response:** <Brief shape description.>
-
-## How to test
-Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
-
-## Known constraints
-- <Guard or limitation 1>
-- <Guard or limitation 2>
-````
+**Step 4** — Generate `docs/<ExtensionName>.md` inside the Sales App package (create the `docs/` folder if needed). Load the [documentation template reference](sales-app-sales-app-extensibility-ref-documentation-template.md) for the required 9-section structure and the markdown skeleton to fill in.
 
 **Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md).
 
@@ -552,73 +281,47 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; **CSS template with the full Sales App design system inlined (tokens, typography, spacing, responsive)**; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
-| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Writing UI text (sentence case rule) or using icons (Phosphor Icons). **CSS-related design rules — tokens, typography, spacing, responsive — are inlined directly in the CSS template inside code-templates-and-patterns.md, so this file is not needed for CSS generation.** |
+| [references/documentation-template.md](sales-app-sales-app-extensibility-ref-documentation-template.md) | Writing the `docs/<ExtensionName>.md` file in Step 4 — the 9-section structure and markdown skeleton |
 
 ## Common failure modes
 
-- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
-- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
-- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
-- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
-- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
-- **Placing code outside packages/sales-app/src/** — Not included in build.
-- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
-- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
-- **Not presenting plan** — User may want a different approach. Always confirm.
-- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
-- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed. Always confirm both before Step 1.
+- **Not presenting plan** — User may want a different approach. Always confirm at Step 2 before generating code.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Load documentation-template.md for the required structure.
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
-- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
-- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
-- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
-- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
-- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
-- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
-- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
-- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
+- **Placing code outside packages/sales-app/src/** — Files outside this path are not included in the build.
+
+> Code-level violations (DOM APIs, Node imports, eval, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and caught during Step 3 validation. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Review checklist
 
+**Workflow gates**
 - [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
 - [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
 - [ ] Discovery completed and use case identified?
 - [ ] Execution plan approved by user?
 - [ ] Extension point is valid (from the 8-point reference)?
 - [ ] Hooks compatible with chosen extension point?
+- [ ] Documentation generated at `docs/<ExtensionName>.md` (9 sections, using documentation-template.md)?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+**TypeScript / runtime guards** (not caught by fsp-analyzer)
 - [ ] Component returns JSX.Element, never null?
 - [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
 - [ ] useCartItem().item checked for undefined?
-- [ ] No auth credentials exposed in frontend code?
-- [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
-- [ ] CSS file path matches component name?
-- [ ] Documentation generated at `docs/<ExtensionName>.md`?
-- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
-- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
-- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
-- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
-- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
-- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
-- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
-- [ ] No @import rules in CSS?
-- [ ] No position: fixed or z-index: 9999 in CSS?
-- [ ] @keyframes names prefixed with extension namespace?
-- [ ] No useLayoutEffect (use useEffect instead)?
-- [ ] No heavyweight library imports (lodash, moment)?
-- [ ] Components under 200 lines?
-- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
-- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
-- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
-- [ ] Build passes: `yarn fsp build {account} sales-app`?
-- [ ] Tested locally: `yarn fsp dev {account}`?
+
+> All other code-level rules (sandbox APIs, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and checked during Step 3. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Related skills
 

--- a/exports/copilot/sales-app.md
+++ b/exports/copilot/sales-app.md
@@ -421,6 +421,36 @@ body { font-size: 14px; }
 @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
 ```
 
+### Constraint: CSS must follow Sales App Design Guidelines
+
+Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
+
+**Why this matters**
+Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
+
+**Detection**
+Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
+
+**Correct**
+
+```css
+.container {
+  --sa-color-primary: #157BF4;
+  --sa-color-text-primary: #1F1F1F;
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.title { color: var(--sa-color-text-primary); font-size: 16px; }
+.buttonPrimary { background-color: var(--sa-color-primary); }
+```
+
+**Wrong**
+
+```css
+.container { font-family: Arial; }
+.title { color: #1a1a1a; font-size: 15px; }
+.buttonPrimary { background-color: #0066cc; }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -431,7 +461,7 @@ body { font-size: 14px; }
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -500,6 +530,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
 
 ## Common failure modes
 
@@ -521,6 +552,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
 - **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
 - **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
+- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
+- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
+- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
+- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
 
 ## Review checklist
 
@@ -551,6 +586,11 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] No useLayoutEffect (use useEffect instead)?
 - [ ] No heavyweight library imports (lodash, moment)?
 - [ ] Components under 200 lines?
+- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
+- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/copilot/sales-app.md
+++ b/exports/copilot/sales-app.md
@@ -56,7 +56,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
-| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 3 | Code Generation & Validation | Generate `Component.tsx` + `Component.css` (plain CSS, never `.module.css`) + `index.tsx` → validate |
 | 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
 | 5 | Local Testing | Provide dev commands and URLs |
 | 6 | Build & Deploy | Build command → deployment guide |
@@ -387,6 +387,32 @@ const fn = new Function('return 42');
 setTimeout('doSomething()', 1000);
 ```
 
+### Constraint: CSS files must use plain .css extension, never .module.css
+
+The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
+
+**Why this matters**
+A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
+
+**Detection**
+Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
+
+**Correct**
+
+```typescript
+import './CashbackWidget.css';
+// Use className strings directly
+<div className="container">
+```
+
+**Wrong**
+
+```typescript
+import styles from './CashbackWidget.module.css';
+// CSS modules object access
+<div className={styles.container}>
+```
+
 ### Constraint: CSS must use namespaced selectors — no global elements
 
 Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
@@ -400,7 +426,7 @@ Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@
 **Correct**
 
 ```css
-/* CSS Module — classes are auto-scoped by the bundler */
+/* Plain CSS — use namespace prefix to scope classes */
 .container { padding: 8px; }
 .title { font-size: 16px; }
 
@@ -459,9 +485,9 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
-**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+**Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -470,7 +496,7 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
 4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
 5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS module file name and summary of key classes.
+6. **Styling** — CSS file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
    - **Source documentation:** URL or file path of the original API documentation, if provided.
    - **Generated types:** list of TypeScript interfaces generated from the API documentation.
@@ -499,7 +525,7 @@ Template for the documentation file:
 <Describe the component tree, key props, and internal state.>
 
 ## Styling
-- **File:** `<ComponentName>.module.css`
+- **File:** `<ComponentName>.css`
 - <Summary of key CSS classes and design decisions.>
 
 ## API integration
@@ -526,7 +552,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |

--- a/exports/copilot/sales-app.md
+++ b/exports/copilot/sales-app.md
@@ -313,6 +313,114 @@ Discovery → Requirements → Present plan → **User approves** → Generate c
 **Wrong**
 Discovery → Generate code immediately.
 
+### Constraint: Never access DOM APIs directly
+
+Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
+
+**Why this matters**
+Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
+
+**Detection**
+Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
+
+**Correct**
+
+```typescript
+// Use React state, props, and Sales App hooks for data
+const { account } = useExtension();
+const cart = useCart();
+```
+
+**Wrong**
+
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+### Constraint: Never import restricted Node.js modules
+
+Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
+
+**Why this matters**
+Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
+
+**Detection**
+`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
+
+**Correct**
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+import React, { useState, useEffect } from 'react';
+```
+
+**Wrong**
+
+```typescript
+import fs from 'fs';
+import crypto from 'crypto';
+```
+
+### Constraint: Never use eval or the Function constructor
+
+Arbitrary code execution is banned in the sandbox.
+
+**Why this matters**
+`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
+
+**Detection**
+Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
+
+**Correct**
+
+```typescript
+const result = computeValue(input); // deterministic logic only
+```
+
+**Wrong**
+
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+### Constraint: CSS must use namespaced selectors — no global elements
+
+Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
+
+**Why this matters**
+Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
+
+**Detection**
+Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
+
+**Correct**
+
+```css
+/* CSS Module — classes are auto-scoped by the bundler */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+
+```css
+body { font-size: 14px; }
+* { box-sizing: border-box; }
+:root { --my-color: red; }
+@import './reset.css';
+.overlay { position: fixed; z-index: 9999; }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -323,7 +431,7 @@ Discovery → Generate code immediately.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -391,6 +499,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
 
 ## Common failure modes
 
@@ -408,6 +517,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
+- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
+- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
+- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
+- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
 
 ## Review checklist
 
@@ -428,6 +541,16 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
 - [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
+- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
+- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
+- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
+- [ ] No @import rules in CSS?
+- [ ] No position: fixed or z-index: 9999 in CSS?
+- [ ] @keyframes names prefixed with extension namespace?
+- [ ] No useLayoutEffect (use useEffect instead)?
+- [ ] No heavyweight library imports (lodash, moment)?
+- [ ] Components under 200 lines?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/cursor/sales-app-all.mdc
+++ b/exports/cursor/sales-app-all.mdc
@@ -317,6 +317,114 @@ Discovery → Requirements → Present plan → **User approves** → Generate c
 **Wrong**
 Discovery → Generate code immediately.
 
+### Constraint: Never access DOM APIs directly
+
+Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
+
+**Why this matters**
+Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
+
+**Detection**
+Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
+
+**Correct**
+
+```typescript
+// Use React state, props, and Sales App hooks for data
+const { account } = useExtension();
+const cart = useCart();
+```
+
+**Wrong**
+
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+### Constraint: Never import restricted Node.js modules
+
+Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
+
+**Why this matters**
+Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
+
+**Detection**
+`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
+
+**Correct**
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+import React, { useState, useEffect } from 'react';
+```
+
+**Wrong**
+
+```typescript
+import fs from 'fs';
+import crypto from 'crypto';
+```
+
+### Constraint: Never use eval or the Function constructor
+
+Arbitrary code execution is banned in the sandbox.
+
+**Why this matters**
+`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
+
+**Detection**
+Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
+
+**Correct**
+
+```typescript
+const result = computeValue(input); // deterministic logic only
+```
+
+**Wrong**
+
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+### Constraint: CSS must use namespaced selectors — no global elements
+
+Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
+
+**Why this matters**
+Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
+
+**Detection**
+Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
+
+**Correct**
+
+```css
+/* CSS Module — classes are auto-scoped by the bundler */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+
+```css
+body { font-size: 14px; }
+* { box-sizing: border-box; }
+:root { --my-color: red; }
+@import './reset.css';
+.overlay { position: fixed; z-index: 9999; }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -327,7 +435,7 @@ Discovery → Generate code immediately.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, and the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -395,6 +503,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](@sales-app-sales-app-extensibility-ref-discovery-and-use-cases.mdc) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](@sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.mdc) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
 
 ## Common failure modes
 
@@ -412,6 +521,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
+- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
+- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
+- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
+- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
 
 ## Review checklist
 
@@ -432,6 +545,16 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
 - [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
+- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
+- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
+- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
+- [ ] No @import rules in CSS?
+- [ ] No position: fixed or z-index: 9999 in CSS?
+- [ ] @keyframes names prefixed with extension namespace?
+- [ ] No useLayoutEffect (use useEffect instead)?
+- [ ] No heavyweight library imports (lodash, moment)?
+- [ ] Components under 200 lines?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/cursor/sales-app-all.mdc
+++ b/exports/cursor/sales-app-all.mdc
@@ -53,7 +53,7 @@ Documentation: https://beta.fast.store/sales-app/setting-up
 
 ## Decision rules
 
-Follow the mandatory 6-step workflow in order. Do not skip steps.
+Follow the mandatory 7-step workflow (Steps 0–6) in order. Do not skip steps.
 
 | Step | Purpose | Gate |
 |------|---------|------|
@@ -181,55 +181,6 @@ const { item } = useCartItem();
 return <div>{item.name}</div>;
 ```
 
-### Constraint: Never expose authentication keys in frontend code
-
-API keys in `fetch` headers are visible in the browser network tab.
-
-**Why this matters**
-Leaked keys compromise the external service.
-
-**Detection**
-Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
-
-**Correct**
-
-```typescript
-const response = await fetch('/_v/my-api/data', {
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-**Wrong**
-
-```typescript
-const response = await fetch('https://api.example.com/data', {
-  headers: { 'x-api-key': 'sk-secret-key-12345' },
-});
-```
-
-### Constraint: IO Proxy must use relative paths only
-
-The Sales App internal proxy resolves the domain automatically.
-
-**Why this matters**
-A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
-
-**Detection**
-`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
-
-**Correct**
-
-```typescript
-await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
-```
-
-**Wrong**
-
-```typescript
-await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
-```
-
 ### Constraint: defineExtensions is required in index.tsx
 
 Entry point must use `defineExtensions` from `@vtex/sales-app`.
@@ -301,186 +252,6 @@ defineExtensions({ 'cart.cart-item.after': ItemWarranty });
 defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
 ```
 
-### Constraint: Always present execution plan and wait for approval
-
-Do not generate code until the user confirms the plan.
-
-**Why this matters**
-Generating without agreement wastes effort and may produce the wrong extension.
-
-**Detection**
-Jumping from discovery to code generation without presenting a plan.
-
-**Correct**
-Discovery → Requirements → Present plan → **User approves** → Generate code.
-
-**Wrong**
-Discovery → Generate code immediately.
-
-### Constraint: Never access DOM APIs directly
-
-Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
-
-**Why this matters**
-Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
-
-**Detection**
-Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
-
-**Correct**
-
-```typescript
-// Use React state, props, and Sales App hooks for data
-const { account } = useExtension();
-const cart = useCart();
-```
-
-**Wrong**
-
-```typescript
-const userId = localStorage.getItem('userId');
-const width = window.innerWidth;
-document.title = 'My Extension';
-```
-
-### Constraint: Never import restricted Node.js modules
-
-Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
-
-**Why this matters**
-Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
-
-**Detection**
-`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
-
-**Correct**
-
-```typescript
-import { useCart } from '@vtex/sales-app';
-import React, { useState, useEffect } from 'react';
-```
-
-**Wrong**
-
-```typescript
-import fs from 'fs';
-import crypto from 'crypto';
-```
-
-### Constraint: Never use eval or the Function constructor
-
-Arbitrary code execution is banned in the sandbox.
-
-**Why this matters**
-`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
-
-**Detection**
-Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
-
-**Correct**
-
-```typescript
-const result = computeValue(input); // deterministic logic only
-```
-
-**Wrong**
-
-```typescript
-eval('doSomething()');
-const fn = new Function('return 42');
-setTimeout('doSomething()', 1000);
-```
-
-### Constraint: CSS files must use plain .css extension, never .module.css
-
-The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
-
-**Why this matters**
-A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
-
-**Detection**
-Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
-
-**Correct**
-
-```typescript
-import './CashbackWidget.css';
-// Use className strings directly
-<div className="container">
-```
-
-**Wrong**
-
-```typescript
-import styles from './CashbackWidget.module.css';
-// CSS modules object access
-<div className={styles.container}>
-```
-
-### Constraint: CSS must use namespaced selectors — no global elements
-
-Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
-
-**Why this matters**
-Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
-
-**Detection**
-Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
-
-**Correct**
-
-```css
-/* Plain CSS — use namespace prefix to scope classes */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-
-@keyframes extension-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-```
-
-**Wrong**
-
-```css
-body { font-size: 14px; }
-* { box-sizing: border-box; }
-:root { --my-color: red; }
-@import './reset.css';
-.overlay { position: fixed; z-index: 9999; }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Constraint: CSS must follow Sales App Design Guidelines
-
-Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
-
-**Why this matters**
-Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
-
-**Detection**
-Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
-
-**Correct**
-
-```css
-.container {
-  --sa-color-primary: #157BF4;
-  --sa-color-text-primary: #1F1F1F;
-  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-}
-.title { color: var(--sa-color-text-primary); font-size: 16px; }
-.buttonPrimary { background-color: var(--sa-color-primary); }
-```
-
-**Wrong**
-
-```css
-.container { font-family: Arial; }
-.title { color: #1a1a1a; font-size: 15px; }
-.buttonPrimary { background-color: #0066cc; }
-```
-
 ## Preferred pattern
 
 ### Workflow overview
@@ -491,59 +262,17 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`.
 
-**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
+Required references for this step (load before generating):
+- [code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) — all component templates, the CSS template (with the full Sales App design system inlined: tokens, typography, spacing, responsive), the `index.tsx` template, type generation rules, and the custom fetch hook pattern.
+- [extension-points-hooks-and-types.md](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) — hook return types and TypeScript definitions.
+- [static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`. Run these checks on all generated files.
+- [design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) — load when the extension renders any UI text (sentence case rule) or uses icons (Phosphor Icons).
 
-1. **Extension name** — title matching the component name.
-2. **Overview** — one-paragraph summary of what the extension does and why it was built.
-3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
-4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
-5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS file name and summary of key classes.
-7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
-   - **Source documentation:** URL or file path of the original API documentation, if provided.
-   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
-   - Note which fields are optional (`?`) vs required per the documentation.
-8. **How to test** — dev server command and URL to reach the extension.
-9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Validate against the 12-point checklist in code-templates-and-patterns.md. Fix all violations before presenting code; surface warnings to the user.
 
-Template for the documentation file:
-
-````markdown
-# <ExtensionName>
-
-## Overview
-<One-paragraph description of the extension purpose and value.>
-
-## Extension point
-- **Point:** `<extension.point.name>`
-- **Rationale:** <Why this extension point was selected.>
-
-## Hooks used
-| Hook | Purpose |
-|------|---------|
-| `useCart` | <What data it provides here> |
-
-## Component structure
-<Describe the component tree, key props, and internal state.>
-
-## Styling
-- **File:** `<ComponentName>.css`
-- <Summary of key CSS classes and design decisions.>
-
-## API integration
-- **Endpoint:** `/_v/...`
-- **Auth strategy:** IO Proxy / Direct / None
-- **Request/Response:** <Brief shape description.>
-
-## How to test
-Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
-
-## Known constraints
-- <Guard or limitation 1>
-- <Guard or limitation 2>
-````
+**Step 4** — Generate `docs/<ExtensionName>.md` inside the Sales App package (create the `docs/` folder if needed). Load the [documentation template reference](@sales-app-sales-app-extensibility-ref-documentation-template.mdc) for the required 9-section structure and the markdown skeleton to fill in.
 
 **Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](@sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.mdc).
 
@@ -556,73 +285,47 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; **CSS template with the full Sales App design system inlined (tokens, typography, spacing, responsive)**; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](@sales-app-sales-app-extensibility-ref-discovery-and-use-cases.mdc) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](@sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.mdc) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
-| [references/design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
+| [references/design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) | Writing UI text (sentence case rule) or using icons (Phosphor Icons). **CSS-related design rules — tokens, typography, spacing, responsive — are inlined directly in the CSS template inside code-templates-and-patterns.md, so this file is not needed for CSS generation.** |
+| [references/documentation-template.md](@sales-app-sales-app-extensibility-ref-documentation-template.mdc) | Writing the `docs/<ExtensionName>.md` file in Step 4 — the 9-section structure and markdown skeleton |
 
 ## Common failure modes
 
-- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
-- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
-- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
-- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
-- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
-- **Placing code outside packages/sales-app/src/** — Not included in build.
-- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
-- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
-- **Not presenting plan** — User may want a different approach. Always confirm.
-- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
-- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed. Always confirm both before Step 1.
+- **Not presenting plan** — User may want a different approach. Always confirm at Step 2 before generating code.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Load documentation-template.md for the required structure.
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
-- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
-- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
-- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
-- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
-- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
-- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
-- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
-- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
+- **Placing code outside packages/sales-app/src/** — Files outside this path are not included in the build.
+
+> Code-level violations (DOM APIs, Node imports, eval, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and caught during Step 3 validation. See [static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) and [design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc).
 
 ## Review checklist
 
+**Workflow gates**
 - [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
 - [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
 - [ ] Discovery completed and use case identified?
 - [ ] Execution plan approved by user?
 - [ ] Extension point is valid (from the 8-point reference)?
 - [ ] Hooks compatible with chosen extension point?
+- [ ] Documentation generated at `docs/<ExtensionName>.md` (9 sections, using documentation-template.md)?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+**TypeScript / runtime guards** (not caught by fsp-analyzer)
 - [ ] Component returns JSX.Element, never null?
 - [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
 - [ ] useCartItem().item checked for undefined?
-- [ ] No auth credentials exposed in frontend code?
-- [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
-- [ ] CSS file path matches component name?
-- [ ] Documentation generated at `docs/<ExtensionName>.md`?
-- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
-- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
-- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
-- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
-- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
-- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
-- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
-- [ ] No @import rules in CSS?
-- [ ] No position: fixed or z-index: 9999 in CSS?
-- [ ] @keyframes names prefixed with extension namespace?
-- [ ] No useLayoutEffect (use useEffect instead)?
-- [ ] No heavyweight library imports (lodash, moment)?
-- [ ] Components under 200 lines?
-- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
-- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
-- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
-- [ ] Build passes: `yarn fsp build {account} sales-app`?
-- [ ] Tested locally: `yarn fsp dev {account}`?
+
+> All other code-level rules (sandbox APIs, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and checked during Step 3. See [static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) and [design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc).
 
 ## Related skills
 

--- a/exports/cursor/sales-app-all.mdc
+++ b/exports/cursor/sales-app-all.mdc
@@ -60,7 +60,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
-| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 3 | Code Generation & Validation | Generate `Component.tsx` + `Component.css` (plain CSS, never `.module.css`) + `index.tsx` → validate |
 | 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
 | 5 | Local Testing | Provide dev commands and URLs |
 | 6 | Build & Deploy | Build command → deployment guide |
@@ -391,6 +391,32 @@ const fn = new Function('return 42');
 setTimeout('doSomething()', 1000);
 ```
 
+### Constraint: CSS files must use plain .css extension, never .module.css
+
+The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
+
+**Why this matters**
+A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
+
+**Detection**
+Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
+
+**Correct**
+
+```typescript
+import './CashbackWidget.css';
+// Use className strings directly
+<div className="container">
+```
+
+**Wrong**
+
+```typescript
+import styles from './CashbackWidget.module.css';
+// CSS modules object access
+<div className={styles.container}>
+```
+
 ### Constraint: CSS must use namespaced selectors — no global elements
 
 Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
@@ -404,7 +430,7 @@ Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@
 **Correct**
 
 ```css
-/* CSS Module — classes are auto-scoped by the bundler */
+/* Plain CSS — use namespace prefix to scope classes */
 .container { padding: 8px; }
 .title { font-size: 16px; }
 
@@ -463,9 +489,9 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](@sales-app-sales-app-extensibility-ref-discovery-and-use-cases.mdc) for detailed question flows and the API Documentation Ingestion section.
 
-**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+**Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -474,7 +500,7 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
 4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
 5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS module file name and summary of key classes.
+6. **Styling** — CSS file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
    - **Source documentation:** URL or file path of the original API documentation, if provided.
    - **Generated types:** list of TypeScript interfaces generated from the API documentation.
@@ -503,7 +529,7 @@ Template for the documentation file:
 <Describe the component tree, key props, and internal state.>
 
 ## Styling
-- **File:** `<ComponentName>.module.css`
+- **File:** `<ComponentName>.css`
 - <Summary of key CSS classes and design decisions.>
 
 ## API integration
@@ -530,7 +556,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](@sales-app-sales-app-extensibility-ref-discovery-and-use-cases.mdc) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](@sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.mdc) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |

--- a/exports/cursor/sales-app-all.mdc
+++ b/exports/cursor/sales-app-all.mdc
@@ -425,6 +425,36 @@ body { font-size: 14px; }
 @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
 ```
 
+### Constraint: CSS must follow Sales App Design Guidelines
+
+Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
+
+**Why this matters**
+Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
+
+**Detection**
+Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
+
+**Correct**
+
+```css
+.container {
+  --sa-color-primary: #157BF4;
+  --sa-color-text-primary: #1F1F1F;
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.title { color: var(--sa-color-text-primary); font-size: 16px; }
+.buttonPrimary { background-color: var(--sa-color-primary); }
+```
+
+**Wrong**
+
+```css
+.container { font-family: Arial; }
+.title { color: #1a1a1a; font-size: 15px; }
+.buttonPrimary { background-color: #0066cc; }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -435,7 +465,7 @@ body { font-size: 14px; }
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, and the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -504,6 +534,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/discovery-and-use-cases.md](@sales-app-sales-app-extensibility-ref-discovery-and-use-cases.mdc) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](@sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.mdc) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
+| [references/design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
 
 ## Common failure modes
 
@@ -525,6 +556,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
 - **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
 - **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
+- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
+- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
+- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
+- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
 
 ## Review checklist
 
@@ -555,6 +590,11 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] No useLayoutEffect (use useEffect instead)?
 - [ ] No heavyweight library imports (lodash, moment)?
 - [ ] Components under 200 lines?
+- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
+- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/cursor/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc
@@ -332,38 +332,73 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Stylesheet
 
-All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules). The full Sales App design system for CSS — tokens, typography, spacing grid, responsive breakpoints, and structure — is inlined below. **Use this template as the single source of truth for any CSS generation.**
 
 **CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
+
+### Design system rules baked into this template
+
+These rules apply to **every** generated extension CSS. The template below already complies — keep it that way.
+
+| Topic | Rule |
+|-------|------|
+| Tokens | All colors must reference `--sa-color-*` tokens declared on `.container`. **Never** use hardcoded hex values anywhere else. |
+| Font family | `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif` on `.container`, inherited by descendants. |
+| Font weights | Only Regular (400), Medium (500), Semibold (600), Bold (700). |
+| Font sizes (px) | Allowed scale only: **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**. Never `13`, `15`, `17`, etc. |
+| Typography roles | Section title = 16px/600 · Subtitle/label = 14px/500 · Body = 14px/400 · Caption = 12px/400 · Price = 18px/600. |
+| Spacing | Multiples of **4px** only (4, 8, 12, 16, 20, 24, 32, 40…). Never `10`, `14`, `18`, `22`. Applies to `padding`, `margin`, `gap`, `height`. |
+| Containment | No `position: fixed`, no `z-index: 9999`, no `:host`, no `:global`, no `@import`. `position: relative` and `sticky` are safe. |
+| Selectors | Use the unprefixed utility class names from this template (`.container`, `.content`, `.row`, `.title`, `.button`, etc.). The Sales App `fsp-analyzer` runs with `transformNonCompliant: true`, so unprefixed selectors emit a `CSS_TRANSFORMED` warning rather than a `CSS_NAMESPACE_REQUIRED` violation. Never use `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` — those are caught by `CSS_GLOBAL_SELECTOR` and remain blocking. |
+| Keyframes | Prefix with `${COMPONENT_NAME}-` (e.g., `${COMPONENT_NAME}-spin`). This raises a `CSS_TRANSFORMED` warning (build still passes) — use `sales-app-extension-${COMPONENT_NAME}-spin` if you want a clean run. |
+| `!important` | Never. |
+| Responsive | Use the breakpoint at `(max-width: 743px)` for mobile overrides. Sales App shell handles the rest. |
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Sales App Design Guidelines.
- * Reference: references/design-guidelines.md
+ * Sales App design system (tokens + typography + spacing + responsive) is fully inlined.
  * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
 .container {
-  /* Sales App design tokens — do not replace with hardcoded hex values */
+  /* === Sales App design tokens — single source of truth ===
+     Always declare these on .container. Reference via var(--sa-color-*) in all other rules.
+     Never use hardcoded hex values in CSS rules. */
+
+  /* Primary action */
   --sa-color-primary:       #157BF4;   /* Light Blue 800 */
   --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-  --sa-color-bg:        #FFFFFF;
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 — high emphasis */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600  — medium emphasis */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500  — low emphasis */
+  --sa-color-text-muted:     #999999;  /* Neutral 700  — disabled / hint */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
   --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
   --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
   --sa-color-border:       #E0E0E0;    /* Neutral 300 */
   --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
   --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
   --sa-color-error-border: #FFDFD9;    /* Red 200 */
   --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
   --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
   --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow / Orange scale) */
   --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
   --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
   --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
   --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
@@ -371,10 +406,16 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
   background-color: var(--sa-color-bg);
   font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
 }
+
+/* Layout */
 .content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
-.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
-.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+.row { display: flex; align-items: center; gap: 12px; }
+.spaceBetween { justify-content: space-between; }
+
+/* Typography — uses approved size scale (10, 12, 14, 16, 18, 20, 22, 24...) */
+.title    { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary);   margin: 0; }
+.subtitle { font-size: 14px; font-weight: 500; color: var(--sa-color-text-secondary); margin: 0; }
+.text     { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
 
 /* Loading state */
 .loading {
@@ -420,7 +461,7 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
 .badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
-.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
+.badgeInfo    { background-color: var(--sa-color-info-bg);    color: var(--sa-color-info-text); }
 
 /* Input */
 .input {
@@ -430,20 +471,33 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/flex helpers */
-.row { display: flex; align-items: center; gap: 12px; }
-.spaceBetween { justify-content: space-between; }
-
 /* Price display */
-.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
-.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+.price          { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld       { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount  { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
 
-/* Responsive — Sales App breakpoints */
+/* Responsive — Sales App breakpoints
+   Small (mobile)  320–743px  → margin: 24px, no column grid
+   Medium (tablet) 744–1279px → host gutters: 16px (no override needed)
+   Large (desktop) 1280–1919px → host gutters: 20px (no override needed)
+   Extra large     1920px+    → host gutters: 20px (no override needed) */
 @media (max-width: 743px) {
   .container { padding: 12px; margin: 0 24px; }
 }
 ```
+
+### CSS file structure
+
+Every extension CSS must follow this order:
+
+1. **Token declarations** — `--sa-color-*` on `.container`
+2. **Layout helpers** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography** — `.title`, `.subtitle`, `.text`
+4. **State** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive** — `@media` queries at the bottom
+
+For UX writing rules (sentence case) and iconography (Phosphor Icons) used in `.tsx`, see [design-guidelines.md](design-guidelines.md).
 
 ## index.tsx with defineExtensions
 
@@ -487,7 +541,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design system compliance** — the CSS file must follow the rules table at the top of the "CSS Stylesheet" section above: `--sa-color-*` custom properties declared on `.container` and used in all rules, `'VTEX Trust'` font family, allowed font sizes (10, 12, 14, 16, 18, 20, 22, 24, 28, 32…), 4px-multiple spacing, scoped selectors, and the responsive override at `(max-width: 743px)`. For UI text (sentence case) and icons (Phosphor), see [design-guidelines.md](design-guidelines.md).
 
 ## API Type Generation from Documentation
 

--- a/exports/cursor/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc
@@ -1,5 +1,5 @@
 ---
-description: "Code generation templates for Sales App extensions — simple, hook-based, API (no auth), IO Proxy (secure), Direct Auth (insecure), CSS module, and index.tsx with defineExtensions. Use when generating or scaffolding extension code."
+description: "Code generation templates for Sales App extensions — simple, hook-based, API (no auth), IO Proxy (secure), Direct Auth (insecure), CSS stylesheet, and index.tsx with defineExtensions. Use when generating or scaffolding extension code."
 globs: 
 alwaysApply: false
 ---
@@ -330,9 +330,11 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 }
 ```
 
-## CSS Module
+## CSS Stylesheet
 
-All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+
+**CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
 
 ```css
 /**
@@ -485,7 +487,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/cursor/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc
@@ -451,6 +451,7 @@ After generating code, validate for these issues:
 8. **API call handling** — loading state and error handling must be present for any `fetch()` call
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
+11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
 
 ## API Type Generation from Documentation
 

--- a/exports/cursor/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc
@@ -332,82 +332,115 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Module
 
-All extensions use CSS modules with Admin UI design tokens.
+All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Admin UI patterns.
+ * Design tokens follow Sales App Design Guidelines.
+ * Reference: references/design-guidelines.md
+ * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
-.container { padding: 16px; background-color: #ffffff; }
-.content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: #1a1a1a; margin: 0; }
-.subtitle { font-size: 14px; color: #666666; margin: 0; }
-.text { font-size: 14px; color: #333333; line-height: 1.5; }
+.container {
+  /* Sales App design tokens — do not replace with hardcoded hex values */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+  --sa-color-bg:        #FFFFFF;
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
-/* Loading State */
+  padding: 16px;
+  background-color: var(--sa-color-bg);
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.content { display: flex; flex-direction: column; gap: 12px; }
+.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
+.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
+.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+
+/* Loading state */
 .loading {
   display: flex; align-items: center; justify-content: center;
-  gap: 8px; padding: 24px; color: #666666;
+  gap: 8px; padding: 24px; color: var(--sa-color-text-secondary);
 }
 .spinner {
   width: 20px; height: 20px;
-  border: 2px solid #e0e0e0; border-top-color: #0066cc;
-  border-radius: 50%; animation: spin 1s linear infinite;
+  border: 2px solid var(--sa-color-border); border-top-color: var(--sa-color-primary);
+  border-radius: 50%; animation: ${COMPONENT_NAME}-spin 1s linear infinite;
 }
-@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes ${COMPONENT_NAME}-spin { to { transform: rotate(360deg); } }
 
-/* Error State */
+/* Error state */
 .error {
-  padding: 16px; background-color: #fff5f5;
-  border: 1px solid #ffcccc; border-radius: 8px;
-  color: #cc0000; font-size: 14px;
+  padding: 16px; background-color: var(--sa-color-error-bg);
+  border: 1px solid var(--sa-color-error-border); border-radius: 8px;
+  color: var(--sa-color-error-text); font-size: 14px;
 }
 
-/* Button Styles */
+/* Button styles */
 .button {
   display: inline-flex; align-items: center; justify-content: center;
-  padding: 10px 16px; font-size: 14px; font-weight: 500;
+  padding: 12px 16px; font-size: 14px; font-weight: 500;
   border: none; border-radius: 6px; cursor: pointer;
   transition: background-color 0.2s ease;
 }
-.buttonPrimary { background-color: #0066cc; color: #ffffff; }
-.buttonPrimary:hover { background-color: #0052a3; }
-.buttonSecondary { background-color: #f0f0f0; color: #333333; }
-.buttonSecondary:hover { background-color: #e0e0e0; }
+.buttonPrimary { background-color: var(--sa-color-primary); color: #FFFFFF; }
+.buttonPrimary:hover { background-color: var(--sa-color-primary-hover); }
+.buttonSecondary { background-color: var(--sa-color-bg-muted); color: var(--sa-color-text-tertiary); }
+.buttonSecondary:hover { background-color: var(--sa-color-border); }
 
-/* Card Styles */
+/* Card */
 .card {
-  padding: 16px; background-color: #f9f9f9;
-  border-radius: 8px; border: 1px solid #e0e0e0;
+  padding: 16px; background-color: var(--sa-color-bg-subtle);
+  border-radius: 8px; border: 1px solid var(--sa-color-border);
 }
 
-/* Badge Styles */
+/* Badges */
 .badge {
   display: inline-block; padding: 4px 8px;
   font-size: 12px; font-weight: 500; border-radius: 4px;
 }
-.badgeSuccess { background-color: #e6f4ea; color: #137333; }
-.badgeWarning { background-color: #fef7e0; color: #b06000; }
-.badgeInfo { background-color: #e8f0fe; color: #1a73e8; }
+.badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
+.badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
+.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
 
-/* Input Styles */
+/* Input */
 .input {
-  width: 100%; padding: 10px 12px; font-size: 14px;
-  border: 1px solid #d0d0d0; border-radius: 6px;
+  width: 100%; padding: 12px; font-size: 14px;
+  border: 1px solid var(--sa-color-border-input); border-radius: 6px;
   outline: none; transition: border-color 0.2s ease;
 }
-.input:focus { border-color: #0066cc; }
+.input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/Flex Helpers */
+/* Row/flex helpers */
 .row { display: flex; align-items: center; gap: 12px; }
 .spaceBetween { justify-content: space-between; }
 
-/* Price Display */
-.price { font-size: 18px; font-weight: 600; color: #1a1a1a; }
-.priceOld { font-size: 14px; color: #999999; text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: #137333; font-weight: 500; }
+/* Price display */
+.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+
+/* Responsive — Sales App breakpoints */
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
 ```
 
 ## index.tsx with defineExtensions
@@ -452,6 +485,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
+12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/cursor/sales-app-sales-app-extensibility-ref-design-guidelines.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility-ref-design-guidelines.mdc
@@ -200,7 +200,7 @@ Sales App extensions render within a host container that handles most layout res
 | Large (desktop) | 1280–1919px | Gutters: 20px |
 | Extra large (monitor) | 1920px+ | Gutters: 20px |
 
-Recommended mobile override (applied to the responsive section of the CSS module):
+Recommended mobile override (applied to the responsive section of the CSS file):
 
 ```css
 @media (max-width: 743px) {
@@ -210,9 +210,9 @@ Recommended mobile override (applied to the responsive section of the CSS module
 
 ---
 
-## 7. CSS Module Structure
+## 7. CSS File Structure
 
-Every extension CSS module must follow this structure:
+Every extension CSS file must follow this structure:
 
 1. **Token declarations** — CSS custom properties on `.container`
 2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`

--- a/exports/cursor/sales-app-sales-app-extensibility-ref-design-guidelines.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility-ref-design-guidelines.mdc
@@ -1,158 +1,61 @@
 ---
-description: "Design tokens, typography, iconography, color palette, UX writing rules, and responsive breakpoints for Sales App extensions. Load when generating CSS, choosing colors, typography, or icons for any extension component."
+description: "UX writing rules (sentence case) and Phosphor Icons usage for Sales App extensions. Load when writing JSX text content or when an extension needs icons. CSS-related design rules (tokens, typography, spacing, responsive) are inlined directly in the CSS template — see code-templates-and-patterns.md."
 globs: 
 alwaysApply: false
 ---
 
-# Sales App Design Guidelines
+# Sales App Design Guidelines (non-CSS)
 
-All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+This reference covers two topics that apply to **TSX content**, not CSS:
+
+1. **UX writing rules** — for any text rendered in JSX
+2. **Iconography** — when the extension uses icons
+
+> **For CSS:** all design tokens, typography scale, spacing grid, and responsive breakpoints are inlined directly in the CSS template at [code-templates-and-patterns.md](code-templates-and-patterns.md) §"CSS Stylesheet". That template is the single source of truth for any CSS generation. Do not invent or duplicate token values here.
 
 ---
 
-## 1. UX and Writing Rules
+## 1. UX Writing Rules
 
-Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+Apply to every string that appears in the UI (labels, buttons, messages, placeholders, alt text).
 
 | Rule | Correct | Wrong |
 |------|---------|-------|
 | Sentence case | "Add to cart" | "ADD TO CART" |
-| Proper nouns | "VTEX account" | "vtex account" |
+| Proper nouns capitalized | "VTEX account" | "vtex account" |
 | No all-caps | "Loyalty points" | "LOYALTY POINTS" |
-| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+| No system-style placeholders | "Your email" | "EMAIL ADDRESS" |
+| No CSS uppercase transforms | (omit `text-transform: uppercase`) | `text-transform: uppercase` |
 
-These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
-
----
-
-## 2. Design Tokens (CSS Custom Properties)
-
-Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
-
-```css
-.container {
-  /* Primary action */
-  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
-  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-
-  /* Text */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-
-  /* Backgrounds */
-  --sa-color-bg:        #FFFFFF;       /* Neutral White */
-  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
-  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
-
-  /* Borders */
-  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
-  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
-
-  /* Error (Red scale) */
-  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
-  --sa-color-error-border: #FFDFD9;    /* Red 200 */
-  --sa-color-error-text:   #EC3727;    /* Red 800 */
-
-  /* Success (Green scale) */
-  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
-  --sa-color-success-text: #01905F;    /* Green 800 */
-
-  /* Warning (Yellow/Orange scale) */
-  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
-  --sa-color-warning-text: #E57001;    /* Orange 700 */
-
-  /* Info (Light Blue scale) */
-  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
-  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
-}
-```
-
-### Token mapping reference
-
-| Semantic role | Token | Hex | Palette origin |
-|--------------|-------|-----|----------------|
-| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
-| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
-| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
-| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
-| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
-| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
-| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
-| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
-| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
-| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
-| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
-| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
-| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
-| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
-| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
-| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
-| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
-| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
-| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
-| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+These rules derive from Google Material Design and Apple Human Interface Guidelines, adopted by VTEX.
 
 ---
 
-## 3. Typography
-
-### Typeface
-
-The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
-
-```css
-font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-```
-
-Set this on the root `.container` class so all descendant elements inherit it.
-
-### Weights
-
-Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
-
-### Allowed font sizes
-
-Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
-
-Do not use arbitrary sizes like 13px, 15px, or 17px.
-
-| Use case | Size | Weight |
-|----------|------|--------|
-| Section title | 16px | Semibold (600) |
-| Subtitle / label | 14px | Medium (500) |
-| Body text | 14px | Regular (400) |
-| Caption / hint | 12px | Regular (400) |
-| Price | 18px | Semibold (600) |
-
----
-
-## 4. Iconography
+## 2. Iconography
 
 ### Library
 
-All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
-
-### Sizes
-
-| Usage | Size |
-|-------|------|
-| Standard / default | 24px |
-| Compact / inline | 16px |
-| Large / featured | 32–48px |
-
-Always use sizes within the supported range: **16px to 48px**.
-
-### Weights
-
-Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use Material Icons, Font Awesome, Heroicons, or any other library.
 
 ### Installation
 
 ```bash
 yarn add @phosphor-icons/react
 ```
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Compact / inline | 16px |
+| Standard / default | 24px |
+| Large / featured | 32–48px |
+
+Always use sizes within **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
 
 ### Usage example
 
@@ -171,74 +74,13 @@ export function MyExtension(): JSX.Element {
 
 ---
 
-## 5. Spacing and Baseline Grid
+## 3. Quick checklist
 
-All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+Before presenting generated `.tsx` to the user, verify:
 
-| Value | Baseline multiple |
-|-------|-----------------|
-| 4px | 1× |
-| 8px | 2× |
-| 12px | 3× |
-| 16px | 4× |
-| 20px | 5× |
-| 24px | 6× |
-| 32px | 8× |
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-style placeholders)?
+- [ ] All icons imported from `@phosphor-icons/react`?
+- [ ] Icon sizes between 16px and 48px (24px default)?
+- [ ] Icon weights consistent within the component?
 
-**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
-
----
-
-## 6. Responsive Breakpoints
-
-Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
-
-| Breakpoint | Resolution range | Notes |
-|-----------|-----------------|-------|
-| Small (mobile) | 320–743px | Margin: 24px, no column grid |
-| Medium (tablet) | 744–1279px | Gutters: 16px |
-| Large (desktop) | 1280–1919px | Gutters: 20px |
-| Extra large (monitor) | 1920px+ | Gutters: 20px |
-
-Recommended mobile override (applied to the responsive section of the CSS file):
-
-```css
-@media (max-width: 743px) {
-  .container { padding: 12px; margin: 0 24px; }
-}
-```
-
----
-
-## 7. CSS File Structure
-
-Every extension CSS file must follow this structure:
-
-1. **Token declarations** — CSS custom properties on `.container`
-2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
-3. **Typography classes** — `.title`, `.subtitle`, `.text`
-4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
-5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
-6. **Responsive overrides** — `@media` queries at the bottom
-
-### Critical CSS rules
-
-- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
-- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
-- No `@import`, `position: fixed`, or `z-index: 9999`.
-- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
-
----
-
-## 8. Quick Compliance Checklist
-
-Before presenting generated CSS to the user, verify:
-
-- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
-- [ ] No hardcoded hex values outside the token declarations block?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
-- [ ] All spacing multiples of 4px?
-- [ ] All icons from Phosphor Icons?
-- [ ] All UI text in sentence case (no ALL-CAPS)?
-- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?
+For CSS verification (tokens, fonts, spacing, responsive), see [code-templates-and-patterns.md](code-templates-and-patterns.md) §"Design system rules baked into this template".

--- a/exports/cursor/sales-app-sales-app-extensibility-ref-design-guidelines.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility-ref-design-guidelines.mdc
@@ -1,0 +1,244 @@
+---
+description: "Design tokens, typography, iconography, color palette, UX writing rules, and responsive breakpoints for Sales App extensions. Load when generating CSS, choosing colors, typography, or icons for any extension component."
+globs: 
+alwaysApply: false
+---
+
+# Sales App Design Guidelines
+
+All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+
+---
+
+## 1. UX and Writing Rules
+
+Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+
+| Rule | Correct | Wrong |
+|------|---------|-------|
+| Sentence case | "Add to cart" | "ADD TO CART" |
+| Proper nouns | "VTEX account" | "vtex account" |
+| No all-caps | "Loyalty points" | "LOYALTY POINTS" |
+| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+
+These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
+
+---
+
+## 2. Design Tokens (CSS Custom Properties)
+
+Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
+
+```css
+.container {
+  /* Primary action */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow/Orange scale) */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
+}
+```
+
+### Token mapping reference
+
+| Semantic role | Token | Hex | Palette origin |
+|--------------|-------|-----|----------------|
+| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
+| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
+| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
+| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
+| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
+| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
+| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
+| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
+| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
+| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
+| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
+| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
+| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
+| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
+| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
+| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
+| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
+| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
+| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
+| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+
+---
+
+## 3. Typography
+
+### Typeface
+
+The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
+
+```css
+font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+```
+
+Set this on the root `.container` class so all descendant elements inherit it.
+
+### Weights
+
+Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
+
+### Allowed font sizes
+
+Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
+
+Do not use arbitrary sizes like 13px, 15px, or 17px.
+
+| Use case | Size | Weight |
+|----------|------|--------|
+| Section title | 16px | Semibold (600) |
+| Subtitle / label | 14px | Medium (500) |
+| Body text | 14px | Regular (400) |
+| Caption / hint | 12px | Regular (400) |
+| Price | 18px | Semibold (600) |
+
+---
+
+## 4. Iconography
+
+### Library
+
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Standard / default | 24px |
+| Compact / inline | 16px |
+| Large / featured | 32–48px |
+
+Always use sizes within the supported range: **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+
+### Installation
+
+```bash
+yarn add @phosphor-icons/react
+```
+
+### Usage example
+
+```typescript
+import { ShoppingCart, Star, Warning } from '@phosphor-icons/react';
+
+export function MyExtension(): JSX.Element {
+  return (
+    <div className="container">
+      <ShoppingCart size={24} />
+      <span>Cart items</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. Spacing and Baseline Grid
+
+All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+
+| Value | Baseline multiple |
+|-------|-----------------|
+| 4px | 1× |
+| 8px | 2× |
+| 12px | 3× |
+| 16px | 4× |
+| 20px | 5× |
+| 24px | 6× |
+| 32px | 8× |
+
+**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
+
+---
+
+## 6. Responsive Breakpoints
+
+Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
+
+| Breakpoint | Resolution range | Notes |
+|-----------|-----------------|-------|
+| Small (mobile) | 320–743px | Margin: 24px, no column grid |
+| Medium (tablet) | 744–1279px | Gutters: 16px |
+| Large (desktop) | 1280–1919px | Gutters: 20px |
+| Extra large (monitor) | 1920px+ | Gutters: 20px |
+
+Recommended mobile override (applied to the responsive section of the CSS module):
+
+```css
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
+```
+
+---
+
+## 7. CSS Module Structure
+
+Every extension CSS module must follow this structure:
+
+1. **Token declarations** — CSS custom properties on `.container`
+2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography classes** — `.title`, `.subtitle`, `.text`
+4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive overrides** — `@media` queries at the bottom
+
+### Critical CSS rules
+
+- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
+- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
+- No `@import`, `position: fixed`, or `z-index: 9999`.
+- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
+
+---
+
+## 8. Quick Compliance Checklist
+
+Before presenting generated CSS to the user, verify:
+
+- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
+- [ ] No hardcoded hex values outside the token declarations block?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
+- [ ] All spacing multiples of 4px?
+- [ ] All icons from Phosphor Icons?
+- [ ] All UI text in sentence case (no ALL-CAPS)?
+- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?

--- a/exports/cursor/sales-app-sales-app-extensibility-ref-documentation-template.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility-ref-documentation-template.mdc
@@ -1,0 +1,59 @@
+---
+description: "Markdown template for the docs/<ExtensionName>.md file generated in Step 4. Load when writing extension documentation to ensure all required sections are covered."
+globs: 
+alwaysApply: false
+---
+
+# Extension Documentation Template
+
+Generate `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist.
+
+The document must contain these 9 sections:
+
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+```markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+```

--- a/exports/cursor/sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc
@@ -203,20 +203,33 @@ import something from 'node_modules/lodash/get';
 
 ---
 
+### `NON_APPROVED_PACKAGE` — Import from non-approved package
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Any import whose source starts with `@` or contains `/`, unless it is `react` or a `node_modules/` direct path. Fires for every `@vtex/*` scoped package and every relative import (`./foo`, `../bar`).
+
+> **Note:** This warning is noisy — it fires for all legitimate Sales App imports (`@vtex/sales-app`, `@phosphor-icons/react`, relative component paths). Do not surface to the user when the import is from `@vtex/*` or a relative path. Investigate only when the import is from an unexpected third-party package.
+
+**Detection:** `import { … } from 'source'` where `source.startsWith('@')` or `source.includes('/')`, and source is not `'react'` or a `node_modules/` path.
+
+---
+
 ### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+Two detection paths:
 
-**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+1. **Direct API use:** `fetch`, `XMLHttpRequest`, `script.src`, `link.href` used as member expressions.
+2. **Known CDN domains in string literal:** `fetch('https://cdn.jsdelivr.net/...')` or any URL containing `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`, `api.example.com`, or ending with `.js`.
 
 > **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
 
 **Correct**
 ```typescript
-// Always use IO Proxy relative path
 const response = await fetch('/_v/my-loyalty-api/points', {
   credentials: 'include',
 });
@@ -225,6 +238,7 @@ const response = await fetch('/_v/my-loyalty-api/points', {
 **Wrong**
 ```typescript
 const response = await fetch('https://api.example.com/data');
+const response = await fetch('https://cdn.jsdelivr.net/npm/lodash.js'); // CDN — also Violation
 const xhr = new XMLHttpRequest();
 ```
 
@@ -232,14 +246,14 @@ const xhr = new XMLHttpRequest();
 
 ### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
 
-**Severity:** Warning (flag)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. CDN domain fetches are actually reported as `EXTERNAL_RESOURCE_LOADING` (Violation, block) — not as this Warning. Treat any fetch to a CDN domain as a **build-blocking Violation**, not a soft warning.
+
+**Severity:** Warning (flag) — *see note above; actual enforcement is via `EXTERNAL_RESOURCE_LOADING`*  
 **Files:** `.ts`, `.tsx`
 
 Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
 
 **Detection:** `fetch()` first argument literal containing one of these domains.
-
-**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
 
 ---
 
@@ -250,7 +264,7 @@ Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.co
 
 Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
 
-**Detection:** Any call to these methods.
+**Detection:** Any call where the callee matches `document.querySelector`, `document.getElementById`, etc. (the variable must be literally named `document`). Calls via a ref object — e.g. `containerRef.current.querySelector(...)` — are **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
@@ -273,14 +287,14 @@ document.getElementById('cart-container');
 
 Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
 
-**Detection:** Any member expression matching these patterns.
+**Detection:** Matches only when the object is literally named `element` (e.g. `element.style`). Equivalent access through other variable names — e.g. `divRef.current.style`, `el.className` — is **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
-// Use plain CSS with namespaced class names
+// Use plain CSS classes from the component stylesheet
 import './MyExtension.css';
 
-return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
+return <div className={isActive ? 'active' : 'inactive'} />;
 ```
 
 **Wrong**
@@ -297,7 +311,7 @@ element.setAttribute('style', 'display: none');
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+**Detection:** `while(true)` or `do...while(true)` with literal `true` condition.
 
 **Wrong**
 ```typescript
@@ -308,9 +322,22 @@ while (true) {
 
 ---
 
+### `POTENTIAL_INFINITE_LOOP` — Incomplete for-loop
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `for` statement with no `update` expression AND no `test` expression (e.g. `for (let i = 0;;) { … }`).
+
+**Action:** Warn the user and ensure the loop has a proper termination condition.
+
+---
+
 ### `MEMORY_LEAK` — Memory leak patterns
 
-**Severity:** Violation (block)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. The active rule is `POTENTIAL_MEMORY_LEAK` (Warning) below. Event listeners without cleanup **will not block the build**, but remain a Hard Constraint — always add a cleanup return in `useEffect`.
+
+**Severity:** Violation (block) — *see note above; not currently enforced at build time*  
 **Files:** `.ts`, `.tsx`
 
 **Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
@@ -334,23 +361,58 @@ useEffect(() => {
 
 ---
 
+### `POTENTIAL_MEMORY_LEAK` — Likely memory leak patterns
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Three triggers:
+1. Any `addEventListener` call — the analyzer warns regardless of whether a corresponding `removeEventListener` exists in cleanup.
+2. Recursive function call where the callee name matches the parent `FunctionDeclaration` identifier.
+3. `Array.push` inside a `for` or `while` loop.
+
+**Action:** Verify the component has a proper cleanup return in `useEffect` for any event listener, and that recursive functions have a clear base case.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+---
+
 ### `EXCESSIVE_API_CALLS` — Excessive API call patterns
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+**Detection:** `fetch` or `XMLHttpRequest` calls whose parent is a `for` or `while` loop.
 
 **Wrong**
 ```typescript
-// fetch inside render — fires on every re-render
-const data = await fetch('/_v/api/data');
-
 // fetch inside loop — excessive calls
 for (const item of items) {
   await fetch(`/_v/api/item/${item.id}`);
 }
 ```
+
+---
+
+### `FREQUENT_API_CALLS` — API call outside loop / rapid setInterval
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Two triggers:
+1. `fetch` or `XMLHttpRequest` call **outside** a loop (i.e. anywhere else in the component). Fires for every fetch — ensure calls are wrapped in `useEffect` with proper deps and are rate-limited or cached.
+2. `setInterval` with a numeric delay argument below 1000 ms.
+
+> **Note:** Trigger 1 is intentionally broad — it flags every `fetch()` call as a reminder to verify it is not running unintentionally on every render. It does **not** mean every fetch is wrong. Only surface this to the user when the fetch is genuinely outside a `useEffect` or appears to run on each render.
+
+**Action:** Warn the user and suggest wrapping fetches in `useEffect`, using caching, or increasing the polling interval.
 
 ---
 
@@ -382,7 +444,25 @@ import _ from 'lodash';
 
 ## 2. CSS Containment Rules
 
-Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`.
+
+**Sales App analyzer configuration** (from `@vtex/sales-app` build/dev hook):
+
+```typescript
+cssOptions: {
+  allowedNamespaces: ['sales-app-extension-'],
+  defaultNamespace: 'sales-app-extension-',
+  transformNonCompliant: true,
+  overwriteTransformed: true,
+}
+```
+
+Two consequences for the rules below:
+
+1. The configured namespace is **`sales-app-extension-`**, not the analyzer's bare default of `extension-`. Any rule that talks about "the allowed namespace" means `sales-app-extension-` in this project.
+2. `transformNonCompliant: true` softens the namespace rules: when a selector or `@keyframes` name is not prefixed, the analyzer auto-rewrites it into a sibling `*.transformed.css` file and emits a `CSS_TRANSFORMED` **warning** instead of a `CSS_NAMESPACE_REQUIRED` / `CSS_GLOBAL_KEYFRAMES` **violation**. The original `.css` (and the `className` strings in JSX) are left untouched, so the build does not break. This is why the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) ships unprefixed selectors like `.container`, `.title`, `.row` — they are valid in this project.
+
+The other CSS rules (`CSS_GLOBAL_SELECTOR`, `CSS_CONTAINMENT_BREAKOUT`, `CSS_GLOBAL_IMPORT`, `CSS_RESTRICTED_PROPERTY`, `CSS_RESTRICTED_VALUE`, and the inline-style rules) are **not** softened by `transformNonCompliant` — they remain build-blocking violations.
 
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
@@ -395,12 +475,12 @@ Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#_
 
 **Correct**
 ```css
-/* Scope all rules inside the extension container */
-.extension-container {
+/* Scope rules inside the extension container — never target global elements */
+.container {
   font-size: 14px;
 }
 
-.extension-container .title {
+.container .title {
   font-weight: bold;
 }
 ```
@@ -435,7 +515,7 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 **Correct**
 ```css
-.extension-container {
+.container {
   position: relative; /* safe — contained */
 }
 ```
@@ -458,26 +538,27 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
+All CSS selectors should be scoped under an allowed namespace prefix. In the Sales App, that prefix is `sales-app-extension-`. Because the project sets `transformNonCompliant: true`, an unprefixed selector does **not** block the build: the analyzer rewrites it inside a sibling `Component.transformed.css` and emits a `CSS_TRANSFORMED` warning instead of `CSS_NAMESPACE_REQUIRED`. The original `Component.css` (which is what gets bundled) keeps the unprefixed class, so the JSX `className="container"` continues to match.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
+**Detection:** A selector that does not include any value from `allowedNamespaces` (substring check on `.namespace`, `#namespace`, or `[class*="namespace"]`).
 
-**Correct**
+**Correct (and matches the CSS template)**
 ```css
-/* Plain CSS — namespace all classes */
-.extension-container { padding: 8px; }
-.extension-title { font-size: 16px; }
-```
-
-**Wrong**
-```css
-/* Plain CSS — no namespace — pollutes global styles */
+/* Unprefixed top-level classes are accepted because transformNonCompliant=true. */
 .container { padding: 8px; }
-.title { font-size: 16px; }
+.title     { font-size: 16px; }
 ```
+
+**Also correct (explicit prefix, never warns)**
+```css
+.sales-app-extension-container { padding: 8px; }
+.sales-app-extension-title     { font-size: 16px; }
+```
+
+> Prefer the unprefixed form to match the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) and the JSX in the component templates. The `CSS_TRANSFORMED` warning that fires for these is informational only.
 
 ---
 
@@ -505,26 +586,27 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell. As with `CSS_NAMESPACE_REQUIRED`, `transformNonCompliant: true` rewrites the name in `*.transformed.css` and emits `CSS_TRANSFORMED` instead of blocking.
 
-**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix (`sales-app-extension-` in this project).
 
-**Correct**
+The CSS template prefixes keyframes with `${COMPONENT_NAME}-` (e.g. `LoyaltyPoints-spin`). That prefix does **not** start with `sales-app-extension-`, so it triggers a `CSS_TRANSFORMED` warning — the build still succeeds, but the transformed file will rename it to `sales-app-extension-LoyaltyPoints-spin`. Either form is acceptable.
+
+**Correct (no warning)**
 ```css
-@keyframes extension-fade-in {
+@keyframes sales-app-extension-fade-in {
   from { opacity: 0; }
   to   { opacity: 1; }
 }
 ```
 
-**Wrong**
+**Also correct (CSS_TRANSFORMED warning, build passes)**
 ```css
-@keyframes fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+@keyframes LoyaltyPoints-spin {
+  to { transform: rotate(360deg); }
 }
 ```
 
@@ -554,16 +636,59 @@ Certain CSS values (e.g., `!important`) override the cascade and break containme
 
 **Correct**
 ```css
-.extension-button {
-  color: var(--vtex-color-primary);
+.button {
+  color: var(--sa-color-primary);
 }
 ```
 
 **Wrong**
 ```css
-.extension-button {
+.button {
   color: red !important;
 }
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_PROPERTY` — Restricted property in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props in JSX may not use properties that affect layout or containment.
+
+Restricted properties: `position`, `z-index`, `top`, `left`, `right`, `bottom`, `all`, `contain`, `content`, `isolation`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted property names.
+
+**Correct**
+```typescript
+// Use CSS classes for layout properties
+return <div className="overlay" />;
+```
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed', top: 0 }} />;
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_VALUE` — Restricted value in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props may not use values that break containment or cascade.
+
+Restricted values: `fixed`, `absolute`, `!important`, `inherit`, `initial`, `unset`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted values.
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed' }} />;
+return <div style={{ display: 'inherit' }} />;
 ```
 
 ---
@@ -593,33 +718,6 @@ setItems(updatedItems);
 for (const item of items) {
   setCount((c) => c + 1); // re-renders on every iteration
 }
-```
-
----
-
-### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
-
-**Severity:** Violation (block)  
-**Files:** `.tsx`
-
-`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
-
-**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
-
-**Correct**
-```typescript
-const filteredItems = useMemo(() => items.filter(isActive), [items]);
-
-return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
-```
-
-**Wrong**
-```typescript
-return (
-  <ul>
-    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
-  </ul>
-);
 ```
 
 ---

--- a/exports/cursor/sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc
@@ -1,0 +1,914 @@
+---
+description: "fsp-analyzer rule catalog for Sales App extension validation. Load during Step 3 (Code Generation & Validation) to check generated TypeScript/CSS against sandbox security, CSS containment, and React performance rules enforced at build time."
+globs: 
+alwaysApply: false
+---
+
+# Static Analysis Rules (fsp-analyzer)
+
+Sales App extensions run inside a sandboxed environment enforced by `@vtex/fsp-analyzer`. These rules are checked at `preBuild` and `preDev` hook time. The AI must validate all generated code against these rules before presenting it to the user.
+
+Rule IDs match the `ViolationKind`, `ReactViolationKind`, `WarningKind`, and `ReactWarningKind` types from `@vtex/fsp-analyzer` so developers can cross-reference with real build output.
+
+---
+
+## How to apply these rules
+
+After generating a component, CSS file, and `index.tsx`, check each generated file against the **violation** rules (block generation — fix before presenting) and the **warning** rules (flag to the user with a suggestion). Do not present code that has unresolved violations.
+
+---
+
+## 1. Sandbox Security Rules
+
+Applied to `.ts` and `.tsx` files by `FastStoreSandboxAnalyzer`.
+
+### `RESTRICTED_API` — DOM API access banned
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted identifiers: `document`, `window`, `localStorage`, `sessionStorage`, `navigator`.
+
+**Detection:** Any use of these identifiers as a value (not as a type import).
+
+**Correct**
+```typescript
+// Use React state and props for data; use useExtension() for account context
+const { account } = useExtension();
+```
+
+**Wrong**
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+---
+
+### `VARIABLE_ALIASING` — Aliasing restricted APIs
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Assigning a restricted API to a variable to circumvent detection.
+
+**Detection:** `const x = document`, `const [w, d] = [window, document]`, or any destructuring that aliases a restricted API.
+
+**Correct**
+```typescript
+// Pass data via props or React context, not via aliased globals
+```
+
+**Wrong**
+```typescript
+const doc = document;
+const [w, d] = [window, document];
+doc.querySelector('.item');
+```
+
+---
+
+### `GLOBAL_MANIPULATION` — Global object manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted member expressions: `window.location`, `window.history`.
+
+**Detection:** Member expressions on `window` to access `location` or `history`.
+
+**Correct**
+```typescript
+// Navigation is managed by Sales App shell; do not manipulate location
+```
+
+**Wrong**
+```typescript
+window.location.href = '/new-path';
+window.location.reload();
+```
+
+---
+
+### `HISTORY_MANIPULATION` — Browser history manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `window.history.pushState`, `window.history.replaceState`, `history.pushState`, `history.replaceState`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Let the Sales App shell handle routing
+```
+
+**Wrong**
+```typescript
+history.pushState({}, '', '/cart');
+window.history.replaceState(null, '', '/pdp');
+```
+
+---
+
+### `DYNAMIC_SCRIPT_CREATION` — Dynamic script creation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `document.createElement`, `document.write`, `document.writeln`, `document.body.appendChild`, `document.head.appendChild`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Render UI via JSX; never inject scripts dynamically
+```
+
+**Wrong**
+```typescript
+const script = document.createElement('script');
+script.src = 'https://cdn.example.com/lib.js';
+document.body.appendChild(script);
+```
+
+---
+
+### `CODE_EXECUTION` — Arbitrary code execution
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `eval`, `Function` (as constructor), `setTimeout` (string form), `setInterval` (string form), `new Function`.
+
+**Detection:** Any call or instantiation of these identifiers.
+
+> **Note on `setTimeout`/`setInterval`:** These are restricted in the sandbox to prevent arbitrary code injection. Use `useEffect` with `AbortController` or cleanup functions for timing-based logic:
+
+**Correct**
+```typescript
+useEffect(() => {
+  const id = window.setTimeout(() => { /* logic */ }, 500);
+  return () => window.clearTimeout(id);
+}, []);
+// Note: even this should be reviewed; prefer event-driven patterns
+```
+
+**Wrong**
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+---
+
+### `RESTRICTED_IMPORT` — Restricted Node.js module imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted modules: `fs`, `path`, `child_process`, `crypto`.
+
+**Detection:** Any `import` statement importing from these module names.
+
+**Correct**
+```typescript
+// Extensions are browser-only React components; do not import Node.js modules
+import { useCart } from '@vtex/sales-app';
+```
+
+**Wrong**
+```typescript
+import fs from 'fs';
+import { resolve } from 'path';
+import crypto from 'crypto';
+```
+
+---
+
+### `RESTRICTED_IMPORT_SOURCE` — Direct node_modules path imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Import paths containing `node_modules/`.
+
+**Wrong**
+```typescript
+import something from 'node_modules/lodash/get';
+```
+
+---
+
+### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+
+**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+
+> **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
+
+**Correct**
+```typescript
+// Always use IO Proxy relative path
+const response = await fetch('/_v/my-loyalty-api/points', {
+  credentials: 'include',
+});
+```
+
+**Wrong**
+```typescript
+const response = await fetch('https://api.example.com/data');
+const xhr = new XMLHttpRequest();
+```
+
+---
+
+### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
+
+**Detection:** `fetch()` first argument literal containing one of these domains.
+
+**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
+
+---
+
+### `QUERY_SELECTOR_USAGE` — DOM query selectors
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Use React refs for direct DOM access when absolutely needed
+const ref = useRef<HTMLDivElement>(null);
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.my-class');
+document.getElementById('cart-container');
+```
+
+---
+
+### `STYLE_MANIPULATION` — Direct style manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
+
+**Detection:** Any member expression matching these patterns.
+
+**Correct**
+```typescript
+// Use CSS modules and conditional class application
+import styles from './MyExtension.module.css';
+
+return <div className={isActive ? styles.active : styles.inactive} />;
+```
+
+**Wrong**
+```typescript
+element.style.color = 'red';
+element.classList.add('active');
+element.setAttribute('style', 'display: none');
+```
+
+---
+
+### `INFINITE_LOOP` — Infinite loops
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+
+**Wrong**
+```typescript
+while (true) {
+  processItem();
+}
+```
+
+---
+
+### `MEMORY_LEAK` — Memory leak patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  window.addEventListener('resize', handler);
+  // Missing cleanup — memory leak
+}, []);
+```
+
+---
+
+### `EXCESSIVE_API_CALLS` — Excessive API call patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+
+**Wrong**
+```typescript
+// fetch inside render — fires on every re-render
+const data = await fetch('/_v/api/data');
+
+// fetch inside loop — excessive calls
+for (const item of items) {
+  await fetch(`/_v/api/item/${item.id}`);
+}
+```
+
+---
+
+### `LARGE_BUNDLE_SIZE_IMPACT` — Bundle size impacts
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:**
+- String literals longer than 1,000 characters
+- Object literals with more than 100 properties
+- Imports from heavyweight libraries: `lodash`, `moment`
+
+**Action:** Warn the user and suggest alternatives (`date-fns` instead of `moment`, native array methods instead of `lodash`).
+
+**Correct**
+```typescript
+import { format } from 'date-fns';
+const formattedDate = format(new Date(), 'yyyy-MM-dd');
+```
+
+**Wrong**
+```typescript
+import moment from 'moment';
+import _ from 'lodash';
+```
+
+---
+
+## 2. CSS Containment Rules
+
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+
+### `CSS_GLOBAL_SELECTOR` — Global element selectors
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
+
+**Detection:** Any CSS rule whose selector matches or contains these elements at the top level.
+
+**Correct**
+```css
+/* Scope all rules inside the extension container */
+.extension-container {
+  font-size: 14px;
+}
+
+.extension-container .title {
+  font-weight: bold;
+}
+```
+
+**Wrong**
+```css
+body {
+  font-size: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --my-color: red;
+}
+```
+
+---
+
+### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
+
+**Detection:** Any rule or declaration matching these patterns.
+
+> **Note on positioning:** `position: relative` and `position: sticky` within the extension container are generally safe. Avoid `fixed` and unbounded `absolute` that escape the extension boundary.
+
+**Correct**
+```css
+.extension-container {
+  position: relative; /* safe — contained */
+}
+```
+
+**Wrong**
+```css
+.overlay {
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+}
+
+:host {
+  display: block;
+}
+```
+
+---
+
+### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+
+**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+
+**Correct**
+```css
+/* CSS Module — all classes are auto-scoped */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+```css
+/* Plain CSS — must namespace manually */
+.extension-container { padding: 8px; }
+.extension-title { font-size: 16px; }
+```
+
+**Wrong**
+```css
+/* Plain CSS — no namespace — pollutes global styles */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+---
+
+### `CSS_GLOBAL_IMPORT` — CSS @import rules
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@import` pulls external stylesheets that affect global styles and bypass containment.
+
+**Detection:** Any `@import` at-rule anywhere in the CSS file.
+
+**Correct**
+```css
+/* Import a local CSS variable file via bundler config, not @import */
+```
+
+**Wrong**
+```css
+@import url('https://fonts.googleapis.com/css2?family=Roboto');
+@import './reset.css';
+```
+
+---
+
+### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+
+**Correct**
+```css
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+```css
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+---
+
+### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
+
+**Detection:** Declarations using restricted property names (e.g., properties that set global layout hints).
+
+**Action:** If detected, remove or scope the declaration appropriately.
+
+---
+
+### `CSS_RESTRICTED_VALUE` — Restricted CSS values
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
+
+**Detection:** `!important` in any declaration, or values targeting global layout tokens.
+
+**Correct**
+```css
+.extension-button {
+  color: var(--vtex-color-primary);
+}
+```
+
+**Wrong**
+```css
+.extension-button {
+  color: red !important;
+}
+```
+
+---
+
+## 3. React Performance Rules
+
+Applied to `.tsx` files by `ReactPerformanceAnalyzer`. Violations block presentation; warnings are flagged to the user.
+
+### `REACT_UNNECESSARY_RERENDER` — State update inside loop
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+State setter calls inside `for` or `while` loops trigger a re-render on every iteration.
+
+**Detection:** A `setState` / `set*` call whose parent node is a `for` or `while` statement.
+
+**Correct**
+```typescript
+// Compute derived value, then set once
+const updatedItems = items.map(transform);
+setItems(updatedItems);
+```
+
+**Wrong**
+```typescript
+for (const item of items) {
+  setCount((c) => c + 1); // re-renders on every iteration
+}
+```
+
+---
+
+### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
+
+**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
+
+**Correct**
+```typescript
+const filteredItems = useMemo(() => items.filter(isActive), [items]);
+
+return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
+  </ul>
+);
+```
+
+---
+
+### `REACT_ANONYMOUS_COMPONENT` — Anonymous (lowercase) component
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Components assigned to variables starting with lowercase are treated as HTML tags by React and cannot be used in JSX.
+
+**Detection:** Arrow function or function expression assigned to a variable that does not start with an uppercase letter.
+
+**Correct**
+```typescript
+export function LoyaltyPoints(): JSX.Element { ... }
+export const WarrantyBadge = (): JSX.Element => { ... };
+```
+
+**Wrong**
+```typescript
+const loyaltyPoints = (): JSX.Element => { ... };
+const warrantyBadge = function() { ... };
+```
+
+---
+
+### `REACT_DIRECT_DOM_MANIPULATION` — Direct DOM manipulation in React
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Bypasses the React virtual DOM and causes unpredictable behavior.
+
+**Detection:** Calls to `document.querySelector` or `document.getElementById` inside a React component.
+
+**Correct**
+```typescript
+const containerRef = useRef<HTMLDivElement>(null);
+// Access DOM via containerRef.current
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.cart-list');
+el.style.display = 'none'; // bypasses React
+```
+
+---
+
+### `REACT_LAYOUT_EFFECT_MISUSE` — useLayoutEffect usage
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`useLayoutEffect` blocks the browser paint and can cause performance issues in a sandboxed extension.
+
+**Detection:** Any call to `useLayoutEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  // DOM reading/writing after paint
+}, []);
+```
+
+**Wrong**
+```typescript
+useLayoutEffect(() => {
+  // blocks paint
+}, []);
+```
+
+---
+
+### `REACT_MISSING_DEPS` — Missing dependency array
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useEffect`, `useCallback`, or `useMemo` without a second argument re-runs on every render.
+
+**Detection:** A call to one of these hooks with fewer than 2 arguments, or with a non-array second argument.
+
+**Correct**
+```typescript
+useEffect(() => {
+  fetchData();
+}, [productId]); // explicit deps
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  fetchData(); // runs on every render
+});
+```
+
+---
+
+### `REACT_INLINE_FUNCTION` — Inline functions in JSX props
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Arrow functions defined directly in JSX attributes create a new function reference on every render, preventing child memoization.
+
+**Detection:** Function expression or arrow function expression whose parent is a JSX expression container or prop.
+
+**Correct**
+```typescript
+const handleClick = useCallback(() => {
+  doSomething();
+}, []);
+
+return <button onClick={handleClick}>Click</button>;
+```
+
+**Wrong**
+```typescript
+return <button onClick={() => doSomething()}>Click</button>;
+```
+
+---
+
+### `REACT_LARGE_COMPONENT` — Component over 200 lines
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Large components are harder to maintain and test. Threshold: **200 lines**.
+
+**Detection:** A function/arrow function with start/end line difference > 200.
+
+**Action:** Suggest splitting into smaller sub-components or extracting logic into custom hooks.
+
+---
+
+### `REACT_MANY_USESTATE` — More than 5 useState calls
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Many `useState` calls in a single component indicate complex local state. Threshold: **5 calls**.
+
+**Detection:** More than 5 calls to `useState` (or `React.useState`) within a single function component.
+
+**Action:** Suggest consolidating related state into a single `useState` with an object, or extracting to a custom hook.
+
+**Correct**
+```typescript
+const [formState, setFormState] = useState({
+  name: '',
+  email: '',
+  quantity: 1,
+});
+```
+
+**Wrong**
+```typescript
+const [name, setName] = useState('');
+const [email, setEmail] = useState('');
+const [quantity, setQuantity] = useState(1);
+const [loading, setLoading] = useState(false);
+const [error, setError] = useState<string | null>(null);
+const [submitted, setSubmitted] = useState(false); // 6th useState — flagged
+```
+
+---
+
+### `REACT_CONDITIONAL_HOOK` — Hook called conditionally
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a hook inside an `if`, `switch`, or ternary expression violates the Rules of Hooks.
+
+**Detection:** A hook call (useEffect, useState, useMemo, useCallback, useLayoutEffect) whose ancestor is an `IfStatement`, `SwitchStatement`, or `ConditionalExpression`.
+
+**Correct**
+```typescript
+const cart = useCart(); // always called unconditionally
+
+if (!cart) return <></>;
+```
+
+**Wrong**
+```typescript
+if (isEnabled) {
+  const cart = useCart(); // conditional hook call — violates Rules of Hooks
+}
+```
+
+---
+
+### `REACT_COMPLEX_JSX` — Deep JSX nesting
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Deep JSX trees are harder to read and may indicate a need to extract sub-components. Threshold: **5 levels deep**.
+
+**Detection:** A JSX element whose JSX child tree exceeds 5 levels of nesting.
+
+**Action:** Extract inner JSX into a named sub-component.
+
+---
+
+### `REACT_UNOPTIMIZED_LIST` — List rendering without key or large list
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Missing `key` props in list rendering causes React reconciliation issues. Lists over 50 items may need virtualization.
+
+**Detection:**
+- `map()` producing JSX without a `key` attribute on the root element
+- List size exceeding 50 items
+
+**Correct**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li key={item.id}>{item.name}</li>
+    ))}
+  </ul>
+);
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li>{item.name}</li> // missing key
+    ))}
+  </ul>
+);
+```
+
+---
+
+### `REACT_COMPLEX_STATE` — useState with complex object
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useState` initialized with an object having more than 5 properties suggests a need for `useReducer`. Threshold: **5 properties**.
+
+**Detection:** `useState(obj)` where `obj` is an object literal with > 5 properties.
+
+**Action:** Suggest converting to `useReducer` for complex state.
+
+---
+
+### `REACT_NESTED_UPDATE` — Nested state updates
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a state setter from within another state setter's callback can cause unexpected re-renders.
+
+**Detection:** A `set*` call whose ancestor is another `set*` call expression.
+
+---
+
+## Validation Output Format
+
+When reporting issues after code review, group by file and severity:
+
+```
+### Static Analysis Results
+
+**Violations (must fix before completing Step 3):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Fix: <suggested fix>
+
+**Warnings (review with user):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Suggestion: <improvement>
+
+✅ No violations found. N warnings flagged.
+```
+
+Do not proceed with Step 4 (Documentation) until all violations are resolved.

--- a/exports/cursor/sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc
@@ -277,10 +277,10 @@ Restricted expressions: `element.style`, `element.className`, `element.classList
 
 **Correct**
 ```typescript
-// Use CSS modules and conditional class application
-import styles from './MyExtension.module.css';
+// Use plain CSS with namespaced class names
+import './MyExtension.css';
 
-return <div className={isActive ? styles.active : styles.inactive} />;
+return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
 ```
 
 **Wrong**
@@ -387,7 +387,7 @@ Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
 
@@ -425,7 +425,7 @@ body {
 ### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
 
@@ -459,21 +459,15 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
 
 **Correct**
 ```css
-/* CSS Module — all classes are auto-scoped */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-```
-
-```css
-/* Plain CSS — must namespace manually */
+/* Plain CSS — namespace all classes */
 .extension-container { padding: 8px; }
 .extension-title { font-size: 16px; }
 ```
@@ -490,7 +484,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_IMPORT` — CSS @import rules
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@import` pulls external stylesheets that affect global styles and bypass containment.
 
@@ -512,7 +506,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
 
@@ -539,7 +533,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
 
@@ -552,7 +546,7 @@ Certain properties affect layout or rendering globally and are restricted to pre
 ### `CSS_RESTRICTED_VALUE` — Restricted CSS values
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
 

--- a/exports/cursor/sales-app-sales-app-extensibility.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility.mdc
@@ -317,6 +317,114 @@ Discovery → Requirements → Present plan → **User approves** → Generate c
 **Wrong**
 Discovery → Generate code immediately.
 
+### Constraint: Never access DOM APIs directly
+
+Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
+
+**Why this matters**
+Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
+
+**Detection**
+Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
+
+**Correct**
+
+```typescript
+// Use React state, props, and Sales App hooks for data
+const { account } = useExtension();
+const cart = useCart();
+```
+
+**Wrong**
+
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+### Constraint: Never import restricted Node.js modules
+
+Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
+
+**Why this matters**
+Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
+
+**Detection**
+`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
+
+**Correct**
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+import React, { useState, useEffect } from 'react';
+```
+
+**Wrong**
+
+```typescript
+import fs from 'fs';
+import crypto from 'crypto';
+```
+
+### Constraint: Never use eval or the Function constructor
+
+Arbitrary code execution is banned in the sandbox.
+
+**Why this matters**
+`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
+
+**Detection**
+Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
+
+**Correct**
+
+```typescript
+const result = computeValue(input); // deterministic logic only
+```
+
+**Wrong**
+
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+### Constraint: CSS must use namespaced selectors — no global elements
+
+Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
+
+**Why this matters**
+Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
+
+**Detection**
+Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
+
+**Correct**
+
+```css
+/* CSS Module — classes are auto-scoped by the bundler */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+
+```css
+body { font-size: 14px; }
+* { box-sizing: border-box; }
+:root { --my-color: red; }
+@import './reset.css';
+.overlay { position: fixed; z-index: 9999; }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -327,7 +435,7 @@ Discovery → Generate code immediately.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, and the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -395,6 +503,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](@sales-app-sales-app-extensibility-ref-discovery-and-use-cases.mdc) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](@sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.mdc) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
 
 ## Common failure modes
 
@@ -412,6 +521,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
+- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
+- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
+- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
+- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
 
 ## Review checklist
 
@@ -432,6 +545,16 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
 - [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
+- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
+- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
+- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
+- [ ] No @import rules in CSS?
+- [ ] No position: fixed or z-index: 9999 in CSS?
+- [ ] @keyframes names prefixed with extension namespace?
+- [ ] No useLayoutEffect (use useEffect instead)?
+- [ ] No heavyweight library imports (lodash, moment)?
+- [ ] Components under 200 lines?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/cursor/sales-app-sales-app-extensibility.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility.mdc
@@ -53,7 +53,7 @@ Documentation: https://beta.fast.store/sales-app/setting-up
 
 ## Decision rules
 
-Follow the mandatory 6-step workflow in order. Do not skip steps.
+Follow the mandatory 7-step workflow (Steps 0–6) in order. Do not skip steps.
 
 | Step | Purpose | Gate |
 |------|---------|------|
@@ -181,55 +181,6 @@ const { item } = useCartItem();
 return <div>{item.name}</div>;
 ```
 
-### Constraint: Never expose authentication keys in frontend code
-
-API keys in `fetch` headers are visible in the browser network tab.
-
-**Why this matters**
-Leaked keys compromise the external service.
-
-**Detection**
-Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
-
-**Correct**
-
-```typescript
-const response = await fetch('/_v/my-api/data', {
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-**Wrong**
-
-```typescript
-const response = await fetch('https://api.example.com/data', {
-  headers: { 'x-api-key': 'sk-secret-key-12345' },
-});
-```
-
-### Constraint: IO Proxy must use relative paths only
-
-The Sales App internal proxy resolves the domain automatically.
-
-**Why this matters**
-A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
-
-**Detection**
-`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
-
-**Correct**
-
-```typescript
-await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
-```
-
-**Wrong**
-
-```typescript
-await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
-```
-
 ### Constraint: defineExtensions is required in index.tsx
 
 Entry point must use `defineExtensions` from `@vtex/sales-app`.
@@ -301,186 +252,6 @@ defineExtensions({ 'cart.cart-item.after': ItemWarranty });
 defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
 ```
 
-### Constraint: Always present execution plan and wait for approval
-
-Do not generate code until the user confirms the plan.
-
-**Why this matters**
-Generating without agreement wastes effort and may produce the wrong extension.
-
-**Detection**
-Jumping from discovery to code generation without presenting a plan.
-
-**Correct**
-Discovery → Requirements → Present plan → **User approves** → Generate code.
-
-**Wrong**
-Discovery → Generate code immediately.
-
-### Constraint: Never access DOM APIs directly
-
-Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
-
-**Why this matters**
-Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
-
-**Detection**
-Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
-
-**Correct**
-
-```typescript
-// Use React state, props, and Sales App hooks for data
-const { account } = useExtension();
-const cart = useCart();
-```
-
-**Wrong**
-
-```typescript
-const userId = localStorage.getItem('userId');
-const width = window.innerWidth;
-document.title = 'My Extension';
-```
-
-### Constraint: Never import restricted Node.js modules
-
-Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
-
-**Why this matters**
-Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
-
-**Detection**
-`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
-
-**Correct**
-
-```typescript
-import { useCart } from '@vtex/sales-app';
-import React, { useState, useEffect } from 'react';
-```
-
-**Wrong**
-
-```typescript
-import fs from 'fs';
-import crypto from 'crypto';
-```
-
-### Constraint: Never use eval or the Function constructor
-
-Arbitrary code execution is banned in the sandbox.
-
-**Why this matters**
-`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
-
-**Detection**
-Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
-
-**Correct**
-
-```typescript
-const result = computeValue(input); // deterministic logic only
-```
-
-**Wrong**
-
-```typescript
-eval('doSomething()');
-const fn = new Function('return 42');
-setTimeout('doSomething()', 1000);
-```
-
-### Constraint: CSS files must use plain .css extension, never .module.css
-
-The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
-
-**Why this matters**
-A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
-
-**Detection**
-Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
-
-**Correct**
-
-```typescript
-import './CashbackWidget.css';
-// Use className strings directly
-<div className="container">
-```
-
-**Wrong**
-
-```typescript
-import styles from './CashbackWidget.module.css';
-// CSS modules object access
-<div className={styles.container}>
-```
-
-### Constraint: CSS must use namespaced selectors — no global elements
-
-Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
-
-**Why this matters**
-Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
-
-**Detection**
-Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
-
-**Correct**
-
-```css
-/* Plain CSS — use namespace prefix to scope classes */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-
-@keyframes extension-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-```
-
-**Wrong**
-
-```css
-body { font-size: 14px; }
-* { box-sizing: border-box; }
-:root { --my-color: red; }
-@import './reset.css';
-.overlay { position: fixed; z-index: 9999; }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Constraint: CSS must follow Sales App Design Guidelines
-
-Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
-
-**Why this matters**
-Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
-
-**Detection**
-Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
-
-**Correct**
-
-```css
-.container {
-  --sa-color-primary: #157BF4;
-  --sa-color-text-primary: #1F1F1F;
-  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-}
-.title { color: var(--sa-color-text-primary); font-size: 16px; }
-.buttonPrimary { background-color: var(--sa-color-primary); }
-```
-
-**Wrong**
-
-```css
-.container { font-family: Arial; }
-.title { color: #1a1a1a; font-size: 15px; }
-.buttonPrimary { background-color: #0066cc; }
-```
-
 ## Preferred pattern
 
 ### Workflow overview
@@ -491,59 +262,17 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`.
 
-**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
+Required references for this step (load before generating):
+- [code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) — all component templates, the CSS template (with the full Sales App design system inlined: tokens, typography, spacing, responsive), the `index.tsx` template, type generation rules, and the custom fetch hook pattern.
+- [extension-points-hooks-and-types.md](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) — hook return types and TypeScript definitions.
+- [static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`. Run these checks on all generated files.
+- [design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) — load when the extension renders any UI text (sentence case rule) or uses icons (Phosphor Icons).
 
-1. **Extension name** — title matching the component name.
-2. **Overview** — one-paragraph summary of what the extension does and why it was built.
-3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
-4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
-5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS file name and summary of key classes.
-7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
-   - **Source documentation:** URL or file path of the original API documentation, if provided.
-   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
-   - Note which fields are optional (`?`) vs required per the documentation.
-8. **How to test** — dev server command and URL to reach the extension.
-9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Validate against the 12-point checklist in code-templates-and-patterns.md. Fix all violations before presenting code; surface warnings to the user.
 
-Template for the documentation file:
-
-````markdown
-# <ExtensionName>
-
-## Overview
-<One-paragraph description of the extension purpose and value.>
-
-## Extension point
-- **Point:** `<extension.point.name>`
-- **Rationale:** <Why this extension point was selected.>
-
-## Hooks used
-| Hook | Purpose |
-|------|---------|
-| `useCart` | <What data it provides here> |
-
-## Component structure
-<Describe the component tree, key props, and internal state.>
-
-## Styling
-- **File:** `<ComponentName>.css`
-- <Summary of key CSS classes and design decisions.>
-
-## API integration
-- **Endpoint:** `/_v/...`
-- **Auth strategy:** IO Proxy / Direct / None
-- **Request/Response:** <Brief shape description.>
-
-## How to test
-Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
-
-## Known constraints
-- <Guard or limitation 1>
-- <Guard or limitation 2>
-````
+**Step 4** — Generate `docs/<ExtensionName>.md` inside the Sales App package (create the `docs/` folder if needed). Load the [documentation template reference](@sales-app-sales-app-extensibility-ref-documentation-template.mdc) for the required 9-section structure and the markdown skeleton to fill in.
 
 **Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](@sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.mdc).
 
@@ -556,73 +285,47 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; **CSS template with the full Sales App design system inlined (tokens, typography, spacing, responsive)**; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](@sales-app-sales-app-extensibility-ref-discovery-and-use-cases.mdc) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](@sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.mdc) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
-| [references/design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
+| [references/design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) | Writing UI text (sentence case rule) or using icons (Phosphor Icons). **CSS-related design rules — tokens, typography, spacing, responsive — are inlined directly in the CSS template inside code-templates-and-patterns.md, so this file is not needed for CSS generation.** |
+| [references/documentation-template.md](@sales-app-sales-app-extensibility-ref-documentation-template.mdc) | Writing the `docs/<ExtensionName>.md` file in Step 4 — the 9-section structure and markdown skeleton |
 
 ## Common failure modes
 
-- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
-- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
-- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
-- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
-- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
-- **Placing code outside packages/sales-app/src/** — Not included in build.
-- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
-- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
-- **Not presenting plan** — User may want a different approach. Always confirm.
-- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
-- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed. Always confirm both before Step 1.
+- **Not presenting plan** — User may want a different approach. Always confirm at Step 2 before generating code.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Load documentation-template.md for the required structure.
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
-- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
-- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
-- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
-- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
-- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
-- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
-- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
-- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
+- **Placing code outside packages/sales-app/src/** — Files outside this path are not included in the build.
+
+> Code-level violations (DOM APIs, Node imports, eval, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and caught during Step 3 validation. See [static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) and [design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc).
 
 ## Review checklist
 
+**Workflow gates**
 - [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
 - [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
 - [ ] Discovery completed and use case identified?
 - [ ] Execution plan approved by user?
 - [ ] Extension point is valid (from the 8-point reference)?
 - [ ] Hooks compatible with chosen extension point?
+- [ ] Documentation generated at `docs/<ExtensionName>.md` (9 sections, using documentation-template.md)?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+**TypeScript / runtime guards** (not caught by fsp-analyzer)
 - [ ] Component returns JSX.Element, never null?
 - [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
 - [ ] useCartItem().item checked for undefined?
-- [ ] No auth credentials exposed in frontend code?
-- [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
-- [ ] CSS file path matches component name?
-- [ ] Documentation generated at `docs/<ExtensionName>.md`?
-- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
-- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
-- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
-- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
-- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
-- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
-- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
-- [ ] No @import rules in CSS?
-- [ ] No position: fixed or z-index: 9999 in CSS?
-- [ ] @keyframes names prefixed with extension namespace?
-- [ ] No useLayoutEffect (use useEffect instead)?
-- [ ] No heavyweight library imports (lodash, moment)?
-- [ ] Components under 200 lines?
-- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
-- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
-- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
-- [ ] Build passes: `yarn fsp build {account} sales-app`?
-- [ ] Tested locally: `yarn fsp dev {account}`?
+
+> All other code-level rules (sandbox APIs, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and checked during Step 3. See [static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) and [design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc).
 
 ## Related skills
 

--- a/exports/cursor/sales-app-sales-app-extensibility.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility.mdc
@@ -60,7 +60,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
-| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 3 | Code Generation & Validation | Generate `Component.tsx` + `Component.css` (plain CSS, never `.module.css`) + `index.tsx` → validate |
 | 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
 | 5 | Local Testing | Provide dev commands and URLs |
 | 6 | Build & Deploy | Build command → deployment guide |
@@ -391,6 +391,32 @@ const fn = new Function('return 42');
 setTimeout('doSomething()', 1000);
 ```
 
+### Constraint: CSS files must use plain .css extension, never .module.css
+
+The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
+
+**Why this matters**
+A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
+
+**Detection**
+Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
+
+**Correct**
+
+```typescript
+import './CashbackWidget.css';
+// Use className strings directly
+<div className="container">
+```
+
+**Wrong**
+
+```typescript
+import styles from './CashbackWidget.module.css';
+// CSS modules object access
+<div className={styles.container}>
+```
+
 ### Constraint: CSS must use namespaced selectors — no global elements
 
 Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
@@ -404,7 +430,7 @@ Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@
 **Correct**
 
 ```css
-/* CSS Module — classes are auto-scoped by the bundler */
+/* Plain CSS — use namespace prefix to scope classes */
 .container { padding: 8px; }
 .title { font-size: 16px; }
 
@@ -463,9 +489,9 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](@sales-app-sales-app-extensibility-ref-discovery-and-use-cases.mdc) for detailed question flows and the API Documentation Ingestion section.
 
-**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+**Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -474,7 +500,7 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
 4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
 5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS module file name and summary of key classes.
+6. **Styling** — CSS file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
    - **Source documentation:** URL or file path of the original API documentation, if provided.
    - **Generated types:** list of TypeScript interfaces generated from the API documentation.
@@ -503,7 +529,7 @@ Template for the documentation file:
 <Describe the component tree, key props, and internal state.>
 
 ## Styling
-- **File:** `<ComponentName>.module.css`
+- **File:** `<ComponentName>.css`
 - <Summary of key CSS classes and design decisions.>
 
 ## API integration
@@ -530,7 +556,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](@sales-app-sales-app-extensibility-ref-discovery-and-use-cases.mdc) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](@sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.mdc) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |

--- a/exports/cursor/sales-app-sales-app-extensibility.mdc
+++ b/exports/cursor/sales-app-sales-app-extensibility.mdc
@@ -425,6 +425,36 @@ body { font-size: 14px; }
 @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
 ```
 
+### Constraint: CSS must follow Sales App Design Guidelines
+
+Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
+
+**Why this matters**
+Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
+
+**Detection**
+Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
+
+**Correct**
+
+```css
+.container {
+  --sa-color-primary: #157BF4;
+  --sa-color-text-primary: #1F1F1F;
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.title { color: var(--sa-color-text-primary); font-size: 16px; }
+.buttonPrimary { background-color: var(--sa-color-primary); }
+```
+
+**Wrong**
+
+```css
+.container { font-family: Arial; }
+.title { color: #1a1a1a; font-size: 15px; }
+.buttonPrimary { background-color: #0066cc; }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -435,7 +465,7 @@ body { font-size: 14px; }
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, and the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](@sales-app-sales-app-extensibility-ref-code-templates-and-patterns.mdc) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](@sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.mdc) for hook return types and TypeScript definitions, the [static analysis reference](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -504,6 +534,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/discovery-and-use-cases.md](@sales-app-sales-app-extensibility-ref-discovery-and-use-cases.mdc) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](@sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.mdc) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](@sales-app-sales-app-extensibility-ref-static-analysis-rules.mdc) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
+| [references/design-guidelines.md](@sales-app-sales-app-extensibility-ref-design-guidelines.mdc) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
 
 ## Common failure modes
 
@@ -525,6 +556,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
 - **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
 - **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
+- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
+- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
+- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
+- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
 
 ## Review checklist
 
@@ -555,6 +590,11 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] No useLayoutEffect (use useEffect instead)?
 - [ ] No heavyweight library imports (lodash, moment)?
 - [ ] Components under 200 lines?
+- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
+- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/kiro/steering/sales-app-all.md
+++ b/exports/kiro/steering/sales-app-all.md
@@ -49,7 +49,7 @@ Documentation: https://beta.fast.store/sales-app/setting-up
 
 ## Decision rules
 
-Follow the mandatory 6-step workflow in order. Do not skip steps.
+Follow the mandatory 7-step workflow (Steps 0–6) in order. Do not skip steps.
 
 | Step | Purpose | Gate |
 |------|---------|------|
@@ -177,55 +177,6 @@ const { item } = useCartItem();
 return <div>{item.name}</div>;
 ```
 
-### Constraint: Never expose authentication keys in frontend code
-
-API keys in `fetch` headers are visible in the browser network tab.
-
-**Why this matters**
-Leaked keys compromise the external service.
-
-**Detection**
-Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
-
-**Correct**
-
-```typescript
-const response = await fetch('/_v/my-api/data', {
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-**Wrong**
-
-```typescript
-const response = await fetch('https://api.example.com/data', {
-  headers: { 'x-api-key': 'sk-secret-key-12345' },
-});
-```
-
-### Constraint: IO Proxy must use relative paths only
-
-The Sales App internal proxy resolves the domain automatically.
-
-**Why this matters**
-A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
-
-**Detection**
-`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
-
-**Correct**
-
-```typescript
-await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
-```
-
-**Wrong**
-
-```typescript
-await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
-```
-
 ### Constraint: defineExtensions is required in index.tsx
 
 Entry point must use `defineExtensions` from `@vtex/sales-app`.
@@ -297,186 +248,6 @@ defineExtensions({ 'cart.cart-item.after': ItemWarranty });
 defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
 ```
 
-### Constraint: Always present execution plan and wait for approval
-
-Do not generate code until the user confirms the plan.
-
-**Why this matters**
-Generating without agreement wastes effort and may produce the wrong extension.
-
-**Detection**
-Jumping from discovery to code generation without presenting a plan.
-
-**Correct**
-Discovery → Requirements → Present plan → **User approves** → Generate code.
-
-**Wrong**
-Discovery → Generate code immediately.
-
-### Constraint: Never access DOM APIs directly
-
-Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
-
-**Why this matters**
-Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
-
-**Detection**
-Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
-
-**Correct**
-
-```typescript
-// Use React state, props, and Sales App hooks for data
-const { account } = useExtension();
-const cart = useCart();
-```
-
-**Wrong**
-
-```typescript
-const userId = localStorage.getItem('userId');
-const width = window.innerWidth;
-document.title = 'My Extension';
-```
-
-### Constraint: Never import restricted Node.js modules
-
-Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
-
-**Why this matters**
-Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
-
-**Detection**
-`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
-
-**Correct**
-
-```typescript
-import { useCart } from '@vtex/sales-app';
-import React, { useState, useEffect } from 'react';
-```
-
-**Wrong**
-
-```typescript
-import fs from 'fs';
-import crypto from 'crypto';
-```
-
-### Constraint: Never use eval or the Function constructor
-
-Arbitrary code execution is banned in the sandbox.
-
-**Why this matters**
-`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
-
-**Detection**
-Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
-
-**Correct**
-
-```typescript
-const result = computeValue(input); // deterministic logic only
-```
-
-**Wrong**
-
-```typescript
-eval('doSomething()');
-const fn = new Function('return 42');
-setTimeout('doSomething()', 1000);
-```
-
-### Constraint: CSS files must use plain .css extension, never .module.css
-
-The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
-
-**Why this matters**
-A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
-
-**Detection**
-Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
-
-**Correct**
-
-```typescript
-import './CashbackWidget.css';
-// Use className strings directly
-<div className="container">
-```
-
-**Wrong**
-
-```typescript
-import styles from './CashbackWidget.module.css';
-// CSS modules object access
-<div className={styles.container}>
-```
-
-### Constraint: CSS must use namespaced selectors — no global elements
-
-Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
-
-**Why this matters**
-Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
-
-**Detection**
-Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
-
-**Correct**
-
-```css
-/* Plain CSS — use namespace prefix to scope classes */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-
-@keyframes extension-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-```
-
-**Wrong**
-
-```css
-body { font-size: 14px; }
-* { box-sizing: border-box; }
-:root { --my-color: red; }
-@import './reset.css';
-.overlay { position: fixed; z-index: 9999; }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Constraint: CSS must follow Sales App Design Guidelines
-
-Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
-
-**Why this matters**
-Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
-
-**Detection**
-Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
-
-**Correct**
-
-```css
-.container {
-  --sa-color-primary: #157BF4;
-  --sa-color-text-primary: #1F1F1F;
-  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-}
-.title { color: var(--sa-color-text-primary); font-size: 16px; }
-.buttonPrimary { background-color: var(--sa-color-primary); }
-```
-
-**Wrong**
-
-```css
-.container { font-family: Arial; }
-.title { color: #1a1a1a; font-size: 15px; }
-.buttonPrimary { background-color: #0066cc; }
-```
-
 ## Preferred pattern
 
 ### Workflow overview
@@ -487,59 +258,17 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`.
 
-**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
+Required references for this step (load before generating):
+- [code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) — all component templates, the CSS template (with the full Sales App design system inlined: tokens, typography, spacing, responsive), the `index.tsx` template, type generation rules, and the custom fetch hook pattern.
+- [extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) — hook return types and TypeScript definitions.
+- [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`. Run these checks on all generated files.
+- [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) — load when the extension renders any UI text (sentence case rule) or uses icons (Phosphor Icons).
 
-1. **Extension name** — title matching the component name.
-2. **Overview** — one-paragraph summary of what the extension does and why it was built.
-3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
-4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
-5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS file name and summary of key classes.
-7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
-   - **Source documentation:** URL or file path of the original API documentation, if provided.
-   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
-   - Note which fields are optional (`?`) vs required per the documentation.
-8. **How to test** — dev server command and URL to reach the extension.
-9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Validate against the 12-point checklist in code-templates-and-patterns.md. Fix all violations before presenting code; surface warnings to the user.
 
-Template for the documentation file:
-
-````markdown
-# <ExtensionName>
-
-## Overview
-<One-paragraph description of the extension purpose and value.>
-
-## Extension point
-- **Point:** `<extension.point.name>`
-- **Rationale:** <Why this extension point was selected.>
-
-## Hooks used
-| Hook | Purpose |
-|------|---------|
-| `useCart` | <What data it provides here> |
-
-## Component structure
-<Describe the component tree, key props, and internal state.>
-
-## Styling
-- **File:** `<ComponentName>.css`
-- <Summary of key CSS classes and design decisions.>
-
-## API integration
-- **Endpoint:** `/_v/...`
-- **Auth strategy:** IO Proxy / Direct / None
-- **Request/Response:** <Brief shape description.>
-
-## How to test
-Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
-
-## Known constraints
-- <Guard or limitation 1>
-- <Guard or limitation 2>
-````
+**Step 4** — Generate `docs/<ExtensionName>.md` inside the Sales App package (create the `docs/` folder if needed). Load the [documentation template reference](sales-app-sales-app-extensibility-ref-documentation-template.md) for the required 9-section structure and the markdown skeleton to fill in.
 
 **Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md).
 
@@ -552,73 +281,47 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; **CSS template with the full Sales App design system inlined (tokens, typography, spacing, responsive)**; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
-| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Writing UI text (sentence case rule) or using icons (Phosphor Icons). **CSS-related design rules — tokens, typography, spacing, responsive — are inlined directly in the CSS template inside code-templates-and-patterns.md, so this file is not needed for CSS generation.** |
+| [references/documentation-template.md](sales-app-sales-app-extensibility-ref-documentation-template.md) | Writing the `docs/<ExtensionName>.md` file in Step 4 — the 9-section structure and markdown skeleton |
 
 ## Common failure modes
 
-- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
-- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
-- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
-- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
-- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
-- **Placing code outside packages/sales-app/src/** — Not included in build.
-- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
-- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
-- **Not presenting plan** — User may want a different approach. Always confirm.
-- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
-- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed. Always confirm both before Step 1.
+- **Not presenting plan** — User may want a different approach. Always confirm at Step 2 before generating code.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Load documentation-template.md for the required structure.
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
-- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
-- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
-- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
-- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
-- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
-- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
-- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
-- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
+- **Placing code outside packages/sales-app/src/** — Files outside this path are not included in the build.
+
+> Code-level violations (DOM APIs, Node imports, eval, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and caught during Step 3 validation. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Review checklist
 
+**Workflow gates**
 - [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
 - [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
 - [ ] Discovery completed and use case identified?
 - [ ] Execution plan approved by user?
 - [ ] Extension point is valid (from the 8-point reference)?
 - [ ] Hooks compatible with chosen extension point?
+- [ ] Documentation generated at `docs/<ExtensionName>.md` (9 sections, using documentation-template.md)?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+**TypeScript / runtime guards** (not caught by fsp-analyzer)
 - [ ] Component returns JSX.Element, never null?
 - [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
 - [ ] useCartItem().item checked for undefined?
-- [ ] No auth credentials exposed in frontend code?
-- [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
-- [ ] CSS file path matches component name?
-- [ ] Documentation generated at `docs/<ExtensionName>.md`?
-- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
-- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
-- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
-- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
-- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
-- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
-- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
-- [ ] No @import rules in CSS?
-- [ ] No position: fixed or z-index: 9999 in CSS?
-- [ ] @keyframes names prefixed with extension namespace?
-- [ ] No useLayoutEffect (use useEffect instead)?
-- [ ] No heavyweight library imports (lodash, moment)?
-- [ ] Components under 200 lines?
-- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
-- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
-- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
-- [ ] Build passes: `yarn fsp build {account} sales-app`?
-- [ ] Tested locally: `yarn fsp dev {account}`?
+
+> All other code-level rules (sandbox APIs, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and checked during Step 3. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Related skills
 

--- a/exports/kiro/steering/sales-app-all.md
+++ b/exports/kiro/steering/sales-app-all.md
@@ -421,6 +421,36 @@ body { font-size: 14px; }
 @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
 ```
 
+### Constraint: CSS must follow Sales App Design Guidelines
+
+Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
+
+**Why this matters**
+Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
+
+**Detection**
+Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
+
+**Correct**
+
+```css
+.container {
+  --sa-color-primary: #157BF4;
+  --sa-color-text-primary: #1F1F1F;
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.title { color: var(--sa-color-text-primary); font-size: 16px; }
+.buttonPrimary { background-color: var(--sa-color-primary); }
+```
+
+**Wrong**
+
+```css
+.container { font-family: Arial; }
+.title { color: #1a1a1a; font-size: 15px; }
+.buttonPrimary { background-color: #0066cc; }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -431,7 +461,7 @@ body { font-size: 14px; }
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -500,6 +530,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
 
 ## Common failure modes
 
@@ -521,6 +552,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
 - **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
 - **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
+- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
+- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
+- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
+- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
 
 ## Review checklist
 
@@ -551,6 +586,11 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] No useLayoutEffect (use useEffect instead)?
 - [ ] No heavyweight library imports (lodash, moment)?
 - [ ] Components under 200 lines?
+- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
+- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/kiro/steering/sales-app-all.md
+++ b/exports/kiro/steering/sales-app-all.md
@@ -56,7 +56,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
-| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 3 | Code Generation & Validation | Generate `Component.tsx` + `Component.css` (plain CSS, never `.module.css`) + `index.tsx` → validate |
 | 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
 | 5 | Local Testing | Provide dev commands and URLs |
 | 6 | Build & Deploy | Build command → deployment guide |
@@ -387,6 +387,32 @@ const fn = new Function('return 42');
 setTimeout('doSomething()', 1000);
 ```
 
+### Constraint: CSS files must use plain .css extension, never .module.css
+
+The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
+
+**Why this matters**
+A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
+
+**Detection**
+Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
+
+**Correct**
+
+```typescript
+import './CashbackWidget.css';
+// Use className strings directly
+<div className="container">
+```
+
+**Wrong**
+
+```typescript
+import styles from './CashbackWidget.module.css';
+// CSS modules object access
+<div className={styles.container}>
+```
+
 ### Constraint: CSS must use namespaced selectors — no global elements
 
 Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
@@ -400,7 +426,7 @@ Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@
 **Correct**
 
 ```css
-/* CSS Module — classes are auto-scoped by the bundler */
+/* Plain CSS — use namespace prefix to scope classes */
 .container { padding: 8px; }
 .title { font-size: 16px; }
 
@@ -459,9 +485,9 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
-**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+**Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -470,7 +496,7 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
 4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
 5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS module file name and summary of key classes.
+6. **Styling** — CSS file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
    - **Source documentation:** URL or file path of the original API documentation, if provided.
    - **Generated types:** list of TypeScript interfaces generated from the API documentation.
@@ -499,7 +525,7 @@ Template for the documentation file:
 <Describe the component tree, key props, and internal state.>
 
 ## Styling
-- **File:** `<ComponentName>.module.css`
+- **File:** `<ComponentName>.css`
 - <Summary of key CSS classes and design decisions.>
 
 ## API integration
@@ -526,7 +552,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |

--- a/exports/kiro/steering/sales-app-all.md
+++ b/exports/kiro/steering/sales-app-all.md
@@ -313,6 +313,114 @@ Discovery → Requirements → Present plan → **User approves** → Generate c
 **Wrong**
 Discovery → Generate code immediately.
 
+### Constraint: Never access DOM APIs directly
+
+Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
+
+**Why this matters**
+Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
+
+**Detection**
+Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
+
+**Correct**
+
+```typescript
+// Use React state, props, and Sales App hooks for data
+const { account } = useExtension();
+const cart = useCart();
+```
+
+**Wrong**
+
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+### Constraint: Never import restricted Node.js modules
+
+Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
+
+**Why this matters**
+Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
+
+**Detection**
+`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
+
+**Correct**
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+import React, { useState, useEffect } from 'react';
+```
+
+**Wrong**
+
+```typescript
+import fs from 'fs';
+import crypto from 'crypto';
+```
+
+### Constraint: Never use eval or the Function constructor
+
+Arbitrary code execution is banned in the sandbox.
+
+**Why this matters**
+`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
+
+**Detection**
+Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
+
+**Correct**
+
+```typescript
+const result = computeValue(input); // deterministic logic only
+```
+
+**Wrong**
+
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+### Constraint: CSS must use namespaced selectors — no global elements
+
+Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
+
+**Why this matters**
+Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
+
+**Detection**
+Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
+
+**Correct**
+
+```css
+/* CSS Module — classes are auto-scoped by the bundler */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+
+```css
+body { font-size: 14px; }
+* { box-sizing: border-box; }
+:root { --my-color: red; }
+@import './reset.css';
+.overlay { position: fixed; z-index: 9999; }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -323,7 +431,7 @@ Discovery → Generate code immediately.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -391,6 +499,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
 
 ## Common failure modes
 
@@ -408,6 +517,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
+- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
+- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
+- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
+- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
 
 ## Review checklist
 
@@ -428,6 +541,16 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
 - [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
+- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
+- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
+- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
+- [ ] No @import rules in CSS?
+- [ ] No position: fixed or z-index: 9999 in CSS?
+- [ ] @keyframes names prefixed with extension namespace?
+- [ ] No useLayoutEffect (use useEffect instead)?
+- [ ] No heavyweight library imports (lodash, moment)?
+- [ ] Components under 200 lines?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/kiro/steering/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -326,82 +326,115 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Module
 
-All extensions use CSS modules with Admin UI design tokens.
+All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Admin UI patterns.
+ * Design tokens follow Sales App Design Guidelines.
+ * Reference: references/design-guidelines.md
+ * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
-.container { padding: 16px; background-color: #ffffff; }
-.content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: #1a1a1a; margin: 0; }
-.subtitle { font-size: 14px; color: #666666; margin: 0; }
-.text { font-size: 14px; color: #333333; line-height: 1.5; }
+.container {
+  /* Sales App design tokens — do not replace with hardcoded hex values */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+  --sa-color-bg:        #FFFFFF;
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
-/* Loading State */
+  padding: 16px;
+  background-color: var(--sa-color-bg);
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.content { display: flex; flex-direction: column; gap: 12px; }
+.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
+.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
+.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+
+/* Loading state */
 .loading {
   display: flex; align-items: center; justify-content: center;
-  gap: 8px; padding: 24px; color: #666666;
+  gap: 8px; padding: 24px; color: var(--sa-color-text-secondary);
 }
 .spinner {
   width: 20px; height: 20px;
-  border: 2px solid #e0e0e0; border-top-color: #0066cc;
-  border-radius: 50%; animation: spin 1s linear infinite;
+  border: 2px solid var(--sa-color-border); border-top-color: var(--sa-color-primary);
+  border-radius: 50%; animation: ${COMPONENT_NAME}-spin 1s linear infinite;
 }
-@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes ${COMPONENT_NAME}-spin { to { transform: rotate(360deg); } }
 
-/* Error State */
+/* Error state */
 .error {
-  padding: 16px; background-color: #fff5f5;
-  border: 1px solid #ffcccc; border-radius: 8px;
-  color: #cc0000; font-size: 14px;
+  padding: 16px; background-color: var(--sa-color-error-bg);
+  border: 1px solid var(--sa-color-error-border); border-radius: 8px;
+  color: var(--sa-color-error-text); font-size: 14px;
 }
 
-/* Button Styles */
+/* Button styles */
 .button {
   display: inline-flex; align-items: center; justify-content: center;
-  padding: 10px 16px; font-size: 14px; font-weight: 500;
+  padding: 12px 16px; font-size: 14px; font-weight: 500;
   border: none; border-radius: 6px; cursor: pointer;
   transition: background-color 0.2s ease;
 }
-.buttonPrimary { background-color: #0066cc; color: #ffffff; }
-.buttonPrimary:hover { background-color: #0052a3; }
-.buttonSecondary { background-color: #f0f0f0; color: #333333; }
-.buttonSecondary:hover { background-color: #e0e0e0; }
+.buttonPrimary { background-color: var(--sa-color-primary); color: #FFFFFF; }
+.buttonPrimary:hover { background-color: var(--sa-color-primary-hover); }
+.buttonSecondary { background-color: var(--sa-color-bg-muted); color: var(--sa-color-text-tertiary); }
+.buttonSecondary:hover { background-color: var(--sa-color-border); }
 
-/* Card Styles */
+/* Card */
 .card {
-  padding: 16px; background-color: #f9f9f9;
-  border-radius: 8px; border: 1px solid #e0e0e0;
+  padding: 16px; background-color: var(--sa-color-bg-subtle);
+  border-radius: 8px; border: 1px solid var(--sa-color-border);
 }
 
-/* Badge Styles */
+/* Badges */
 .badge {
   display: inline-block; padding: 4px 8px;
   font-size: 12px; font-weight: 500; border-radius: 4px;
 }
-.badgeSuccess { background-color: #e6f4ea; color: #137333; }
-.badgeWarning { background-color: #fef7e0; color: #b06000; }
-.badgeInfo { background-color: #e8f0fe; color: #1a73e8; }
+.badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
+.badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
+.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
 
-/* Input Styles */
+/* Input */
 .input {
-  width: 100%; padding: 10px 12px; font-size: 14px;
-  border: 1px solid #d0d0d0; border-radius: 6px;
+  width: 100%; padding: 12px; font-size: 14px;
+  border: 1px solid var(--sa-color-border-input); border-radius: 6px;
   outline: none; transition: border-color 0.2s ease;
 }
-.input:focus { border-color: #0066cc; }
+.input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/Flex Helpers */
+/* Row/flex helpers */
 .row { display: flex; align-items: center; gap: 12px; }
 .spaceBetween { justify-content: space-between; }
 
-/* Price Display */
-.price { font-size: 18px; font-weight: 600; color: #1a1a1a; }
-.priceOld { font-size: 14px; color: #999999; text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: #137333; font-weight: 500; }
+/* Price display */
+.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+
+/* Responsive — Sales App breakpoints */
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
 ```
 
 ## index.tsx with defineExtensions
@@ -446,6 +479,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
+12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/kiro/steering/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -326,38 +326,73 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Stylesheet
 
-All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules). The full Sales App design system for CSS — tokens, typography, spacing grid, responsive breakpoints, and structure — is inlined below. **Use this template as the single source of truth for any CSS generation.**
 
 **CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
+
+### Design system rules baked into this template
+
+These rules apply to **every** generated extension CSS. The template below already complies — keep it that way.
+
+| Topic | Rule |
+|-------|------|
+| Tokens | All colors must reference `--sa-color-*` tokens declared on `.container`. **Never** use hardcoded hex values anywhere else. |
+| Font family | `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif` on `.container`, inherited by descendants. |
+| Font weights | Only Regular (400), Medium (500), Semibold (600), Bold (700). |
+| Font sizes (px) | Allowed scale only: **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**. Never `13`, `15`, `17`, etc. |
+| Typography roles | Section title = 16px/600 · Subtitle/label = 14px/500 · Body = 14px/400 · Caption = 12px/400 · Price = 18px/600. |
+| Spacing | Multiples of **4px** only (4, 8, 12, 16, 20, 24, 32, 40…). Never `10`, `14`, `18`, `22`. Applies to `padding`, `margin`, `gap`, `height`. |
+| Containment | No `position: fixed`, no `z-index: 9999`, no `:host`, no `:global`, no `@import`. `position: relative` and `sticky` are safe. |
+| Selectors | Use the unprefixed utility class names from this template (`.container`, `.content`, `.row`, `.title`, `.button`, etc.). The Sales App `fsp-analyzer` runs with `transformNonCompliant: true`, so unprefixed selectors emit a `CSS_TRANSFORMED` warning rather than a `CSS_NAMESPACE_REQUIRED` violation. Never use `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` — those are caught by `CSS_GLOBAL_SELECTOR` and remain blocking. |
+| Keyframes | Prefix with `${COMPONENT_NAME}-` (e.g., `${COMPONENT_NAME}-spin`). This raises a `CSS_TRANSFORMED` warning (build still passes) — use `sales-app-extension-${COMPONENT_NAME}-spin` if you want a clean run. |
+| `!important` | Never. |
+| Responsive | Use the breakpoint at `(max-width: 743px)` for mobile overrides. Sales App shell handles the rest. |
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Sales App Design Guidelines.
- * Reference: references/design-guidelines.md
+ * Sales App design system (tokens + typography + spacing + responsive) is fully inlined.
  * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
 .container {
-  /* Sales App design tokens — do not replace with hardcoded hex values */
+  /* === Sales App design tokens — single source of truth ===
+     Always declare these on .container. Reference via var(--sa-color-*) in all other rules.
+     Never use hardcoded hex values in CSS rules. */
+
+  /* Primary action */
   --sa-color-primary:       #157BF4;   /* Light Blue 800 */
   --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-  --sa-color-bg:        #FFFFFF;
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 — high emphasis */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600  — medium emphasis */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500  — low emphasis */
+  --sa-color-text-muted:     #999999;  /* Neutral 700  — disabled / hint */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
   --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
   --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
   --sa-color-border:       #E0E0E0;    /* Neutral 300 */
   --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
   --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
   --sa-color-error-border: #FFDFD9;    /* Red 200 */
   --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
   --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
   --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow / Orange scale) */
   --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
   --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
   --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
   --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
@@ -365,10 +400,16 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
   background-color: var(--sa-color-bg);
   font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
 }
+
+/* Layout */
 .content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
-.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
-.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+.row { display: flex; align-items: center; gap: 12px; }
+.spaceBetween { justify-content: space-between; }
+
+/* Typography — uses approved size scale (10, 12, 14, 16, 18, 20, 22, 24...) */
+.title    { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary);   margin: 0; }
+.subtitle { font-size: 14px; font-weight: 500; color: var(--sa-color-text-secondary); margin: 0; }
+.text     { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
 
 /* Loading state */
 .loading {
@@ -414,7 +455,7 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
 .badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
-.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
+.badgeInfo    { background-color: var(--sa-color-info-bg);    color: var(--sa-color-info-text); }
 
 /* Input */
 .input {
@@ -424,20 +465,33 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/flex helpers */
-.row { display: flex; align-items: center; gap: 12px; }
-.spaceBetween { justify-content: space-between; }
-
 /* Price display */
-.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
-.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+.price          { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld       { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount  { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
 
-/* Responsive — Sales App breakpoints */
+/* Responsive — Sales App breakpoints
+   Small (mobile)  320–743px  → margin: 24px, no column grid
+   Medium (tablet) 744–1279px → host gutters: 16px (no override needed)
+   Large (desktop) 1280–1919px → host gutters: 20px (no override needed)
+   Extra large     1920px+    → host gutters: 20px (no override needed) */
 @media (max-width: 743px) {
   .container { padding: 12px; margin: 0 24px; }
 }
 ```
+
+### CSS file structure
+
+Every extension CSS must follow this order:
+
+1. **Token declarations** — `--sa-color-*` on `.container`
+2. **Layout helpers** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography** — `.title`, `.subtitle`, `.text`
+4. **State** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive** — `@media` queries at the bottom
+
+For UX writing rules (sentence case) and iconography (Phosphor Icons) used in `.tsx`, see [design-guidelines.md](design-guidelines.md).
 
 ## index.tsx with defineExtensions
 
@@ -481,7 +535,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design system compliance** — the CSS file must follow the rules table at the top of the "CSS Stylesheet" section above: `--sa-color-*` custom properties declared on `.container` and used in all rules, `'VTEX Trust'` font family, allowed font sizes (10, 12, 14, 16, 18, 20, 22, 24, 28, 32…), 4px-multiple spacing, scoped selectors, and the responsive override at `(max-width: 743px)`. For UI text (sentence case) and icons (Phosphor), see [design-guidelines.md](design-guidelines.md).
 
 ## API Type Generation from Documentation
 

--- a/exports/kiro/steering/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -445,6 +445,7 @@ After generating code, validate for these issues:
 8. **API call handling** — loading state and error handling must be present for any `fetch()` call
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
+11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
 
 ## API Type Generation from Documentation
 

--- a/exports/kiro/steering/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md
@@ -324,9 +324,11 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 }
 ```
 
-## CSS Module
+## CSS Stylesheet
 
-All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+
+**CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
 
 ```css
 /**
@@ -479,7 +481,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/kiro/steering/sales-app-sales-app-extensibility-ref-design-guidelines.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility-ref-design-guidelines.md
@@ -194,7 +194,7 @@ Sales App extensions render within a host container that handles most layout res
 | Large (desktop) | 1280–1919px | Gutters: 20px |
 | Extra large (monitor) | 1920px+ | Gutters: 20px |
 
-Recommended mobile override (applied to the responsive section of the CSS module):
+Recommended mobile override (applied to the responsive section of the CSS file):
 
 ```css
 @media (max-width: 743px) {
@@ -204,9 +204,9 @@ Recommended mobile override (applied to the responsive section of the CSS module
 
 ---
 
-## 7. CSS Module Structure
+## 7. CSS File Structure
 
-Every extension CSS module must follow this structure:
+Every extension CSS file must follow this structure:
 
 1. **Token declarations** — CSS custom properties on `.container`
 2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`

--- a/exports/kiro/steering/sales-app-sales-app-extensibility-ref-design-guidelines.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility-ref-design-guidelines.md
@@ -1,0 +1,238 @@
+# Sales App Design Guidelines
+
+All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+
+---
+
+## 1. UX and Writing Rules
+
+Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+
+| Rule | Correct | Wrong |
+|------|---------|-------|
+| Sentence case | "Add to cart" | "ADD TO CART" |
+| Proper nouns | "VTEX account" | "vtex account" |
+| No all-caps | "Loyalty points" | "LOYALTY POINTS" |
+| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+
+These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
+
+---
+
+## 2. Design Tokens (CSS Custom Properties)
+
+Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
+
+```css
+.container {
+  /* Primary action */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow/Orange scale) */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
+}
+```
+
+### Token mapping reference
+
+| Semantic role | Token | Hex | Palette origin |
+|--------------|-------|-----|----------------|
+| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
+| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
+| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
+| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
+| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
+| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
+| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
+| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
+| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
+| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
+| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
+| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
+| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
+| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
+| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
+| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
+| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
+| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
+| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
+| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+
+---
+
+## 3. Typography
+
+### Typeface
+
+The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
+
+```css
+font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+```
+
+Set this on the root `.container` class so all descendant elements inherit it.
+
+### Weights
+
+Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
+
+### Allowed font sizes
+
+Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
+
+Do not use arbitrary sizes like 13px, 15px, or 17px.
+
+| Use case | Size | Weight |
+|----------|------|--------|
+| Section title | 16px | Semibold (600) |
+| Subtitle / label | 14px | Medium (500) |
+| Body text | 14px | Regular (400) |
+| Caption / hint | 12px | Regular (400) |
+| Price | 18px | Semibold (600) |
+
+---
+
+## 4. Iconography
+
+### Library
+
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Standard / default | 24px |
+| Compact / inline | 16px |
+| Large / featured | 32–48px |
+
+Always use sizes within the supported range: **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+
+### Installation
+
+```bash
+yarn add @phosphor-icons/react
+```
+
+### Usage example
+
+```typescript
+import { ShoppingCart, Star, Warning } from '@phosphor-icons/react';
+
+export function MyExtension(): JSX.Element {
+  return (
+    <div className="container">
+      <ShoppingCart size={24} />
+      <span>Cart items</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. Spacing and Baseline Grid
+
+All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+
+| Value | Baseline multiple |
+|-------|-----------------|
+| 4px | 1× |
+| 8px | 2× |
+| 12px | 3× |
+| 16px | 4× |
+| 20px | 5× |
+| 24px | 6× |
+| 32px | 8× |
+
+**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
+
+---
+
+## 6. Responsive Breakpoints
+
+Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
+
+| Breakpoint | Resolution range | Notes |
+|-----------|-----------------|-------|
+| Small (mobile) | 320–743px | Margin: 24px, no column grid |
+| Medium (tablet) | 744–1279px | Gutters: 16px |
+| Large (desktop) | 1280–1919px | Gutters: 20px |
+| Extra large (monitor) | 1920px+ | Gutters: 20px |
+
+Recommended mobile override (applied to the responsive section of the CSS module):
+
+```css
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
+```
+
+---
+
+## 7. CSS Module Structure
+
+Every extension CSS module must follow this structure:
+
+1. **Token declarations** — CSS custom properties on `.container`
+2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography classes** — `.title`, `.subtitle`, `.text`
+4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive overrides** — `@media` queries at the bottom
+
+### Critical CSS rules
+
+- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
+- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
+- No `@import`, `position: fixed`, or `z-index: 9999`.
+- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
+
+---
+
+## 8. Quick Compliance Checklist
+
+Before presenting generated CSS to the user, verify:
+
+- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
+- [ ] No hardcoded hex values outside the token declarations block?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
+- [ ] All spacing multiples of 4px?
+- [ ] All icons from Phosphor Icons?
+- [ ] All UI text in sentence case (no ALL-CAPS)?
+- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?

--- a/exports/kiro/steering/sales-app-sales-app-extensibility-ref-design-guidelines.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility-ref-design-guidelines.md
@@ -1,152 +1,55 @@
-# Sales App Design Guidelines
+# Sales App Design Guidelines (non-CSS)
 
-All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+This reference covers two topics that apply to **TSX content**, not CSS:
+
+1. **UX writing rules** — for any text rendered in JSX
+2. **Iconography** — when the extension uses icons
+
+> **For CSS:** all design tokens, typography scale, spacing grid, and responsive breakpoints are inlined directly in the CSS template at [code-templates-and-patterns.md](code-templates-and-patterns.md) §"CSS Stylesheet". That template is the single source of truth for any CSS generation. Do not invent or duplicate token values here.
 
 ---
 
-## 1. UX and Writing Rules
+## 1. UX Writing Rules
 
-Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+Apply to every string that appears in the UI (labels, buttons, messages, placeholders, alt text).
 
 | Rule | Correct | Wrong |
 |------|---------|-------|
 | Sentence case | "Add to cart" | "ADD TO CART" |
-| Proper nouns | "VTEX account" | "vtex account" |
+| Proper nouns capitalized | "VTEX account" | "vtex account" |
 | No all-caps | "Loyalty points" | "LOYALTY POINTS" |
-| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+| No system-style placeholders | "Your email" | "EMAIL ADDRESS" |
+| No CSS uppercase transforms | (omit `text-transform: uppercase`) | `text-transform: uppercase` |
 
-These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
-
----
-
-## 2. Design Tokens (CSS Custom Properties)
-
-Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
-
-```css
-.container {
-  /* Primary action */
-  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
-  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-
-  /* Text */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-
-  /* Backgrounds */
-  --sa-color-bg:        #FFFFFF;       /* Neutral White */
-  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
-  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
-
-  /* Borders */
-  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
-  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
-
-  /* Error (Red scale) */
-  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
-  --sa-color-error-border: #FFDFD9;    /* Red 200 */
-  --sa-color-error-text:   #EC3727;    /* Red 800 */
-
-  /* Success (Green scale) */
-  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
-  --sa-color-success-text: #01905F;    /* Green 800 */
-
-  /* Warning (Yellow/Orange scale) */
-  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
-  --sa-color-warning-text: #E57001;    /* Orange 700 */
-
-  /* Info (Light Blue scale) */
-  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
-  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
-}
-```
-
-### Token mapping reference
-
-| Semantic role | Token | Hex | Palette origin |
-|--------------|-------|-----|----------------|
-| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
-| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
-| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
-| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
-| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
-| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
-| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
-| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
-| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
-| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
-| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
-| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
-| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
-| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
-| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
-| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
-| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
-| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
-| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
-| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+These rules derive from Google Material Design and Apple Human Interface Guidelines, adopted by VTEX.
 
 ---
 
-## 3. Typography
-
-### Typeface
-
-The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
-
-```css
-font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-```
-
-Set this on the root `.container` class so all descendant elements inherit it.
-
-### Weights
-
-Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
-
-### Allowed font sizes
-
-Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
-
-Do not use arbitrary sizes like 13px, 15px, or 17px.
-
-| Use case | Size | Weight |
-|----------|------|--------|
-| Section title | 16px | Semibold (600) |
-| Subtitle / label | 14px | Medium (500) |
-| Body text | 14px | Regular (400) |
-| Caption / hint | 12px | Regular (400) |
-| Price | 18px | Semibold (600) |
-
----
-
-## 4. Iconography
+## 2. Iconography
 
 ### Library
 
-All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
-
-### Sizes
-
-| Usage | Size |
-|-------|------|
-| Standard / default | 24px |
-| Compact / inline | 16px |
-| Large / featured | 32–48px |
-
-Always use sizes within the supported range: **16px to 48px**.
-
-### Weights
-
-Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use Material Icons, Font Awesome, Heroicons, or any other library.
 
 ### Installation
 
 ```bash
 yarn add @phosphor-icons/react
 ```
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Compact / inline | 16px |
+| Standard / default | 24px |
+| Large / featured | 32–48px |
+
+Always use sizes within **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
 
 ### Usage example
 
@@ -165,74 +68,13 @@ export function MyExtension(): JSX.Element {
 
 ---
 
-## 5. Spacing and Baseline Grid
+## 3. Quick checklist
 
-All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+Before presenting generated `.tsx` to the user, verify:
 
-| Value | Baseline multiple |
-|-------|-----------------|
-| 4px | 1× |
-| 8px | 2× |
-| 12px | 3× |
-| 16px | 4× |
-| 20px | 5× |
-| 24px | 6× |
-| 32px | 8× |
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-style placeholders)?
+- [ ] All icons imported from `@phosphor-icons/react`?
+- [ ] Icon sizes between 16px and 48px (24px default)?
+- [ ] Icon weights consistent within the component?
 
-**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
-
----
-
-## 6. Responsive Breakpoints
-
-Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
-
-| Breakpoint | Resolution range | Notes |
-|-----------|-----------------|-------|
-| Small (mobile) | 320–743px | Margin: 24px, no column grid |
-| Medium (tablet) | 744–1279px | Gutters: 16px |
-| Large (desktop) | 1280–1919px | Gutters: 20px |
-| Extra large (monitor) | 1920px+ | Gutters: 20px |
-
-Recommended mobile override (applied to the responsive section of the CSS file):
-
-```css
-@media (max-width: 743px) {
-  .container { padding: 12px; margin: 0 24px; }
-}
-```
-
----
-
-## 7. CSS File Structure
-
-Every extension CSS file must follow this structure:
-
-1. **Token declarations** — CSS custom properties on `.container`
-2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
-3. **Typography classes** — `.title`, `.subtitle`, `.text`
-4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
-5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
-6. **Responsive overrides** — `@media` queries at the bottom
-
-### Critical CSS rules
-
-- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
-- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
-- No `@import`, `position: fixed`, or `z-index: 9999`.
-- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
-
----
-
-## 8. Quick Compliance Checklist
-
-Before presenting generated CSS to the user, verify:
-
-- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
-- [ ] No hardcoded hex values outside the token declarations block?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
-- [ ] All spacing multiples of 4px?
-- [ ] All icons from Phosphor Icons?
-- [ ] All UI text in sentence case (no ALL-CAPS)?
-- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?
+For CSS verification (tokens, fonts, spacing, responsive), see [code-templates-and-patterns.md](code-templates-and-patterns.md) §"Design system rules baked into this template".

--- a/exports/kiro/steering/sales-app-sales-app-extensibility-ref-documentation-template.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility-ref-documentation-template.md
@@ -1,0 +1,53 @@
+# Extension Documentation Template
+
+Generate `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist.
+
+The document must contain these 9 sections:
+
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+```markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+```

--- a/exports/kiro/steering/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
@@ -1,0 +1,908 @@
+# Static Analysis Rules (fsp-analyzer)
+
+Sales App extensions run inside a sandboxed environment enforced by `@vtex/fsp-analyzer`. These rules are checked at `preBuild` and `preDev` hook time. The AI must validate all generated code against these rules before presenting it to the user.
+
+Rule IDs match the `ViolationKind`, `ReactViolationKind`, `WarningKind`, and `ReactWarningKind` types from `@vtex/fsp-analyzer` so developers can cross-reference with real build output.
+
+---
+
+## How to apply these rules
+
+After generating a component, CSS file, and `index.tsx`, check each generated file against the **violation** rules (block generation — fix before presenting) and the **warning** rules (flag to the user with a suggestion). Do not present code that has unresolved violations.
+
+---
+
+## 1. Sandbox Security Rules
+
+Applied to `.ts` and `.tsx` files by `FastStoreSandboxAnalyzer`.
+
+### `RESTRICTED_API` — DOM API access banned
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted identifiers: `document`, `window`, `localStorage`, `sessionStorage`, `navigator`.
+
+**Detection:** Any use of these identifiers as a value (not as a type import).
+
+**Correct**
+```typescript
+// Use React state and props for data; use useExtension() for account context
+const { account } = useExtension();
+```
+
+**Wrong**
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+---
+
+### `VARIABLE_ALIASING` — Aliasing restricted APIs
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Assigning a restricted API to a variable to circumvent detection.
+
+**Detection:** `const x = document`, `const [w, d] = [window, document]`, or any destructuring that aliases a restricted API.
+
+**Correct**
+```typescript
+// Pass data via props or React context, not via aliased globals
+```
+
+**Wrong**
+```typescript
+const doc = document;
+const [w, d] = [window, document];
+doc.querySelector('.item');
+```
+
+---
+
+### `GLOBAL_MANIPULATION` — Global object manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted member expressions: `window.location`, `window.history`.
+
+**Detection:** Member expressions on `window` to access `location` or `history`.
+
+**Correct**
+```typescript
+// Navigation is managed by Sales App shell; do not manipulate location
+```
+
+**Wrong**
+```typescript
+window.location.href = '/new-path';
+window.location.reload();
+```
+
+---
+
+### `HISTORY_MANIPULATION` — Browser history manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `window.history.pushState`, `window.history.replaceState`, `history.pushState`, `history.replaceState`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Let the Sales App shell handle routing
+```
+
+**Wrong**
+```typescript
+history.pushState({}, '', '/cart');
+window.history.replaceState(null, '', '/pdp');
+```
+
+---
+
+### `DYNAMIC_SCRIPT_CREATION` — Dynamic script creation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `document.createElement`, `document.write`, `document.writeln`, `document.body.appendChild`, `document.head.appendChild`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Render UI via JSX; never inject scripts dynamically
+```
+
+**Wrong**
+```typescript
+const script = document.createElement('script');
+script.src = 'https://cdn.example.com/lib.js';
+document.body.appendChild(script);
+```
+
+---
+
+### `CODE_EXECUTION` — Arbitrary code execution
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `eval`, `Function` (as constructor), `setTimeout` (string form), `setInterval` (string form), `new Function`.
+
+**Detection:** Any call or instantiation of these identifiers.
+
+> **Note on `setTimeout`/`setInterval`:** These are restricted in the sandbox to prevent arbitrary code injection. Use `useEffect` with `AbortController` or cleanup functions for timing-based logic:
+
+**Correct**
+```typescript
+useEffect(() => {
+  const id = window.setTimeout(() => { /* logic */ }, 500);
+  return () => window.clearTimeout(id);
+}, []);
+// Note: even this should be reviewed; prefer event-driven patterns
+```
+
+**Wrong**
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+---
+
+### `RESTRICTED_IMPORT` — Restricted Node.js module imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted modules: `fs`, `path`, `child_process`, `crypto`.
+
+**Detection:** Any `import` statement importing from these module names.
+
+**Correct**
+```typescript
+// Extensions are browser-only React components; do not import Node.js modules
+import { useCart } from '@vtex/sales-app';
+```
+
+**Wrong**
+```typescript
+import fs from 'fs';
+import { resolve } from 'path';
+import crypto from 'crypto';
+```
+
+---
+
+### `RESTRICTED_IMPORT_SOURCE` — Direct node_modules path imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Import paths containing `node_modules/`.
+
+**Wrong**
+```typescript
+import something from 'node_modules/lodash/get';
+```
+
+---
+
+### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+
+**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+
+> **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
+
+**Correct**
+```typescript
+// Always use IO Proxy relative path
+const response = await fetch('/_v/my-loyalty-api/points', {
+  credentials: 'include',
+});
+```
+
+**Wrong**
+```typescript
+const response = await fetch('https://api.example.com/data');
+const xhr = new XMLHttpRequest();
+```
+
+---
+
+### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
+
+**Detection:** `fetch()` first argument literal containing one of these domains.
+
+**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
+
+---
+
+### `QUERY_SELECTOR_USAGE` — DOM query selectors
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Use React refs for direct DOM access when absolutely needed
+const ref = useRef<HTMLDivElement>(null);
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.my-class');
+document.getElementById('cart-container');
+```
+
+---
+
+### `STYLE_MANIPULATION` — Direct style manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
+
+**Detection:** Any member expression matching these patterns.
+
+**Correct**
+```typescript
+// Use CSS modules and conditional class application
+import styles from './MyExtension.module.css';
+
+return <div className={isActive ? styles.active : styles.inactive} />;
+```
+
+**Wrong**
+```typescript
+element.style.color = 'red';
+element.classList.add('active');
+element.setAttribute('style', 'display: none');
+```
+
+---
+
+### `INFINITE_LOOP` — Infinite loops
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+
+**Wrong**
+```typescript
+while (true) {
+  processItem();
+}
+```
+
+---
+
+### `MEMORY_LEAK` — Memory leak patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  window.addEventListener('resize', handler);
+  // Missing cleanup — memory leak
+}, []);
+```
+
+---
+
+### `EXCESSIVE_API_CALLS` — Excessive API call patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+
+**Wrong**
+```typescript
+// fetch inside render — fires on every re-render
+const data = await fetch('/_v/api/data');
+
+// fetch inside loop — excessive calls
+for (const item of items) {
+  await fetch(`/_v/api/item/${item.id}`);
+}
+```
+
+---
+
+### `LARGE_BUNDLE_SIZE_IMPACT` — Bundle size impacts
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:**
+- String literals longer than 1,000 characters
+- Object literals with more than 100 properties
+- Imports from heavyweight libraries: `lodash`, `moment`
+
+**Action:** Warn the user and suggest alternatives (`date-fns` instead of `moment`, native array methods instead of `lodash`).
+
+**Correct**
+```typescript
+import { format } from 'date-fns';
+const formattedDate = format(new Date(), 'yyyy-MM-dd');
+```
+
+**Wrong**
+```typescript
+import moment from 'moment';
+import _ from 'lodash';
+```
+
+---
+
+## 2. CSS Containment Rules
+
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+
+### `CSS_GLOBAL_SELECTOR` — Global element selectors
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
+
+**Detection:** Any CSS rule whose selector matches or contains these elements at the top level.
+
+**Correct**
+```css
+/* Scope all rules inside the extension container */
+.extension-container {
+  font-size: 14px;
+}
+
+.extension-container .title {
+  font-weight: bold;
+}
+```
+
+**Wrong**
+```css
+body {
+  font-size: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --my-color: red;
+}
+```
+
+---
+
+### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
+
+**Detection:** Any rule or declaration matching these patterns.
+
+> **Note on positioning:** `position: relative` and `position: sticky` within the extension container are generally safe. Avoid `fixed` and unbounded `absolute` that escape the extension boundary.
+
+**Correct**
+```css
+.extension-container {
+  position: relative; /* safe — contained */
+}
+```
+
+**Wrong**
+```css
+.overlay {
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+}
+
+:host {
+  display: block;
+}
+```
+
+---
+
+### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+
+**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+
+**Correct**
+```css
+/* CSS Module — all classes are auto-scoped */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+```css
+/* Plain CSS — must namespace manually */
+.extension-container { padding: 8px; }
+.extension-title { font-size: 16px; }
+```
+
+**Wrong**
+```css
+/* Plain CSS — no namespace — pollutes global styles */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+---
+
+### `CSS_GLOBAL_IMPORT` — CSS @import rules
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@import` pulls external stylesheets that affect global styles and bypass containment.
+
+**Detection:** Any `@import` at-rule anywhere in the CSS file.
+
+**Correct**
+```css
+/* Import a local CSS variable file via bundler config, not @import */
+```
+
+**Wrong**
+```css
+@import url('https://fonts.googleapis.com/css2?family=Roboto');
+@import './reset.css';
+```
+
+---
+
+### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+
+**Correct**
+```css
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+```css
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+---
+
+### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
+
+**Detection:** Declarations using restricted property names (e.g., properties that set global layout hints).
+
+**Action:** If detected, remove or scope the declaration appropriately.
+
+---
+
+### `CSS_RESTRICTED_VALUE` — Restricted CSS values
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
+
+**Detection:** `!important` in any declaration, or values targeting global layout tokens.
+
+**Correct**
+```css
+.extension-button {
+  color: var(--vtex-color-primary);
+}
+```
+
+**Wrong**
+```css
+.extension-button {
+  color: red !important;
+}
+```
+
+---
+
+## 3. React Performance Rules
+
+Applied to `.tsx` files by `ReactPerformanceAnalyzer`. Violations block presentation; warnings are flagged to the user.
+
+### `REACT_UNNECESSARY_RERENDER` — State update inside loop
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+State setter calls inside `for` or `while` loops trigger a re-render on every iteration.
+
+**Detection:** A `setState` / `set*` call whose parent node is a `for` or `while` statement.
+
+**Correct**
+```typescript
+// Compute derived value, then set once
+const updatedItems = items.map(transform);
+setItems(updatedItems);
+```
+
+**Wrong**
+```typescript
+for (const item of items) {
+  setCount((c) => c + 1); // re-renders on every iteration
+}
+```
+
+---
+
+### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
+
+**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
+
+**Correct**
+```typescript
+const filteredItems = useMemo(() => items.filter(isActive), [items]);
+
+return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
+  </ul>
+);
+```
+
+---
+
+### `REACT_ANONYMOUS_COMPONENT` — Anonymous (lowercase) component
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Components assigned to variables starting with lowercase are treated as HTML tags by React and cannot be used in JSX.
+
+**Detection:** Arrow function or function expression assigned to a variable that does not start with an uppercase letter.
+
+**Correct**
+```typescript
+export function LoyaltyPoints(): JSX.Element { ... }
+export const WarrantyBadge = (): JSX.Element => { ... };
+```
+
+**Wrong**
+```typescript
+const loyaltyPoints = (): JSX.Element => { ... };
+const warrantyBadge = function() { ... };
+```
+
+---
+
+### `REACT_DIRECT_DOM_MANIPULATION` — Direct DOM manipulation in React
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Bypasses the React virtual DOM and causes unpredictable behavior.
+
+**Detection:** Calls to `document.querySelector` or `document.getElementById` inside a React component.
+
+**Correct**
+```typescript
+const containerRef = useRef<HTMLDivElement>(null);
+// Access DOM via containerRef.current
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.cart-list');
+el.style.display = 'none'; // bypasses React
+```
+
+---
+
+### `REACT_LAYOUT_EFFECT_MISUSE` — useLayoutEffect usage
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`useLayoutEffect` blocks the browser paint and can cause performance issues in a sandboxed extension.
+
+**Detection:** Any call to `useLayoutEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  // DOM reading/writing after paint
+}, []);
+```
+
+**Wrong**
+```typescript
+useLayoutEffect(() => {
+  // blocks paint
+}, []);
+```
+
+---
+
+### `REACT_MISSING_DEPS` — Missing dependency array
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useEffect`, `useCallback`, or `useMemo` without a second argument re-runs on every render.
+
+**Detection:** A call to one of these hooks with fewer than 2 arguments, or with a non-array second argument.
+
+**Correct**
+```typescript
+useEffect(() => {
+  fetchData();
+}, [productId]); // explicit deps
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  fetchData(); // runs on every render
+});
+```
+
+---
+
+### `REACT_INLINE_FUNCTION` — Inline functions in JSX props
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Arrow functions defined directly in JSX attributes create a new function reference on every render, preventing child memoization.
+
+**Detection:** Function expression or arrow function expression whose parent is a JSX expression container or prop.
+
+**Correct**
+```typescript
+const handleClick = useCallback(() => {
+  doSomething();
+}, []);
+
+return <button onClick={handleClick}>Click</button>;
+```
+
+**Wrong**
+```typescript
+return <button onClick={() => doSomething()}>Click</button>;
+```
+
+---
+
+### `REACT_LARGE_COMPONENT` — Component over 200 lines
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Large components are harder to maintain and test. Threshold: **200 lines**.
+
+**Detection:** A function/arrow function with start/end line difference > 200.
+
+**Action:** Suggest splitting into smaller sub-components or extracting logic into custom hooks.
+
+---
+
+### `REACT_MANY_USESTATE` — More than 5 useState calls
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Many `useState` calls in a single component indicate complex local state. Threshold: **5 calls**.
+
+**Detection:** More than 5 calls to `useState` (or `React.useState`) within a single function component.
+
+**Action:** Suggest consolidating related state into a single `useState` with an object, or extracting to a custom hook.
+
+**Correct**
+```typescript
+const [formState, setFormState] = useState({
+  name: '',
+  email: '',
+  quantity: 1,
+});
+```
+
+**Wrong**
+```typescript
+const [name, setName] = useState('');
+const [email, setEmail] = useState('');
+const [quantity, setQuantity] = useState(1);
+const [loading, setLoading] = useState(false);
+const [error, setError] = useState<string | null>(null);
+const [submitted, setSubmitted] = useState(false); // 6th useState — flagged
+```
+
+---
+
+### `REACT_CONDITIONAL_HOOK` — Hook called conditionally
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a hook inside an `if`, `switch`, or ternary expression violates the Rules of Hooks.
+
+**Detection:** A hook call (useEffect, useState, useMemo, useCallback, useLayoutEffect) whose ancestor is an `IfStatement`, `SwitchStatement`, or `ConditionalExpression`.
+
+**Correct**
+```typescript
+const cart = useCart(); // always called unconditionally
+
+if (!cart) return <></>;
+```
+
+**Wrong**
+```typescript
+if (isEnabled) {
+  const cart = useCart(); // conditional hook call — violates Rules of Hooks
+}
+```
+
+---
+
+### `REACT_COMPLEX_JSX` — Deep JSX nesting
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Deep JSX trees are harder to read and may indicate a need to extract sub-components. Threshold: **5 levels deep**.
+
+**Detection:** A JSX element whose JSX child tree exceeds 5 levels of nesting.
+
+**Action:** Extract inner JSX into a named sub-component.
+
+---
+
+### `REACT_UNOPTIMIZED_LIST` — List rendering without key or large list
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Missing `key` props in list rendering causes React reconciliation issues. Lists over 50 items may need virtualization.
+
+**Detection:**
+- `map()` producing JSX without a `key` attribute on the root element
+- List size exceeding 50 items
+
+**Correct**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li key={item.id}>{item.name}</li>
+    ))}
+  </ul>
+);
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li>{item.name}</li> // missing key
+    ))}
+  </ul>
+);
+```
+
+---
+
+### `REACT_COMPLEX_STATE` — useState with complex object
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useState` initialized with an object having more than 5 properties suggests a need for `useReducer`. Threshold: **5 properties**.
+
+**Detection:** `useState(obj)` where `obj` is an object literal with > 5 properties.
+
+**Action:** Suggest converting to `useReducer` for complex state.
+
+---
+
+### `REACT_NESTED_UPDATE` — Nested state updates
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a state setter from within another state setter's callback can cause unexpected re-renders.
+
+**Detection:** A `set*` call whose ancestor is another `set*` call expression.
+
+---
+
+## Validation Output Format
+
+When reporting issues after code review, group by file and severity:
+
+```
+### Static Analysis Results
+
+**Violations (must fix before completing Step 3):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Fix: <suggested fix>
+
+**Warnings (review with user):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Suggestion: <improvement>
+
+✅ No violations found. N warnings flagged.
+```
+
+Do not proceed with Step 4 (Documentation) until all violations are resolved.

--- a/exports/kiro/steering/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
@@ -197,20 +197,33 @@ import something from 'node_modules/lodash/get';
 
 ---
 
+### `NON_APPROVED_PACKAGE` — Import from non-approved package
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Any import whose source starts with `@` or contains `/`, unless it is `react` or a `node_modules/` direct path. Fires for every `@vtex/*` scoped package and every relative import (`./foo`, `../bar`).
+
+> **Note:** This warning is noisy — it fires for all legitimate Sales App imports (`@vtex/sales-app`, `@phosphor-icons/react`, relative component paths). Do not surface to the user when the import is from `@vtex/*` or a relative path. Investigate only when the import is from an unexpected third-party package.
+
+**Detection:** `import { … } from 'source'` where `source.startsWith('@')` or `source.includes('/')`, and source is not `'react'` or a `node_modules/` path.
+
+---
+
 ### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+Two detection paths:
 
-**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+1. **Direct API use:** `fetch`, `XMLHttpRequest`, `script.src`, `link.href` used as member expressions.
+2. **Known CDN domains in string literal:** `fetch('https://cdn.jsdelivr.net/...')` or any URL containing `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`, `api.example.com`, or ending with `.js`.
 
 > **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
 
 **Correct**
 ```typescript
-// Always use IO Proxy relative path
 const response = await fetch('/_v/my-loyalty-api/points', {
   credentials: 'include',
 });
@@ -219,6 +232,7 @@ const response = await fetch('/_v/my-loyalty-api/points', {
 **Wrong**
 ```typescript
 const response = await fetch('https://api.example.com/data');
+const response = await fetch('https://cdn.jsdelivr.net/npm/lodash.js'); // CDN — also Violation
 const xhr = new XMLHttpRequest();
 ```
 
@@ -226,14 +240,14 @@ const xhr = new XMLHttpRequest();
 
 ### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
 
-**Severity:** Warning (flag)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. CDN domain fetches are actually reported as `EXTERNAL_RESOURCE_LOADING` (Violation, block) — not as this Warning. Treat any fetch to a CDN domain as a **build-blocking Violation**, not a soft warning.
+
+**Severity:** Warning (flag) — *see note above; actual enforcement is via `EXTERNAL_RESOURCE_LOADING`*  
 **Files:** `.ts`, `.tsx`
 
 Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
 
 **Detection:** `fetch()` first argument literal containing one of these domains.
-
-**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
 
 ---
 
@@ -244,7 +258,7 @@ Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.co
 
 Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
 
-**Detection:** Any call to these methods.
+**Detection:** Any call where the callee matches `document.querySelector`, `document.getElementById`, etc. (the variable must be literally named `document`). Calls via a ref object — e.g. `containerRef.current.querySelector(...)` — are **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
@@ -267,14 +281,14 @@ document.getElementById('cart-container');
 
 Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
 
-**Detection:** Any member expression matching these patterns.
+**Detection:** Matches only when the object is literally named `element` (e.g. `element.style`). Equivalent access through other variable names — e.g. `divRef.current.style`, `el.className` — is **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
-// Use plain CSS with namespaced class names
+// Use plain CSS classes from the component stylesheet
 import './MyExtension.css';
 
-return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
+return <div className={isActive ? 'active' : 'inactive'} />;
 ```
 
 **Wrong**
@@ -291,7 +305,7 @@ element.setAttribute('style', 'display: none');
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+**Detection:** `while(true)` or `do...while(true)` with literal `true` condition.
 
 **Wrong**
 ```typescript
@@ -302,9 +316,22 @@ while (true) {
 
 ---
 
+### `POTENTIAL_INFINITE_LOOP` — Incomplete for-loop
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `for` statement with no `update` expression AND no `test` expression (e.g. `for (let i = 0;;) { … }`).
+
+**Action:** Warn the user and ensure the loop has a proper termination condition.
+
+---
+
 ### `MEMORY_LEAK` — Memory leak patterns
 
-**Severity:** Violation (block)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. The active rule is `POTENTIAL_MEMORY_LEAK` (Warning) below. Event listeners without cleanup **will not block the build**, but remain a Hard Constraint — always add a cleanup return in `useEffect`.
+
+**Severity:** Violation (block) — *see note above; not currently enforced at build time*  
 **Files:** `.ts`, `.tsx`
 
 **Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
@@ -328,23 +355,58 @@ useEffect(() => {
 
 ---
 
+### `POTENTIAL_MEMORY_LEAK` — Likely memory leak patterns
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Three triggers:
+1. Any `addEventListener` call — the analyzer warns regardless of whether a corresponding `removeEventListener` exists in cleanup.
+2. Recursive function call where the callee name matches the parent `FunctionDeclaration` identifier.
+3. `Array.push` inside a `for` or `while` loop.
+
+**Action:** Verify the component has a proper cleanup return in `useEffect` for any event listener, and that recursive functions have a clear base case.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+---
+
 ### `EXCESSIVE_API_CALLS` — Excessive API call patterns
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+**Detection:** `fetch` or `XMLHttpRequest` calls whose parent is a `for` or `while` loop.
 
 **Wrong**
 ```typescript
-// fetch inside render — fires on every re-render
-const data = await fetch('/_v/api/data');
-
 // fetch inside loop — excessive calls
 for (const item of items) {
   await fetch(`/_v/api/item/${item.id}`);
 }
 ```
+
+---
+
+### `FREQUENT_API_CALLS` — API call outside loop / rapid setInterval
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Two triggers:
+1. `fetch` or `XMLHttpRequest` call **outside** a loop (i.e. anywhere else in the component). Fires for every fetch — ensure calls are wrapped in `useEffect` with proper deps and are rate-limited or cached.
+2. `setInterval` with a numeric delay argument below 1000 ms.
+
+> **Note:** Trigger 1 is intentionally broad — it flags every `fetch()` call as a reminder to verify it is not running unintentionally on every render. It does **not** mean every fetch is wrong. Only surface this to the user when the fetch is genuinely outside a `useEffect` or appears to run on each render.
+
+**Action:** Warn the user and suggest wrapping fetches in `useEffect`, using caching, or increasing the polling interval.
 
 ---
 
@@ -376,7 +438,25 @@ import _ from 'lodash';
 
 ## 2. CSS Containment Rules
 
-Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`.
+
+**Sales App analyzer configuration** (from `@vtex/sales-app` build/dev hook):
+
+```typescript
+cssOptions: {
+  allowedNamespaces: ['sales-app-extension-'],
+  defaultNamespace: 'sales-app-extension-',
+  transformNonCompliant: true,
+  overwriteTransformed: true,
+}
+```
+
+Two consequences for the rules below:
+
+1. The configured namespace is **`sales-app-extension-`**, not the analyzer's bare default of `extension-`. Any rule that talks about "the allowed namespace" means `sales-app-extension-` in this project.
+2. `transformNonCompliant: true` softens the namespace rules: when a selector or `@keyframes` name is not prefixed, the analyzer auto-rewrites it into a sibling `*.transformed.css` file and emits a `CSS_TRANSFORMED` **warning** instead of a `CSS_NAMESPACE_REQUIRED` / `CSS_GLOBAL_KEYFRAMES` **violation**. The original `.css` (and the `className` strings in JSX) are left untouched, so the build does not break. This is why the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) ships unprefixed selectors like `.container`, `.title`, `.row` — they are valid in this project.
+
+The other CSS rules (`CSS_GLOBAL_SELECTOR`, `CSS_CONTAINMENT_BREAKOUT`, `CSS_GLOBAL_IMPORT`, `CSS_RESTRICTED_PROPERTY`, `CSS_RESTRICTED_VALUE`, and the inline-style rules) are **not** softened by `transformNonCompliant` — they remain build-blocking violations.
 
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
@@ -389,12 +469,12 @@ Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#_
 
 **Correct**
 ```css
-/* Scope all rules inside the extension container */
-.extension-container {
+/* Scope rules inside the extension container — never target global elements */
+.container {
   font-size: 14px;
 }
 
-.extension-container .title {
+.container .title {
   font-weight: bold;
 }
 ```
@@ -429,7 +509,7 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 **Correct**
 ```css
-.extension-container {
+.container {
   position: relative; /* safe — contained */
 }
 ```
@@ -452,26 +532,27 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
+All CSS selectors should be scoped under an allowed namespace prefix. In the Sales App, that prefix is `sales-app-extension-`. Because the project sets `transformNonCompliant: true`, an unprefixed selector does **not** block the build: the analyzer rewrites it inside a sibling `Component.transformed.css` and emits a `CSS_TRANSFORMED` warning instead of `CSS_NAMESPACE_REQUIRED`. The original `Component.css` (which is what gets bundled) keeps the unprefixed class, so the JSX `className="container"` continues to match.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
+**Detection:** A selector that does not include any value from `allowedNamespaces` (substring check on `.namespace`, `#namespace`, or `[class*="namespace"]`).
 
-**Correct**
+**Correct (and matches the CSS template)**
 ```css
-/* Plain CSS — namespace all classes */
-.extension-container { padding: 8px; }
-.extension-title { font-size: 16px; }
-```
-
-**Wrong**
-```css
-/* Plain CSS — no namespace — pollutes global styles */
+/* Unprefixed top-level classes are accepted because transformNonCompliant=true. */
 .container { padding: 8px; }
-.title { font-size: 16px; }
+.title     { font-size: 16px; }
 ```
+
+**Also correct (explicit prefix, never warns)**
+```css
+.sales-app-extension-container { padding: 8px; }
+.sales-app-extension-title     { font-size: 16px; }
+```
+
+> Prefer the unprefixed form to match the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) and the JSX in the component templates. The `CSS_TRANSFORMED` warning that fires for these is informational only.
 
 ---
 
@@ -499,26 +580,27 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell. As with `CSS_NAMESPACE_REQUIRED`, `transformNonCompliant: true` rewrites the name in `*.transformed.css` and emits `CSS_TRANSFORMED` instead of blocking.
 
-**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix (`sales-app-extension-` in this project).
 
-**Correct**
+The CSS template prefixes keyframes with `${COMPONENT_NAME}-` (e.g. `LoyaltyPoints-spin`). That prefix does **not** start with `sales-app-extension-`, so it triggers a `CSS_TRANSFORMED` warning — the build still succeeds, but the transformed file will rename it to `sales-app-extension-LoyaltyPoints-spin`. Either form is acceptable.
+
+**Correct (no warning)**
 ```css
-@keyframes extension-fade-in {
+@keyframes sales-app-extension-fade-in {
   from { opacity: 0; }
   to   { opacity: 1; }
 }
 ```
 
-**Wrong**
+**Also correct (CSS_TRANSFORMED warning, build passes)**
 ```css
-@keyframes fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+@keyframes LoyaltyPoints-spin {
+  to { transform: rotate(360deg); }
 }
 ```
 
@@ -548,16 +630,59 @@ Certain CSS values (e.g., `!important`) override the cascade and break containme
 
 **Correct**
 ```css
-.extension-button {
-  color: var(--vtex-color-primary);
+.button {
+  color: var(--sa-color-primary);
 }
 ```
 
 **Wrong**
 ```css
-.extension-button {
+.button {
   color: red !important;
 }
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_PROPERTY` — Restricted property in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props in JSX may not use properties that affect layout or containment.
+
+Restricted properties: `position`, `z-index`, `top`, `left`, `right`, `bottom`, `all`, `contain`, `content`, `isolation`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted property names.
+
+**Correct**
+```typescript
+// Use CSS classes for layout properties
+return <div className="overlay" />;
+```
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed', top: 0 }} />;
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_VALUE` — Restricted value in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props may not use values that break containment or cascade.
+
+Restricted values: `fixed`, `absolute`, `!important`, `inherit`, `initial`, `unset`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted values.
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed' }} />;
+return <div style={{ display: 'inherit' }} />;
 ```
 
 ---
@@ -587,33 +712,6 @@ setItems(updatedItems);
 for (const item of items) {
   setCount((c) => c + 1); // re-renders on every iteration
 }
-```
-
----
-
-### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
-
-**Severity:** Violation (block)  
-**Files:** `.tsx`
-
-`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
-
-**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
-
-**Correct**
-```typescript
-const filteredItems = useMemo(() => items.filter(isActive), [items]);
-
-return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
-```
-
-**Wrong**
-```typescript
-return (
-  <ul>
-    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
-  </ul>
-);
 ```
 
 ---

--- a/exports/kiro/steering/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility-ref-static-analysis-rules.md
@@ -271,10 +271,10 @@ Restricted expressions: `element.style`, `element.className`, `element.classList
 
 **Correct**
 ```typescript
-// Use CSS modules and conditional class application
-import styles from './MyExtension.module.css';
+// Use plain CSS with namespaced class names
+import './MyExtension.css';
 
-return <div className={isActive ? styles.active : styles.inactive} />;
+return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
 ```
 
 **Wrong**
@@ -381,7 +381,7 @@ Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
 
@@ -419,7 +419,7 @@ body {
 ### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
 
@@ -453,21 +453,15 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
 
 **Correct**
 ```css
-/* CSS Module — all classes are auto-scoped */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-```
-
-```css
-/* Plain CSS — must namespace manually */
+/* Plain CSS — namespace all classes */
 .extension-container { padding: 8px; }
 .extension-title { font-size: 16px; }
 ```
@@ -484,7 +478,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_IMPORT` — CSS @import rules
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@import` pulls external stylesheets that affect global styles and bypass containment.
 
@@ -506,7 +500,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
 
@@ -533,7 +527,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
 
@@ -546,7 +540,7 @@ Certain properties affect layout or rendering globally and are restricted to pre
 ### `CSS_RESTRICTED_VALUE` — Restricted CSS values
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
 

--- a/exports/kiro/steering/sales-app-sales-app-extensibility.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility.md
@@ -58,7 +58,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
-| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 3 | Code Generation & Validation | Generate `Component.tsx` + `Component.css` (plain CSS, never `.module.css`) + `index.tsx` → validate |
 | 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
 | 5 | Local Testing | Provide dev commands and URLs |
 | 6 | Build & Deploy | Build command → deployment guide |
@@ -389,6 +389,32 @@ const fn = new Function('return 42');
 setTimeout('doSomething()', 1000);
 ```
 
+### Constraint: CSS files must use plain .css extension, never .module.css
+
+The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
+
+**Why this matters**
+A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
+
+**Detection**
+Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
+
+**Correct**
+
+```typescript
+import './CashbackWidget.css';
+// Use className strings directly
+<div className="container">
+```
+
+**Wrong**
+
+```typescript
+import styles from './CashbackWidget.module.css';
+// CSS modules object access
+<div className={styles.container}>
+```
+
 ### Constraint: CSS must use namespaced selectors — no global elements
 
 Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
@@ -402,7 +428,7 @@ Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@
 **Correct**
 
 ```css
-/* CSS Module — classes are auto-scoped by the bundler */
+/* Plain CSS — use namespace prefix to scope classes */
 .container { padding: 8px; }
 .title { font-size: 16px; }
 
@@ -461,9 +487,9 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
-**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+**Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -472,7 +498,7 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
 4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
 5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS module file name and summary of key classes.
+6. **Styling** — CSS file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
    - **Source documentation:** URL or file path of the original API documentation, if provided.
    - **Generated types:** list of TypeScript interfaces generated from the API documentation.
@@ -501,7 +527,7 @@ Template for the documentation file:
 <Describe the component tree, key props, and internal state.>
 
 ## Styling
-- **File:** `<ComponentName>.module.css`
+- **File:** `<ComponentName>.css`
 - <Summary of key CSS classes and design decisions.>
 
 ## API integration
@@ -528,7 +554,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |

--- a/exports/kiro/steering/sales-app-sales-app-extensibility.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility.md
@@ -423,6 +423,36 @@ body { font-size: 14px; }
 @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
 ```
 
+### Constraint: CSS must follow Sales App Design Guidelines
+
+Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
+
+**Why this matters**
+Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
+
+**Detection**
+Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
+
+**Correct**
+
+```css
+.container {
+  --sa-color-primary: #157BF4;
+  --sa-color-text-primary: #1F1F1F;
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.title { color: var(--sa-color-text-primary); font-size: 16px; }
+.buttonPrimary { background-color: var(--sa-color-primary); }
+```
+
+**Wrong**
+
+```css
+.container { font-family: Arial; }
+.title { color: #1a1a1a; font-size: 15px; }
+.buttonPrimary { background-color: #0066cc; }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -433,7 +463,7 @@ body { font-size: 14px; }
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -502,6 +532,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
 
 ## Common failure modes
 
@@ -523,6 +554,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
 - **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
 - **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
+- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
+- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
+- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
+- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
 
 ## Review checklist
 
@@ -553,6 +588,11 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] No useLayoutEffect (use useEffect instead)?
 - [ ] No heavyweight library imports (lodash, moment)?
 - [ ] Components under 200 lines?
+- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
+- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/kiro/steering/sales-app-sales-app-extensibility.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility.md
@@ -51,7 +51,7 @@ Documentation: https://beta.fast.store/sales-app/setting-up
 
 ## Decision rules
 
-Follow the mandatory 6-step workflow in order. Do not skip steps.
+Follow the mandatory 7-step workflow (Steps 0–6) in order. Do not skip steps.
 
 | Step | Purpose | Gate |
 |------|---------|------|
@@ -179,55 +179,6 @@ const { item } = useCartItem();
 return <div>{item.name}</div>;
 ```
 
-### Constraint: Never expose authentication keys in frontend code
-
-API keys in `fetch` headers are visible in the browser network tab.
-
-**Why this matters**
-Leaked keys compromise the external service.
-
-**Detection**
-Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
-
-**Correct**
-
-```typescript
-const response = await fetch('/_v/my-api/data', {
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-**Wrong**
-
-```typescript
-const response = await fetch('https://api.example.com/data', {
-  headers: { 'x-api-key': 'sk-secret-key-12345' },
-});
-```
-
-### Constraint: IO Proxy must use relative paths only
-
-The Sales App internal proxy resolves the domain automatically.
-
-**Why this matters**
-A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
-
-**Detection**
-`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
-
-**Correct**
-
-```typescript
-await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
-```
-
-**Wrong**
-
-```typescript
-await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
-```
-
 ### Constraint: defineExtensions is required in index.tsx
 
 Entry point must use `defineExtensions` from `@vtex/sales-app`.
@@ -299,186 +250,6 @@ defineExtensions({ 'cart.cart-item.after': ItemWarranty });
 defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
 ```
 
-### Constraint: Always present execution plan and wait for approval
-
-Do not generate code until the user confirms the plan.
-
-**Why this matters**
-Generating without agreement wastes effort and may produce the wrong extension.
-
-**Detection**
-Jumping from discovery to code generation without presenting a plan.
-
-**Correct**
-Discovery → Requirements → Present plan → **User approves** → Generate code.
-
-**Wrong**
-Discovery → Generate code immediately.
-
-### Constraint: Never access DOM APIs directly
-
-Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
-
-**Why this matters**
-Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
-
-**Detection**
-Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
-
-**Correct**
-
-```typescript
-// Use React state, props, and Sales App hooks for data
-const { account } = useExtension();
-const cart = useCart();
-```
-
-**Wrong**
-
-```typescript
-const userId = localStorage.getItem('userId');
-const width = window.innerWidth;
-document.title = 'My Extension';
-```
-
-### Constraint: Never import restricted Node.js modules
-
-Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
-
-**Why this matters**
-Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
-
-**Detection**
-`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
-
-**Correct**
-
-```typescript
-import { useCart } from '@vtex/sales-app';
-import React, { useState, useEffect } from 'react';
-```
-
-**Wrong**
-
-```typescript
-import fs from 'fs';
-import crypto from 'crypto';
-```
-
-### Constraint: Never use eval or the Function constructor
-
-Arbitrary code execution is banned in the sandbox.
-
-**Why this matters**
-`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
-
-**Detection**
-Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
-
-**Correct**
-
-```typescript
-const result = computeValue(input); // deterministic logic only
-```
-
-**Wrong**
-
-```typescript
-eval('doSomething()');
-const fn = new Function('return 42');
-setTimeout('doSomething()', 1000);
-```
-
-### Constraint: CSS files must use plain .css extension, never .module.css
-
-The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
-
-**Why this matters**
-A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
-
-**Detection**
-Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
-
-**Correct**
-
-```typescript
-import './CashbackWidget.css';
-// Use className strings directly
-<div className="container">
-```
-
-**Wrong**
-
-```typescript
-import styles from './CashbackWidget.module.css';
-// CSS modules object access
-<div className={styles.container}>
-```
-
-### Constraint: CSS must use namespaced selectors — no global elements
-
-Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
-
-**Why this matters**
-Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
-
-**Detection**
-Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
-
-**Correct**
-
-```css
-/* Plain CSS — use namespace prefix to scope classes */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-
-@keyframes extension-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-```
-
-**Wrong**
-
-```css
-body { font-size: 14px; }
-* { box-sizing: border-box; }
-:root { --my-color: red; }
-@import './reset.css';
-.overlay { position: fixed; z-index: 9999; }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Constraint: CSS must follow Sales App Design Guidelines
-
-Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
-
-**Why this matters**
-Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
-
-**Detection**
-Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
-
-**Correct**
-
-```css
-.container {
-  --sa-color-primary: #157BF4;
-  --sa-color-text-primary: #1F1F1F;
-  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-}
-.title { color: var(--sa-color-text-primary); font-size: 16px; }
-.buttonPrimary { background-color: var(--sa-color-primary); }
-```
-
-**Wrong**
-
-```css
-.container { font-family: Arial; }
-.title { color: #1a1a1a; font-size: 15px; }
-.buttonPrimary { background-color: #0066cc; }
-```
-
 ## Preferred pattern
 
 ### Workflow overview
@@ -489,59 +260,17 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](sales-app-sales-app-extensibility-ref-design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`.
 
-**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
+Required references for this step (load before generating):
+- [code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) — all component templates, the CSS template (with the full Sales App design system inlined: tokens, typography, spacing, responsive), the `index.tsx` template, type generation rules, and the custom fetch hook pattern.
+- [extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) — hook return types and TypeScript definitions.
+- [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`. Run these checks on all generated files.
+- [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) — load when the extension renders any UI text (sentence case rule) or uses icons (Phosphor Icons).
 
-1. **Extension name** — title matching the component name.
-2. **Overview** — one-paragraph summary of what the extension does and why it was built.
-3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
-4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
-5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS file name and summary of key classes.
-7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
-   - **Source documentation:** URL or file path of the original API documentation, if provided.
-   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
-   - Note which fields are optional (`?`) vs required per the documentation.
-8. **How to test** — dev server command and URL to reach the extension.
-9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Validate against the 12-point checklist in code-templates-and-patterns.md. Fix all violations before presenting code; surface warnings to the user.
 
-Template for the documentation file:
-
-````markdown
-# <ExtensionName>
-
-## Overview
-<One-paragraph description of the extension purpose and value.>
-
-## Extension point
-- **Point:** `<extension.point.name>`
-- **Rationale:** <Why this extension point was selected.>
-
-## Hooks used
-| Hook | Purpose |
-|------|---------|
-| `useCart` | <What data it provides here> |
-
-## Component structure
-<Describe the component tree, key props, and internal state.>
-
-## Styling
-- **File:** `<ComponentName>.css`
-- <Summary of key CSS classes and design decisions.>
-
-## API integration
-- **Endpoint:** `/_v/...`
-- **Auth strategy:** IO Proxy / Direct / None
-- **Request/Response:** <Brief shape description.>
-
-## How to test
-Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
-
-## Known constraints
-- <Guard or limitation 1>
-- <Guard or limitation 2>
-````
+**Step 4** — Generate `docs/<ExtensionName>.md` inside the Sales App package (create the `docs/` folder if needed). Load the [documentation template reference](sales-app-sales-app-extensibility-ref-documentation-template.md) for the required 9-section structure and the markdown skeleton to fill in.
 
 **Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md).
 
@@ -554,73 +283,47 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; **CSS template with the full Sales App design system inlined (tokens, typography, spacing, responsive)**; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
-| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
+| [references/design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md) | Writing UI text (sentence case rule) or using icons (Phosphor Icons). **CSS-related design rules — tokens, typography, spacing, responsive — are inlined directly in the CSS template inside code-templates-and-patterns.md, so this file is not needed for CSS generation.** |
+| [references/documentation-template.md](sales-app-sales-app-extensibility-ref-documentation-template.md) | Writing the `docs/<ExtensionName>.md` file in Step 4 — the 9-section structure and markdown skeleton |
 
 ## Common failure modes
 
-- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
-- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
-- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
-- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
-- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
-- **Placing code outside packages/sales-app/src/** — Not included in build.
-- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
-- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
-- **Not presenting plan** — User may want a different approach. Always confirm.
-- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
-- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed. Always confirm both before Step 1.
+- **Not presenting plan** — User may want a different approach. Always confirm at Step 2 before generating code.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Load documentation-template.md for the required structure.
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
-- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
-- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
-- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
-- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
-- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
-- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
-- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
-- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
+- **Placing code outside packages/sales-app/src/** — Files outside this path are not included in the build.
+
+> Code-level violations (DOM APIs, Node imports, eval, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and caught during Step 3 validation. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Review checklist
 
+**Workflow gates**
 - [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
 - [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
 - [ ] Discovery completed and use case identified?
 - [ ] Execution plan approved by user?
 - [ ] Extension point is valid (from the 8-point reference)?
 - [ ] Hooks compatible with chosen extension point?
+- [ ] Documentation generated at `docs/<ExtensionName>.md` (9 sections, using documentation-template.md)?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+**TypeScript / runtime guards** (not caught by fsp-analyzer)
 - [ ] Component returns JSX.Element, never null?
 - [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
 - [ ] useCartItem().item checked for undefined?
-- [ ] No auth credentials exposed in frontend code?
-- [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
-- [ ] CSS file path matches component name?
-- [ ] Documentation generated at `docs/<ExtensionName>.md`?
-- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
-- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
-- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
-- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
-- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
-- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
-- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
-- [ ] No @import rules in CSS?
-- [ ] No position: fixed or z-index: 9999 in CSS?
-- [ ] @keyframes names prefixed with extension namespace?
-- [ ] No useLayoutEffect (use useEffect instead)?
-- [ ] No heavyweight library imports (lodash, moment)?
-- [ ] Components under 200 lines?
-- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
-- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
-- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
-- [ ] Build passes: `yarn fsp build {account} sales-app`?
-- [ ] Tested locally: `yarn fsp dev {account}`?
+
+> All other code-level rules (sandbox APIs, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and checked during Step 3. See [static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) and [design-guidelines.md](sales-app-sales-app-extensibility-ref-design-guidelines.md).
 
 ## Related skills
 

--- a/exports/kiro/steering/sales-app-sales-app-extensibility.md
+++ b/exports/kiro/steering/sales-app-sales-app-extensibility.md
@@ -315,6 +315,114 @@ Discovery → Requirements → Present plan → **User approves** → Generate c
 **Wrong**
 Discovery → Generate code immediately.
 
+### Constraint: Never access DOM APIs directly
+
+Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
+
+**Why this matters**
+Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
+
+**Detection**
+Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
+
+**Correct**
+
+```typescript
+// Use React state, props, and Sales App hooks for data
+const { account } = useExtension();
+const cart = useCart();
+```
+
+**Wrong**
+
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+### Constraint: Never import restricted Node.js modules
+
+Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
+
+**Why this matters**
+Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
+
+**Detection**
+`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
+
+**Correct**
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+import React, { useState, useEffect } from 'react';
+```
+
+**Wrong**
+
+```typescript
+import fs from 'fs';
+import crypto from 'crypto';
+```
+
+### Constraint: Never use eval or the Function constructor
+
+Arbitrary code execution is banned in the sandbox.
+
+**Why this matters**
+`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
+
+**Detection**
+Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
+
+**Correct**
+
+```typescript
+const result = computeValue(input); // deterministic logic only
+```
+
+**Wrong**
+
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+### Constraint: CSS must use namespaced selectors — no global elements
+
+Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
+
+**Why this matters**
+Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
+
+**Detection**
+Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
+
+**Correct**
+
+```css
+/* CSS Module — classes are auto-scoped by the bundler */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+
+```css
+body { font-size: 14px; }
+* { box-sizing: border-box; }
+:root { --my-color: red; }
+@import './reset.css';
+.overlay { position: fixed; z-index: 9999; }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -325,7 +433,7 @@ Discovery → Generate code immediately.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](sales-app-sales-app-extensibility-ref-extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -393,6 +501,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/code-templates-and-patterns.md](sales-app-sales-app-extensibility-ref-code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](sales-app-sales-app-extensibility-ref-discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](sales-app-sales-app-extensibility-ref-local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/static-analysis-rules.md](sales-app-sales-app-extensibility-ref-static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
 
 ## Common failure modes
 
@@ -410,6 +519,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
+- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
+- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
+- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
+- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
 
 ## Review checklist
 
@@ -430,6 +543,16 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
 - [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
+- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
+- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
+- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
+- [ ] No @import rules in CSS?
+- [ ] No position: fixed or z-index: 9999 in CSS?
+- [ ] @keyframes names prefixed with extension namespace?
+- [ ] No useLayoutEffect (use useEffect instead)?
+- [ ] No heavyweight library imports (lodash, moment)?
+- [ ] Components under 200 lines?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/opencode/sales-app-extensibility/SKILL.md
+++ b/exports/opencode/sales-app-extensibility/SKILL.md
@@ -316,6 +316,114 @@ Discovery → Requirements → Present plan → **User approves** → Generate c
 **Wrong**
 Discovery → Generate code immediately.
 
+### Constraint: Never access DOM APIs directly
+
+Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
+
+**Why this matters**
+Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
+
+**Detection**
+Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
+
+**Correct**
+
+```typescript
+// Use React state, props, and Sales App hooks for data
+const { account } = useExtension();
+const cart = useCart();
+```
+
+**Wrong**
+
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+### Constraint: Never import restricted Node.js modules
+
+Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
+
+**Why this matters**
+Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
+
+**Detection**
+`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
+
+**Correct**
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+import React, { useState, useEffect } from 'react';
+```
+
+**Wrong**
+
+```typescript
+import fs from 'fs';
+import crypto from 'crypto';
+```
+
+### Constraint: Never use eval or the Function constructor
+
+Arbitrary code execution is banned in the sandbox.
+
+**Why this matters**
+`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
+
+**Detection**
+Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
+
+**Correct**
+
+```typescript
+const result = computeValue(input); // deterministic logic only
+```
+
+**Wrong**
+
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+### Constraint: CSS must use namespaced selectors — no global elements
+
+Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
+
+**Why this matters**
+Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
+
+**Detection**
+Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
+
+**Correct**
+
+```css
+/* CSS Module — classes are auto-scoped by the bundler */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+
+```css
+body { font-size: 14px; }
+* { box-sizing: border-box; }
+:root { --my-color: red; }
+@import './reset.css';
+.overlay { position: fixed; z-index: 9999; }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -326,7 +434,7 @@ Discovery → Generate code immediately.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -394,6 +502,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/static-analysis-rules.md](references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
 
 ## Common failure modes
 
@@ -411,6 +520,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
+- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
+- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
+- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
+- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
 
 ## Review checklist
 
@@ -431,6 +544,16 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
 - [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
+- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
+- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
+- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
+- [ ] No @import rules in CSS?
+- [ ] No position: fixed or z-index: 9999 in CSS?
+- [ ] @keyframes names prefixed with extension namespace?
+- [ ] No useLayoutEffect (use useEffect instead)?
+- [ ] No heavyweight library imports (lodash, moment)?
+- [ ] Components under 200 lines?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/opencode/sales-app-extensibility/SKILL.md
+++ b/exports/opencode/sales-app-extensibility/SKILL.md
@@ -52,7 +52,7 @@ Documentation: https://beta.fast.store/sales-app/setting-up
 
 ## Decision rules
 
-Follow the mandatory 6-step workflow in order. Do not skip steps.
+Follow the mandatory 7-step workflow (Steps 0–6) in order. Do not skip steps.
 
 | Step | Purpose | Gate |
 |------|---------|------|
@@ -180,55 +180,6 @@ const { item } = useCartItem();
 return <div>{item.name}</div>;
 ```
 
-### Constraint: Never expose authentication keys in frontend code
-
-API keys in `fetch` headers are visible in the browser network tab.
-
-**Why this matters**
-Leaked keys compromise the external service.
-
-**Detection**
-Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
-
-**Correct**
-
-```typescript
-const response = await fetch('/_v/my-api/data', {
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-**Wrong**
-
-```typescript
-const response = await fetch('https://api.example.com/data', {
-  headers: { 'x-api-key': 'sk-secret-key-12345' },
-});
-```
-
-### Constraint: IO Proxy must use relative paths only
-
-The Sales App internal proxy resolves the domain automatically.
-
-**Why this matters**
-A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
-
-**Detection**
-`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
-
-**Correct**
-
-```typescript
-await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
-```
-
-**Wrong**
-
-```typescript
-await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
-```
-
 ### Constraint: defineExtensions is required in index.tsx
 
 Entry point must use `defineExtensions` from `@vtex/sales-app`.
@@ -300,186 +251,6 @@ defineExtensions({ 'cart.cart-item.after': ItemWarranty });
 defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
 ```
 
-### Constraint: Always present execution plan and wait for approval
-
-Do not generate code until the user confirms the plan.
-
-**Why this matters**
-Generating without agreement wastes effort and may produce the wrong extension.
-
-**Detection**
-Jumping from discovery to code generation without presenting a plan.
-
-**Correct**
-Discovery → Requirements → Present plan → **User approves** → Generate code.
-
-**Wrong**
-Discovery → Generate code immediately.
-
-### Constraint: Never access DOM APIs directly
-
-Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
-
-**Why this matters**
-Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
-
-**Detection**
-Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
-
-**Correct**
-
-```typescript
-// Use React state, props, and Sales App hooks for data
-const { account } = useExtension();
-const cart = useCart();
-```
-
-**Wrong**
-
-```typescript
-const userId = localStorage.getItem('userId');
-const width = window.innerWidth;
-document.title = 'My Extension';
-```
-
-### Constraint: Never import restricted Node.js modules
-
-Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
-
-**Why this matters**
-Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
-
-**Detection**
-`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
-
-**Correct**
-
-```typescript
-import { useCart } from '@vtex/sales-app';
-import React, { useState, useEffect } from 'react';
-```
-
-**Wrong**
-
-```typescript
-import fs from 'fs';
-import crypto from 'crypto';
-```
-
-### Constraint: Never use eval or the Function constructor
-
-Arbitrary code execution is banned in the sandbox.
-
-**Why this matters**
-`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
-
-**Detection**
-Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
-
-**Correct**
-
-```typescript
-const result = computeValue(input); // deterministic logic only
-```
-
-**Wrong**
-
-```typescript
-eval('doSomething()');
-const fn = new Function('return 42');
-setTimeout('doSomething()', 1000);
-```
-
-### Constraint: CSS files must use plain .css extension, never .module.css
-
-The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
-
-**Why this matters**
-A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
-
-**Detection**
-Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
-
-**Correct**
-
-```typescript
-import './CashbackWidget.css';
-// Use className strings directly
-<div className="container">
-```
-
-**Wrong**
-
-```typescript
-import styles from './CashbackWidget.module.css';
-// CSS modules object access
-<div className={styles.container}>
-```
-
-### Constraint: CSS must use namespaced selectors — no global elements
-
-Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
-
-**Why this matters**
-Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
-
-**Detection**
-Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
-
-**Correct**
-
-```css
-/* Plain CSS — use namespace prefix to scope classes */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-
-@keyframes extension-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-```
-
-**Wrong**
-
-```css
-body { font-size: 14px; }
-* { box-sizing: border-box; }
-:root { --my-color: red; }
-@import './reset.css';
-.overlay { position: fixed; z-index: 9999; }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Constraint: CSS must follow Sales App Design Guidelines
-
-Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
-
-**Why this matters**
-Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
-
-**Detection**
-Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
-
-**Correct**
-
-```css
-.container {
-  --sa-color-primary: #157BF4;
-  --sa-color-text-primary: #1F1F1F;
-  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-}
-.title { color: var(--sa-color-text-primary); font-size: 16px; }
-.buttonPrimary { background-color: var(--sa-color-primary); }
-```
-
-**Wrong**
-
-```css
-.container { font-family: Arial; }
-.title { color: #1a1a1a; font-size: 15px; }
-.buttonPrimary { background-color: #0066cc; }
-```
-
 ## Preferred pattern
 
 ### Workflow overview
@@ -490,59 +261,17 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`.
 
-**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
+Required references for this step (load before generating):
+- [code-templates-and-patterns.md](references/code-templates-and-patterns.md) — all component templates, the CSS template (with the full Sales App design system inlined: tokens, typography, spacing, responsive), the `index.tsx` template, type generation rules, and the custom fetch hook pattern.
+- [extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) — hook return types and TypeScript definitions.
+- [static-analysis-rules.md](references/static-analysis-rules.md) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`. Run these checks on all generated files.
+- [design-guidelines.md](references/design-guidelines.md) — load when the extension renders any UI text (sentence case rule) or uses icons (Phosphor Icons).
 
-1. **Extension name** — title matching the component name.
-2. **Overview** — one-paragraph summary of what the extension does and why it was built.
-3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
-4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
-5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS file name and summary of key classes.
-7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
-   - **Source documentation:** URL or file path of the original API documentation, if provided.
-   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
-   - Note which fields are optional (`?`) vs required per the documentation.
-8. **How to test** — dev server command and URL to reach the extension.
-9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Validate against the 12-point checklist in code-templates-and-patterns.md. Fix all violations before presenting code; surface warnings to the user.
 
-Template for the documentation file:
-
-````markdown
-# <ExtensionName>
-
-## Overview
-<One-paragraph description of the extension purpose and value.>
-
-## Extension point
-- **Point:** `<extension.point.name>`
-- **Rationale:** <Why this extension point was selected.>
-
-## Hooks used
-| Hook | Purpose |
-|------|---------|
-| `useCart` | <What data it provides here> |
-
-## Component structure
-<Describe the component tree, key props, and internal state.>
-
-## Styling
-- **File:** `<ComponentName>.css`
-- <Summary of key CSS classes and design decisions.>
-
-## API integration
-- **Endpoint:** `/_v/...`
-- **Auth strategy:** IO Proxy / Direct / None
-- **Request/Response:** <Brief shape description.>
-
-## How to test
-Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
-
-## Known constraints
-- <Guard or limitation 1>
-- <Guard or limitation 2>
-````
+**Step 4** — Generate `docs/<ExtensionName>.md` inside the Sales App package (create the `docs/` folder if needed). Load the [documentation template reference](references/documentation-template.md) for the required 9-section structure and the markdown skeleton to fill in.
 
 **Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
@@ -555,73 +284,47 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; **CSS template with the full Sales App design system inlined (tokens, typography, spacing, responsive)**; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
-| [references/design-guidelines.md](references/design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
+| [references/design-guidelines.md](references/design-guidelines.md) | Writing UI text (sentence case rule) or using icons (Phosphor Icons). **CSS-related design rules — tokens, typography, spacing, responsive — are inlined directly in the CSS template inside code-templates-and-patterns.md, so this file is not needed for CSS generation.** |
+| [references/documentation-template.md](references/documentation-template.md) | Writing the `docs/<ExtensionName>.md` file in Step 4 — the 9-section structure and markdown skeleton |
 
 ## Common failure modes
 
-- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
-- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
-- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
-- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
-- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
-- **Placing code outside packages/sales-app/src/** — Not included in build.
-- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
-- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
-- **Not presenting plan** — User may want a different approach. Always confirm.
-- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
-- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed. Always confirm both before Step 1.
+- **Not presenting plan** — User may want a different approach. Always confirm at Step 2 before generating code.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Load documentation-template.md for the required structure.
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
-- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
-- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
-- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
-- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
-- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
-- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
-- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
-- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
+- **Placing code outside packages/sales-app/src/** — Files outside this path are not included in the build.
+
+> Code-level violations (DOM APIs, Node imports, eval, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and caught during Step 3 validation. See [static-analysis-rules.md](references/static-analysis-rules.md) and [design-guidelines.md](references/design-guidelines.md).
 
 ## Review checklist
 
+**Workflow gates**
 - [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
 - [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
 - [ ] Discovery completed and use case identified?
 - [ ] Execution plan approved by user?
 - [ ] Extension point is valid (from the 8-point reference)?
 - [ ] Hooks compatible with chosen extension point?
+- [ ] Documentation generated at `docs/<ExtensionName>.md` (9 sections, using documentation-template.md)?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+**TypeScript / runtime guards** (not caught by fsp-analyzer)
 - [ ] Component returns JSX.Element, never null?
 - [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
 - [ ] useCartItem().item checked for undefined?
-- [ ] No auth credentials exposed in frontend code?
-- [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
-- [ ] CSS file path matches component name?
-- [ ] Documentation generated at `docs/<ExtensionName>.md`?
-- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
-- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
-- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
-- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
-- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
-- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
-- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
-- [ ] No @import rules in CSS?
-- [ ] No position: fixed or z-index: 9999 in CSS?
-- [ ] @keyframes names prefixed with extension namespace?
-- [ ] No useLayoutEffect (use useEffect instead)?
-- [ ] No heavyweight library imports (lodash, moment)?
-- [ ] Components under 200 lines?
-- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
-- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
-- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
-- [ ] Build passes: `yarn fsp build {account} sales-app`?
-- [ ] Tested locally: `yarn fsp dev {account}`?
+
+> All other code-level rules (sandbox APIs, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and checked during Step 3. See [static-analysis-rules.md](references/static-analysis-rules.md) and [design-guidelines.md](references/design-guidelines.md).
 
 ## Related skills
 

--- a/exports/opencode/sales-app-extensibility/SKILL.md
+++ b/exports/opencode/sales-app-extensibility/SKILL.md
@@ -424,6 +424,36 @@ body { font-size: 14px; }
 @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
 ```
 
+### Constraint: CSS must follow Sales App Design Guidelines
+
+Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
+
+**Why this matters**
+Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
+
+**Detection**
+Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
+
+**Correct**
+
+```css
+.container {
+  --sa-color-primary: #157BF4;
+  --sa-color-text-primary: #1F1F1F;
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.title { color: var(--sa-color-text-primary); font-size: 16px; }
+.buttonPrimary { background-color: var(--sa-color-primary); }
+```
+
+**Wrong**
+
+```css
+.container { font-family: Arial; }
+.title { color: #1a1a1a; font-size: 15px; }
+.buttonPrimary { background-color: #0066cc; }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -434,7 +464,7 @@ body { font-size: 14px; }
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -503,6 +533,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
+| [references/design-guidelines.md](references/design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
 
 ## Common failure modes
 
@@ -524,6 +555,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
 - **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
 - **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
+- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
+- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
+- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
+- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
 
 ## Review checklist
 
@@ -554,6 +589,11 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] No useLayoutEffect (use useEffect instead)?
 - [ ] No heavyweight library imports (lodash, moment)?
 - [ ] Components under 200 lines?
+- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
+- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/exports/opencode/sales-app-extensibility/SKILL.md
+++ b/exports/opencode/sales-app-extensibility/SKILL.md
@@ -59,7 +59,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
-| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 3 | Code Generation & Validation | Generate `Component.tsx` + `Component.css` (plain CSS, never `.module.css`) + `index.tsx` → validate |
 | 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
 | 5 | Local Testing | Provide dev commands and URLs |
 | 6 | Build & Deploy | Build command → deployment guide |
@@ -390,6 +390,32 @@ const fn = new Function('return 42');
 setTimeout('doSomething()', 1000);
 ```
 
+### Constraint: CSS files must use plain .css extension, never .module.css
+
+The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
+
+**Why this matters**
+A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
+
+**Detection**
+Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
+
+**Correct**
+
+```typescript
+import './CashbackWidget.css';
+// Use className strings directly
+<div className="container">
+```
+
+**Wrong**
+
+```typescript
+import styles from './CashbackWidget.module.css';
+// CSS modules object access
+<div className={styles.container}>
+```
+
 ### Constraint: CSS must use namespaced selectors — no global elements
 
 Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
@@ -403,7 +429,7 @@ Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@
 **Correct**
 
 ```css
-/* CSS Module — classes are auto-scoped by the bundler */
+/* Plain CSS — use namespace prefix to scope classes */
 .container { padding: 8px; }
 .title { font-size: 16px; }
 
@@ -462,9 +488,9 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
-**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+**Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -473,7 +499,7 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
 4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
 5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS module file name and summary of key classes.
+6. **Styling** — CSS file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
    - **Source documentation:** URL or file path of the original API documentation, if provided.
    - **Generated types:** list of TypeScript interfaces generated from the API documentation.
@@ -502,7 +528,7 @@ Template for the documentation file:
 <Describe the component tree, key props, and internal state.>
 
 ## Styling
-- **File:** `<ComponentName>.module.css`
+- **File:** `<ComponentName>.css`
 - <Summary of key CSS classes and design decisions.>
 
 ## API integration
@@ -529,7 +555,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |

--- a/exports/opencode/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/exports/opencode/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -1,6 +1,6 @@
 ---
 name: sales-app-code-templates
-description: Code generation templates for Sales App extensions — simple, hook-based, API (no auth), IO Proxy (secure), Direct Auth (insecure), CSS module, and index.tsx with defineExtensions. Use when generating or scaffolding extension code.
+description: Code generation templates for Sales App extensions — simple, hook-based, API (no auth), IO Proxy (secure), Direct Auth (insecure), CSS stylesheet, and index.tsx with defineExtensions. Use when generating or scaffolding extension code.
 metadata:
   version: "1.0"
 ---
@@ -331,9 +331,11 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 }
 ```
 
-## CSS Module
+## CSS Stylesheet
 
-All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+
+**CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
 
 ```css
 /**
@@ -486,7 +488,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/opencode/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/exports/opencode/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -333,82 +333,115 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Module
 
-All extensions use CSS modules with Admin UI design tokens.
+All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Admin UI patterns.
+ * Design tokens follow Sales App Design Guidelines.
+ * Reference: references/design-guidelines.md
+ * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
-.container { padding: 16px; background-color: #ffffff; }
-.content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: #1a1a1a; margin: 0; }
-.subtitle { font-size: 14px; color: #666666; margin: 0; }
-.text { font-size: 14px; color: #333333; line-height: 1.5; }
+.container {
+  /* Sales App design tokens — do not replace with hardcoded hex values */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+  --sa-color-bg:        #FFFFFF;
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
-/* Loading State */
+  padding: 16px;
+  background-color: var(--sa-color-bg);
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.content { display: flex; flex-direction: column; gap: 12px; }
+.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
+.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
+.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+
+/* Loading state */
 .loading {
   display: flex; align-items: center; justify-content: center;
-  gap: 8px; padding: 24px; color: #666666;
+  gap: 8px; padding: 24px; color: var(--sa-color-text-secondary);
 }
 .spinner {
   width: 20px; height: 20px;
-  border: 2px solid #e0e0e0; border-top-color: #0066cc;
-  border-radius: 50%; animation: spin 1s linear infinite;
+  border: 2px solid var(--sa-color-border); border-top-color: var(--sa-color-primary);
+  border-radius: 50%; animation: ${COMPONENT_NAME}-spin 1s linear infinite;
 }
-@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes ${COMPONENT_NAME}-spin { to { transform: rotate(360deg); } }
 
-/* Error State */
+/* Error state */
 .error {
-  padding: 16px; background-color: #fff5f5;
-  border: 1px solid #ffcccc; border-radius: 8px;
-  color: #cc0000; font-size: 14px;
+  padding: 16px; background-color: var(--sa-color-error-bg);
+  border: 1px solid var(--sa-color-error-border); border-radius: 8px;
+  color: var(--sa-color-error-text); font-size: 14px;
 }
 
-/* Button Styles */
+/* Button styles */
 .button {
   display: inline-flex; align-items: center; justify-content: center;
-  padding: 10px 16px; font-size: 14px; font-weight: 500;
+  padding: 12px 16px; font-size: 14px; font-weight: 500;
   border: none; border-radius: 6px; cursor: pointer;
   transition: background-color 0.2s ease;
 }
-.buttonPrimary { background-color: #0066cc; color: #ffffff; }
-.buttonPrimary:hover { background-color: #0052a3; }
-.buttonSecondary { background-color: #f0f0f0; color: #333333; }
-.buttonSecondary:hover { background-color: #e0e0e0; }
+.buttonPrimary { background-color: var(--sa-color-primary); color: #FFFFFF; }
+.buttonPrimary:hover { background-color: var(--sa-color-primary-hover); }
+.buttonSecondary { background-color: var(--sa-color-bg-muted); color: var(--sa-color-text-tertiary); }
+.buttonSecondary:hover { background-color: var(--sa-color-border); }
 
-/* Card Styles */
+/* Card */
 .card {
-  padding: 16px; background-color: #f9f9f9;
-  border-radius: 8px; border: 1px solid #e0e0e0;
+  padding: 16px; background-color: var(--sa-color-bg-subtle);
+  border-radius: 8px; border: 1px solid var(--sa-color-border);
 }
 
-/* Badge Styles */
+/* Badges */
 .badge {
   display: inline-block; padding: 4px 8px;
   font-size: 12px; font-weight: 500; border-radius: 4px;
 }
-.badgeSuccess { background-color: #e6f4ea; color: #137333; }
-.badgeWarning { background-color: #fef7e0; color: #b06000; }
-.badgeInfo { background-color: #e8f0fe; color: #1a73e8; }
+.badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
+.badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
+.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
 
-/* Input Styles */
+/* Input */
 .input {
-  width: 100%; padding: 10px 12px; font-size: 14px;
-  border: 1px solid #d0d0d0; border-radius: 6px;
+  width: 100%; padding: 12px; font-size: 14px;
+  border: 1px solid var(--sa-color-border-input); border-radius: 6px;
   outline: none; transition: border-color 0.2s ease;
 }
-.input:focus { border-color: #0066cc; }
+.input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/Flex Helpers */
+/* Row/flex helpers */
 .row { display: flex; align-items: center; gap: 12px; }
 .spaceBetween { justify-content: space-between; }
 
-/* Price Display */
-.price { font-size: 18px; font-weight: 600; color: #1a1a1a; }
-.priceOld { font-size: 14px; color: #999999; text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: #137333; font-weight: 500; }
+/* Price display */
+.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+
+/* Responsive — Sales App breakpoints */
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
 ```
 
 ## index.tsx with defineExtensions
@@ -453,6 +486,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
+12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/exports/opencode/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/exports/opencode/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -452,6 +452,7 @@ After generating code, validate for these issues:
 8. **API call handling** — loading state and error handling must be present for any `fetch()` call
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
+11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
 
 ## API Type Generation from Documentation
 

--- a/exports/opencode/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/exports/opencode/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -333,38 +333,73 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Stylesheet
 
-All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules). The full Sales App design system for CSS — tokens, typography, spacing grid, responsive breakpoints, and structure — is inlined below. **Use this template as the single source of truth for any CSS generation.**
 
 **CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
+
+### Design system rules baked into this template
+
+These rules apply to **every** generated extension CSS. The template below already complies — keep it that way.
+
+| Topic | Rule |
+|-------|------|
+| Tokens | All colors must reference `--sa-color-*` tokens declared on `.container`. **Never** use hardcoded hex values anywhere else. |
+| Font family | `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif` on `.container`, inherited by descendants. |
+| Font weights | Only Regular (400), Medium (500), Semibold (600), Bold (700). |
+| Font sizes (px) | Allowed scale only: **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**. Never `13`, `15`, `17`, etc. |
+| Typography roles | Section title = 16px/600 · Subtitle/label = 14px/500 · Body = 14px/400 · Caption = 12px/400 · Price = 18px/600. |
+| Spacing | Multiples of **4px** only (4, 8, 12, 16, 20, 24, 32, 40…). Never `10`, `14`, `18`, `22`. Applies to `padding`, `margin`, `gap`, `height`. |
+| Containment | No `position: fixed`, no `z-index: 9999`, no `:host`, no `:global`, no `@import`. `position: relative` and `sticky` are safe. |
+| Selectors | Use the unprefixed utility class names from this template (`.container`, `.content`, `.row`, `.title`, `.button`, etc.). The Sales App `fsp-analyzer` runs with `transformNonCompliant: true`, so unprefixed selectors emit a `CSS_TRANSFORMED` warning rather than a `CSS_NAMESPACE_REQUIRED` violation. Never use `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` — those are caught by `CSS_GLOBAL_SELECTOR` and remain blocking. |
+| Keyframes | Prefix with `${COMPONENT_NAME}-` (e.g., `${COMPONENT_NAME}-spin`). This raises a `CSS_TRANSFORMED` warning (build still passes) — use `sales-app-extension-${COMPONENT_NAME}-spin` if you want a clean run. |
+| `!important` | Never. |
+| Responsive | Use the breakpoint at `(max-width: 743px)` for mobile overrides. Sales App shell handles the rest. |
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Sales App Design Guidelines.
- * Reference: references/design-guidelines.md
+ * Sales App design system (tokens + typography + spacing + responsive) is fully inlined.
  * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
 .container {
-  /* Sales App design tokens — do not replace with hardcoded hex values */
+  /* === Sales App design tokens — single source of truth ===
+     Always declare these on .container. Reference via var(--sa-color-*) in all other rules.
+     Never use hardcoded hex values in CSS rules. */
+
+  /* Primary action */
   --sa-color-primary:       #157BF4;   /* Light Blue 800 */
   --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-  --sa-color-bg:        #FFFFFF;
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 — high emphasis */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600  — medium emphasis */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500  — low emphasis */
+  --sa-color-text-muted:     #999999;  /* Neutral 700  — disabled / hint */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
   --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
   --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
   --sa-color-border:       #E0E0E0;    /* Neutral 300 */
   --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
   --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
   --sa-color-error-border: #FFDFD9;    /* Red 200 */
   --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
   --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
   --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow / Orange scale) */
   --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
   --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
   --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
   --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
@@ -372,10 +407,16 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
   background-color: var(--sa-color-bg);
   font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
 }
+
+/* Layout */
 .content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
-.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
-.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+.row { display: flex; align-items: center; gap: 12px; }
+.spaceBetween { justify-content: space-between; }
+
+/* Typography — uses approved size scale (10, 12, 14, 16, 18, 20, 22, 24...) */
+.title    { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary);   margin: 0; }
+.subtitle { font-size: 14px; font-weight: 500; color: var(--sa-color-text-secondary); margin: 0; }
+.text     { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
 
 /* Loading state */
 .loading {
@@ -421,7 +462,7 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
 .badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
-.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
+.badgeInfo    { background-color: var(--sa-color-info-bg);    color: var(--sa-color-info-text); }
 
 /* Input */
 .input {
@@ -431,20 +472,33 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/flex helpers */
-.row { display: flex; align-items: center; gap: 12px; }
-.spaceBetween { justify-content: space-between; }
-
 /* Price display */
-.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
-.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+.price          { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld       { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount  { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
 
-/* Responsive — Sales App breakpoints */
+/* Responsive — Sales App breakpoints
+   Small (mobile)  320–743px  → margin: 24px, no column grid
+   Medium (tablet) 744–1279px → host gutters: 16px (no override needed)
+   Large (desktop) 1280–1919px → host gutters: 20px (no override needed)
+   Extra large     1920px+    → host gutters: 20px (no override needed) */
 @media (max-width: 743px) {
   .container { padding: 12px; margin: 0 24px; }
 }
 ```
+
+### CSS file structure
+
+Every extension CSS must follow this order:
+
+1. **Token declarations** — `--sa-color-*` on `.container`
+2. **Layout helpers** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography** — `.title`, `.subtitle`, `.text`
+4. **State** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive** — `@media` queries at the bottom
+
+For UX writing rules (sentence case) and iconography (Phosphor Icons) used in `.tsx`, see [design-guidelines.md](design-guidelines.md).
 
 ## index.tsx with defineExtensions
 
@@ -488,7 +542,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design system compliance** — the CSS file must follow the rules table at the top of the "CSS Stylesheet" section above: `--sa-color-*` custom properties declared on `.container` and used in all rules, `'VTEX Trust'` font family, allowed font sizes (10, 12, 14, 16, 18, 20, 22, 24, 28, 32…), 4px-multiple spacing, scoped selectors, and the responsive override at `(max-width: 743px)`. For UI text (sentence case) and icons (Phosphor), see [design-guidelines.md](design-guidelines.md).
 
 ## API Type Generation from Documentation
 

--- a/exports/opencode/sales-app-extensibility/references/design-guidelines.md
+++ b/exports/opencode/sales-app-extensibility/references/design-guidelines.md
@@ -1,0 +1,245 @@
+---
+name: sales-app-design-guidelines
+description: Design tokens, typography, iconography, color palette, UX writing rules, and responsive breakpoints for Sales App extensions. Load when generating CSS, choosing colors, typography, or icons for any extension component.
+metadata:
+  version: "1.0"
+---
+
+# Sales App Design Guidelines
+
+All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+
+---
+
+## 1. UX and Writing Rules
+
+Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+
+| Rule | Correct | Wrong |
+|------|---------|-------|
+| Sentence case | "Add to cart" | "ADD TO CART" |
+| Proper nouns | "VTEX account" | "vtex account" |
+| No all-caps | "Loyalty points" | "LOYALTY POINTS" |
+| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+
+These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
+
+---
+
+## 2. Design Tokens (CSS Custom Properties)
+
+Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
+
+```css
+.container {
+  /* Primary action */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow/Orange scale) */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
+}
+```
+
+### Token mapping reference
+
+| Semantic role | Token | Hex | Palette origin |
+|--------------|-------|-----|----------------|
+| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
+| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
+| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
+| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
+| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
+| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
+| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
+| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
+| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
+| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
+| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
+| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
+| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
+| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
+| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
+| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
+| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
+| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
+| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
+| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+
+---
+
+## 3. Typography
+
+### Typeface
+
+The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
+
+```css
+font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+```
+
+Set this on the root `.container` class so all descendant elements inherit it.
+
+### Weights
+
+Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
+
+### Allowed font sizes
+
+Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
+
+Do not use arbitrary sizes like 13px, 15px, or 17px.
+
+| Use case | Size | Weight |
+|----------|------|--------|
+| Section title | 16px | Semibold (600) |
+| Subtitle / label | 14px | Medium (500) |
+| Body text | 14px | Regular (400) |
+| Caption / hint | 12px | Regular (400) |
+| Price | 18px | Semibold (600) |
+
+---
+
+## 4. Iconography
+
+### Library
+
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Standard / default | 24px |
+| Compact / inline | 16px |
+| Large / featured | 32–48px |
+
+Always use sizes within the supported range: **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+
+### Installation
+
+```bash
+yarn add @phosphor-icons/react
+```
+
+### Usage example
+
+```typescript
+import { ShoppingCart, Star, Warning } from '@phosphor-icons/react';
+
+export function MyExtension(): JSX.Element {
+  return (
+    <div className="container">
+      <ShoppingCart size={24} />
+      <span>Cart items</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. Spacing and Baseline Grid
+
+All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+
+| Value | Baseline multiple |
+|-------|-----------------|
+| 4px | 1× |
+| 8px | 2× |
+| 12px | 3× |
+| 16px | 4× |
+| 20px | 5× |
+| 24px | 6× |
+| 32px | 8× |
+
+**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
+
+---
+
+## 6. Responsive Breakpoints
+
+Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
+
+| Breakpoint | Resolution range | Notes |
+|-----------|-----------------|-------|
+| Small (mobile) | 320–743px | Margin: 24px, no column grid |
+| Medium (tablet) | 744–1279px | Gutters: 16px |
+| Large (desktop) | 1280–1919px | Gutters: 20px |
+| Extra large (monitor) | 1920px+ | Gutters: 20px |
+
+Recommended mobile override (applied to the responsive section of the CSS module):
+
+```css
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
+```
+
+---
+
+## 7. CSS Module Structure
+
+Every extension CSS module must follow this structure:
+
+1. **Token declarations** — CSS custom properties on `.container`
+2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography classes** — `.title`, `.subtitle`, `.text`
+4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive overrides** — `@media` queries at the bottom
+
+### Critical CSS rules
+
+- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
+- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
+- No `@import`, `position: fixed`, or `z-index: 9999`.
+- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
+
+---
+
+## 8. Quick Compliance Checklist
+
+Before presenting generated CSS to the user, verify:
+
+- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
+- [ ] No hardcoded hex values outside the token declarations block?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
+- [ ] All spacing multiples of 4px?
+- [ ] All icons from Phosphor Icons?
+- [ ] All UI text in sentence case (no ALL-CAPS)?
+- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?

--- a/exports/opencode/sales-app-extensibility/references/design-guidelines.md
+++ b/exports/opencode/sales-app-extensibility/references/design-guidelines.md
@@ -1,159 +1,62 @@
 ---
 name: sales-app-design-guidelines
-description: Design tokens, typography, iconography, color palette, UX writing rules, and responsive breakpoints for Sales App extensions. Load when generating CSS, choosing colors, typography, or icons for any extension component.
+description: UX writing rules (sentence case) and Phosphor Icons usage for Sales App extensions. Load when writing JSX text content or when an extension needs icons. CSS-related design rules (tokens, typography, spacing, responsive) are inlined directly in the CSS template — see code-templates-and-patterns.md.
 metadata:
-  version: "1.0"
+  version: "2.0"
 ---
 
-# Sales App Design Guidelines
+# Sales App Design Guidelines (non-CSS)
 
-All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+This reference covers two topics that apply to **TSX content**, not CSS:
+
+1. **UX writing rules** — for any text rendered in JSX
+2. **Iconography** — when the extension uses icons
+
+> **For CSS:** all design tokens, typography scale, spacing grid, and responsive breakpoints are inlined directly in the CSS template at [code-templates-and-patterns.md](code-templates-and-patterns.md) §"CSS Stylesheet". That template is the single source of truth for any CSS generation. Do not invent or duplicate token values here.
 
 ---
 
-## 1. UX and Writing Rules
+## 1. UX Writing Rules
 
-Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+Apply to every string that appears in the UI (labels, buttons, messages, placeholders, alt text).
 
 | Rule | Correct | Wrong |
 |------|---------|-------|
 | Sentence case | "Add to cart" | "ADD TO CART" |
-| Proper nouns | "VTEX account" | "vtex account" |
+| Proper nouns capitalized | "VTEX account" | "vtex account" |
 | No all-caps | "Loyalty points" | "LOYALTY POINTS" |
-| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+| No system-style placeholders | "Your email" | "EMAIL ADDRESS" |
+| No CSS uppercase transforms | (omit `text-transform: uppercase`) | `text-transform: uppercase` |
 
-These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
-
----
-
-## 2. Design Tokens (CSS Custom Properties)
-
-Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
-
-```css
-.container {
-  /* Primary action */
-  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
-  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-
-  /* Text */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-
-  /* Backgrounds */
-  --sa-color-bg:        #FFFFFF;       /* Neutral White */
-  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
-  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
-
-  /* Borders */
-  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
-  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
-
-  /* Error (Red scale) */
-  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
-  --sa-color-error-border: #FFDFD9;    /* Red 200 */
-  --sa-color-error-text:   #EC3727;    /* Red 800 */
-
-  /* Success (Green scale) */
-  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
-  --sa-color-success-text: #01905F;    /* Green 800 */
-
-  /* Warning (Yellow/Orange scale) */
-  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
-  --sa-color-warning-text: #E57001;    /* Orange 700 */
-
-  /* Info (Light Blue scale) */
-  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
-  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
-}
-```
-
-### Token mapping reference
-
-| Semantic role | Token | Hex | Palette origin |
-|--------------|-------|-----|----------------|
-| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
-| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
-| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
-| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
-| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
-| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
-| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
-| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
-| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
-| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
-| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
-| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
-| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
-| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
-| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
-| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
-| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
-| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
-| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
-| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+These rules derive from Google Material Design and Apple Human Interface Guidelines, adopted by VTEX.
 
 ---
 
-## 3. Typography
-
-### Typeface
-
-The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
-
-```css
-font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-```
-
-Set this on the root `.container` class so all descendant elements inherit it.
-
-### Weights
-
-Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
-
-### Allowed font sizes
-
-Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
-
-Do not use arbitrary sizes like 13px, 15px, or 17px.
-
-| Use case | Size | Weight |
-|----------|------|--------|
-| Section title | 16px | Semibold (600) |
-| Subtitle / label | 14px | Medium (500) |
-| Body text | 14px | Regular (400) |
-| Caption / hint | 12px | Regular (400) |
-| Price | 18px | Semibold (600) |
-
----
-
-## 4. Iconography
+## 2. Iconography
 
 ### Library
 
-All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
-
-### Sizes
-
-| Usage | Size |
-|-------|------|
-| Standard / default | 24px |
-| Compact / inline | 16px |
-| Large / featured | 32–48px |
-
-Always use sizes within the supported range: **16px to 48px**.
-
-### Weights
-
-Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use Material Icons, Font Awesome, Heroicons, or any other library.
 
 ### Installation
 
 ```bash
 yarn add @phosphor-icons/react
 ```
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Compact / inline | 16px |
+| Standard / default | 24px |
+| Large / featured | 32–48px |
+
+Always use sizes within **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
 
 ### Usage example
 
@@ -172,74 +75,13 @@ export function MyExtension(): JSX.Element {
 
 ---
 
-## 5. Spacing and Baseline Grid
+## 3. Quick checklist
 
-All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+Before presenting generated `.tsx` to the user, verify:
 
-| Value | Baseline multiple |
-|-------|-----------------|
-| 4px | 1× |
-| 8px | 2× |
-| 12px | 3× |
-| 16px | 4× |
-| 20px | 5× |
-| 24px | 6× |
-| 32px | 8× |
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-style placeholders)?
+- [ ] All icons imported from `@phosphor-icons/react`?
+- [ ] Icon sizes between 16px and 48px (24px default)?
+- [ ] Icon weights consistent within the component?
 
-**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
-
----
-
-## 6. Responsive Breakpoints
-
-Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
-
-| Breakpoint | Resolution range | Notes |
-|-----------|-----------------|-------|
-| Small (mobile) | 320–743px | Margin: 24px, no column grid |
-| Medium (tablet) | 744–1279px | Gutters: 16px |
-| Large (desktop) | 1280–1919px | Gutters: 20px |
-| Extra large (monitor) | 1920px+ | Gutters: 20px |
-
-Recommended mobile override (applied to the responsive section of the CSS file):
-
-```css
-@media (max-width: 743px) {
-  .container { padding: 12px; margin: 0 24px; }
-}
-```
-
----
-
-## 7. CSS File Structure
-
-Every extension CSS file must follow this structure:
-
-1. **Token declarations** — CSS custom properties on `.container`
-2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
-3. **Typography classes** — `.title`, `.subtitle`, `.text`
-4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
-5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
-6. **Responsive overrides** — `@media` queries at the bottom
-
-### Critical CSS rules
-
-- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
-- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
-- No `@import`, `position: fixed`, or `z-index: 9999`.
-- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
-
----
-
-## 8. Quick Compliance Checklist
-
-Before presenting generated CSS to the user, verify:
-
-- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
-- [ ] No hardcoded hex values outside the token declarations block?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
-- [ ] All spacing multiples of 4px?
-- [ ] All icons from Phosphor Icons?
-- [ ] All UI text in sentence case (no ALL-CAPS)?
-- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?
+For CSS verification (tokens, fonts, spacing, responsive), see [code-templates-and-patterns.md](code-templates-and-patterns.md) §"Design system rules baked into this template".

--- a/exports/opencode/sales-app-extensibility/references/design-guidelines.md
+++ b/exports/opencode/sales-app-extensibility/references/design-guidelines.md
@@ -201,7 +201,7 @@ Sales App extensions render within a host container that handles most layout res
 | Large (desktop) | 1280–1919px | Gutters: 20px |
 | Extra large (monitor) | 1920px+ | Gutters: 20px |
 
-Recommended mobile override (applied to the responsive section of the CSS module):
+Recommended mobile override (applied to the responsive section of the CSS file):
 
 ```css
 @media (max-width: 743px) {
@@ -211,9 +211,9 @@ Recommended mobile override (applied to the responsive section of the CSS module
 
 ---
 
-## 7. CSS Module Structure
+## 7. CSS File Structure
 
-Every extension CSS module must follow this structure:
+Every extension CSS file must follow this structure:
 
 1. **Token declarations** — CSS custom properties on `.container`
 2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`

--- a/exports/opencode/sales-app-extensibility/references/documentation-template.md
+++ b/exports/opencode/sales-app-extensibility/references/documentation-template.md
@@ -1,0 +1,60 @@
+---
+name: sales-app-documentation-template
+description: Markdown template for the docs/<ExtensionName>.md file generated in Step 4. Load when writing extension documentation to ensure all required sections are covered.
+metadata:
+  version: "1.0"
+---
+
+# Extension Documentation Template
+
+Generate `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist.
+
+The document must contain these 9 sections:
+
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+```markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+```

--- a/exports/opencode/sales-app-extensibility/references/static-analysis-rules.md
+++ b/exports/opencode/sales-app-extensibility/references/static-analysis-rules.md
@@ -1,0 +1,915 @@
+---
+name: sales-app-static-analysis-rules
+description: fsp-analyzer rule catalog for Sales App extension validation. Load during Step 3 (Code Generation & Validation) to check generated TypeScript/CSS against sandbox security, CSS containment, and React performance rules enforced at build time.
+metadata:
+  version: "1.0"
+---
+
+# Static Analysis Rules (fsp-analyzer)
+
+Sales App extensions run inside a sandboxed environment enforced by `@vtex/fsp-analyzer`. These rules are checked at `preBuild` and `preDev` hook time. The AI must validate all generated code against these rules before presenting it to the user.
+
+Rule IDs match the `ViolationKind`, `ReactViolationKind`, `WarningKind`, and `ReactWarningKind` types from `@vtex/fsp-analyzer` so developers can cross-reference with real build output.
+
+---
+
+## How to apply these rules
+
+After generating a component, CSS file, and `index.tsx`, check each generated file against the **violation** rules (block generation — fix before presenting) and the **warning** rules (flag to the user with a suggestion). Do not present code that has unresolved violations.
+
+---
+
+## 1. Sandbox Security Rules
+
+Applied to `.ts` and `.tsx` files by `FastStoreSandboxAnalyzer`.
+
+### `RESTRICTED_API` — DOM API access banned
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted identifiers: `document`, `window`, `localStorage`, `sessionStorage`, `navigator`.
+
+**Detection:** Any use of these identifiers as a value (not as a type import).
+
+**Correct**
+```typescript
+// Use React state and props for data; use useExtension() for account context
+const { account } = useExtension();
+```
+
+**Wrong**
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+---
+
+### `VARIABLE_ALIASING` — Aliasing restricted APIs
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Assigning a restricted API to a variable to circumvent detection.
+
+**Detection:** `const x = document`, `const [w, d] = [window, document]`, or any destructuring that aliases a restricted API.
+
+**Correct**
+```typescript
+// Pass data via props or React context, not via aliased globals
+```
+
+**Wrong**
+```typescript
+const doc = document;
+const [w, d] = [window, document];
+doc.querySelector('.item');
+```
+
+---
+
+### `GLOBAL_MANIPULATION` — Global object manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted member expressions: `window.location`, `window.history`.
+
+**Detection:** Member expressions on `window` to access `location` or `history`.
+
+**Correct**
+```typescript
+// Navigation is managed by Sales App shell; do not manipulate location
+```
+
+**Wrong**
+```typescript
+window.location.href = '/new-path';
+window.location.reload();
+```
+
+---
+
+### `HISTORY_MANIPULATION` — Browser history manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `window.history.pushState`, `window.history.replaceState`, `history.pushState`, `history.replaceState`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Let the Sales App shell handle routing
+```
+
+**Wrong**
+```typescript
+history.pushState({}, '', '/cart');
+window.history.replaceState(null, '', '/pdp');
+```
+
+---
+
+### `DYNAMIC_SCRIPT_CREATION` — Dynamic script creation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `document.createElement`, `document.write`, `document.writeln`, `document.body.appendChild`, `document.head.appendChild`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Render UI via JSX; never inject scripts dynamically
+```
+
+**Wrong**
+```typescript
+const script = document.createElement('script');
+script.src = 'https://cdn.example.com/lib.js';
+document.body.appendChild(script);
+```
+
+---
+
+### `CODE_EXECUTION` — Arbitrary code execution
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `eval`, `Function` (as constructor), `setTimeout` (string form), `setInterval` (string form), `new Function`.
+
+**Detection:** Any call or instantiation of these identifiers.
+
+> **Note on `setTimeout`/`setInterval`:** These are restricted in the sandbox to prevent arbitrary code injection. Use `useEffect` with `AbortController` or cleanup functions for timing-based logic:
+
+**Correct**
+```typescript
+useEffect(() => {
+  const id = window.setTimeout(() => { /* logic */ }, 500);
+  return () => window.clearTimeout(id);
+}, []);
+// Note: even this should be reviewed; prefer event-driven patterns
+```
+
+**Wrong**
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+---
+
+### `RESTRICTED_IMPORT` — Restricted Node.js module imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted modules: `fs`, `path`, `child_process`, `crypto`.
+
+**Detection:** Any `import` statement importing from these module names.
+
+**Correct**
+```typescript
+// Extensions are browser-only React components; do not import Node.js modules
+import { useCart } from '@vtex/sales-app';
+```
+
+**Wrong**
+```typescript
+import fs from 'fs';
+import { resolve } from 'path';
+import crypto from 'crypto';
+```
+
+---
+
+### `RESTRICTED_IMPORT_SOURCE` — Direct node_modules path imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Import paths containing `node_modules/`.
+
+**Wrong**
+```typescript
+import something from 'node_modules/lodash/get';
+```
+
+---
+
+### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+
+**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+
+> **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
+
+**Correct**
+```typescript
+// Always use IO Proxy relative path
+const response = await fetch('/_v/my-loyalty-api/points', {
+  credentials: 'include',
+});
+```
+
+**Wrong**
+```typescript
+const response = await fetch('https://api.example.com/data');
+const xhr = new XMLHttpRequest();
+```
+
+---
+
+### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
+
+**Detection:** `fetch()` first argument literal containing one of these domains.
+
+**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
+
+---
+
+### `QUERY_SELECTOR_USAGE` — DOM query selectors
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Use React refs for direct DOM access when absolutely needed
+const ref = useRef<HTMLDivElement>(null);
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.my-class');
+document.getElementById('cart-container');
+```
+
+---
+
+### `STYLE_MANIPULATION` — Direct style manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
+
+**Detection:** Any member expression matching these patterns.
+
+**Correct**
+```typescript
+// Use CSS modules and conditional class application
+import styles from './MyExtension.module.css';
+
+return <div className={isActive ? styles.active : styles.inactive} />;
+```
+
+**Wrong**
+```typescript
+element.style.color = 'red';
+element.classList.add('active');
+element.setAttribute('style', 'display: none');
+```
+
+---
+
+### `INFINITE_LOOP` — Infinite loops
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+
+**Wrong**
+```typescript
+while (true) {
+  processItem();
+}
+```
+
+---
+
+### `MEMORY_LEAK` — Memory leak patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  window.addEventListener('resize', handler);
+  // Missing cleanup — memory leak
+}, []);
+```
+
+---
+
+### `EXCESSIVE_API_CALLS` — Excessive API call patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+
+**Wrong**
+```typescript
+// fetch inside render — fires on every re-render
+const data = await fetch('/_v/api/data');
+
+// fetch inside loop — excessive calls
+for (const item of items) {
+  await fetch(`/_v/api/item/${item.id}`);
+}
+```
+
+---
+
+### `LARGE_BUNDLE_SIZE_IMPACT` — Bundle size impacts
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:**
+- String literals longer than 1,000 characters
+- Object literals with more than 100 properties
+- Imports from heavyweight libraries: `lodash`, `moment`
+
+**Action:** Warn the user and suggest alternatives (`date-fns` instead of `moment`, native array methods instead of `lodash`).
+
+**Correct**
+```typescript
+import { format } from 'date-fns';
+const formattedDate = format(new Date(), 'yyyy-MM-dd');
+```
+
+**Wrong**
+```typescript
+import moment from 'moment';
+import _ from 'lodash';
+```
+
+---
+
+## 2. CSS Containment Rules
+
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+
+### `CSS_GLOBAL_SELECTOR` — Global element selectors
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
+
+**Detection:** Any CSS rule whose selector matches or contains these elements at the top level.
+
+**Correct**
+```css
+/* Scope all rules inside the extension container */
+.extension-container {
+  font-size: 14px;
+}
+
+.extension-container .title {
+  font-weight: bold;
+}
+```
+
+**Wrong**
+```css
+body {
+  font-size: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --my-color: red;
+}
+```
+
+---
+
+### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
+
+**Detection:** Any rule or declaration matching these patterns.
+
+> **Note on positioning:** `position: relative` and `position: sticky` within the extension container are generally safe. Avoid `fixed` and unbounded `absolute` that escape the extension boundary.
+
+**Correct**
+```css
+.extension-container {
+  position: relative; /* safe — contained */
+}
+```
+
+**Wrong**
+```css
+.overlay {
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+}
+
+:host {
+  display: block;
+}
+```
+
+---
+
+### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+
+**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+
+**Correct**
+```css
+/* CSS Module — all classes are auto-scoped */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+```css
+/* Plain CSS — must namespace manually */
+.extension-container { padding: 8px; }
+.extension-title { font-size: 16px; }
+```
+
+**Wrong**
+```css
+/* Plain CSS — no namespace — pollutes global styles */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+---
+
+### `CSS_GLOBAL_IMPORT` — CSS @import rules
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@import` pulls external stylesheets that affect global styles and bypass containment.
+
+**Detection:** Any `@import` at-rule anywhere in the CSS file.
+
+**Correct**
+```css
+/* Import a local CSS variable file via bundler config, not @import */
+```
+
+**Wrong**
+```css
+@import url('https://fonts.googleapis.com/css2?family=Roboto');
+@import './reset.css';
+```
+
+---
+
+### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+
+**Correct**
+```css
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+```css
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+---
+
+### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
+
+**Detection:** Declarations using restricted property names (e.g., properties that set global layout hints).
+
+**Action:** If detected, remove or scope the declaration appropriately.
+
+---
+
+### `CSS_RESTRICTED_VALUE` — Restricted CSS values
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
+
+**Detection:** `!important` in any declaration, or values targeting global layout tokens.
+
+**Correct**
+```css
+.extension-button {
+  color: var(--vtex-color-primary);
+}
+```
+
+**Wrong**
+```css
+.extension-button {
+  color: red !important;
+}
+```
+
+---
+
+## 3. React Performance Rules
+
+Applied to `.tsx` files by `ReactPerformanceAnalyzer`. Violations block presentation; warnings are flagged to the user.
+
+### `REACT_UNNECESSARY_RERENDER` — State update inside loop
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+State setter calls inside `for` or `while` loops trigger a re-render on every iteration.
+
+**Detection:** A `setState` / `set*` call whose parent node is a `for` or `while` statement.
+
+**Correct**
+```typescript
+// Compute derived value, then set once
+const updatedItems = items.map(transform);
+setItems(updatedItems);
+```
+
+**Wrong**
+```typescript
+for (const item of items) {
+  setCount((c) => c + 1); // re-renders on every iteration
+}
+```
+
+---
+
+### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
+
+**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
+
+**Correct**
+```typescript
+const filteredItems = useMemo(() => items.filter(isActive), [items]);
+
+return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
+  </ul>
+);
+```
+
+---
+
+### `REACT_ANONYMOUS_COMPONENT` — Anonymous (lowercase) component
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Components assigned to variables starting with lowercase are treated as HTML tags by React and cannot be used in JSX.
+
+**Detection:** Arrow function or function expression assigned to a variable that does not start with an uppercase letter.
+
+**Correct**
+```typescript
+export function LoyaltyPoints(): JSX.Element { ... }
+export const WarrantyBadge = (): JSX.Element => { ... };
+```
+
+**Wrong**
+```typescript
+const loyaltyPoints = (): JSX.Element => { ... };
+const warrantyBadge = function() { ... };
+```
+
+---
+
+### `REACT_DIRECT_DOM_MANIPULATION` — Direct DOM manipulation in React
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Bypasses the React virtual DOM and causes unpredictable behavior.
+
+**Detection:** Calls to `document.querySelector` or `document.getElementById` inside a React component.
+
+**Correct**
+```typescript
+const containerRef = useRef<HTMLDivElement>(null);
+// Access DOM via containerRef.current
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.cart-list');
+el.style.display = 'none'; // bypasses React
+```
+
+---
+
+### `REACT_LAYOUT_EFFECT_MISUSE` — useLayoutEffect usage
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`useLayoutEffect` blocks the browser paint and can cause performance issues in a sandboxed extension.
+
+**Detection:** Any call to `useLayoutEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  // DOM reading/writing after paint
+}, []);
+```
+
+**Wrong**
+```typescript
+useLayoutEffect(() => {
+  // blocks paint
+}, []);
+```
+
+---
+
+### `REACT_MISSING_DEPS` — Missing dependency array
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useEffect`, `useCallback`, or `useMemo` without a second argument re-runs on every render.
+
+**Detection:** A call to one of these hooks with fewer than 2 arguments, or with a non-array second argument.
+
+**Correct**
+```typescript
+useEffect(() => {
+  fetchData();
+}, [productId]); // explicit deps
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  fetchData(); // runs on every render
+});
+```
+
+---
+
+### `REACT_INLINE_FUNCTION` — Inline functions in JSX props
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Arrow functions defined directly in JSX attributes create a new function reference on every render, preventing child memoization.
+
+**Detection:** Function expression or arrow function expression whose parent is a JSX expression container or prop.
+
+**Correct**
+```typescript
+const handleClick = useCallback(() => {
+  doSomething();
+}, []);
+
+return <button onClick={handleClick}>Click</button>;
+```
+
+**Wrong**
+```typescript
+return <button onClick={() => doSomething()}>Click</button>;
+```
+
+---
+
+### `REACT_LARGE_COMPONENT` — Component over 200 lines
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Large components are harder to maintain and test. Threshold: **200 lines**.
+
+**Detection:** A function/arrow function with start/end line difference > 200.
+
+**Action:** Suggest splitting into smaller sub-components or extracting logic into custom hooks.
+
+---
+
+### `REACT_MANY_USESTATE` — More than 5 useState calls
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Many `useState` calls in a single component indicate complex local state. Threshold: **5 calls**.
+
+**Detection:** More than 5 calls to `useState` (or `React.useState`) within a single function component.
+
+**Action:** Suggest consolidating related state into a single `useState` with an object, or extracting to a custom hook.
+
+**Correct**
+```typescript
+const [formState, setFormState] = useState({
+  name: '',
+  email: '',
+  quantity: 1,
+});
+```
+
+**Wrong**
+```typescript
+const [name, setName] = useState('');
+const [email, setEmail] = useState('');
+const [quantity, setQuantity] = useState(1);
+const [loading, setLoading] = useState(false);
+const [error, setError] = useState<string | null>(null);
+const [submitted, setSubmitted] = useState(false); // 6th useState — flagged
+```
+
+---
+
+### `REACT_CONDITIONAL_HOOK` — Hook called conditionally
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a hook inside an `if`, `switch`, or ternary expression violates the Rules of Hooks.
+
+**Detection:** A hook call (useEffect, useState, useMemo, useCallback, useLayoutEffect) whose ancestor is an `IfStatement`, `SwitchStatement`, or `ConditionalExpression`.
+
+**Correct**
+```typescript
+const cart = useCart(); // always called unconditionally
+
+if (!cart) return <></>;
+```
+
+**Wrong**
+```typescript
+if (isEnabled) {
+  const cart = useCart(); // conditional hook call — violates Rules of Hooks
+}
+```
+
+---
+
+### `REACT_COMPLEX_JSX` — Deep JSX nesting
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Deep JSX trees are harder to read and may indicate a need to extract sub-components. Threshold: **5 levels deep**.
+
+**Detection:** A JSX element whose JSX child tree exceeds 5 levels of nesting.
+
+**Action:** Extract inner JSX into a named sub-component.
+
+---
+
+### `REACT_UNOPTIMIZED_LIST` — List rendering without key or large list
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Missing `key` props in list rendering causes React reconciliation issues. Lists over 50 items may need virtualization.
+
+**Detection:**
+- `map()` producing JSX without a `key` attribute on the root element
+- List size exceeding 50 items
+
+**Correct**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li key={item.id}>{item.name}</li>
+    ))}
+  </ul>
+);
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li>{item.name}</li> // missing key
+    ))}
+  </ul>
+);
+```
+
+---
+
+### `REACT_COMPLEX_STATE` — useState with complex object
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useState` initialized with an object having more than 5 properties suggests a need for `useReducer`. Threshold: **5 properties**.
+
+**Detection:** `useState(obj)` where `obj` is an object literal with > 5 properties.
+
+**Action:** Suggest converting to `useReducer` for complex state.
+
+---
+
+### `REACT_NESTED_UPDATE` — Nested state updates
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a state setter from within another state setter's callback can cause unexpected re-renders.
+
+**Detection:** A `set*` call whose ancestor is another `set*` call expression.
+
+---
+
+## Validation Output Format
+
+When reporting issues after code review, group by file and severity:
+
+```
+### Static Analysis Results
+
+**Violations (must fix before completing Step 3):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Fix: <suggested fix>
+
+**Warnings (review with user):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Suggestion: <improvement>
+
+✅ No violations found. N warnings flagged.
+```
+
+Do not proceed with Step 4 (Documentation) until all violations are resolved.

--- a/exports/opencode/sales-app-extensibility/references/static-analysis-rules.md
+++ b/exports/opencode/sales-app-extensibility/references/static-analysis-rules.md
@@ -204,20 +204,33 @@ import something from 'node_modules/lodash/get';
 
 ---
 
+### `NON_APPROVED_PACKAGE` — Import from non-approved package
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Any import whose source starts with `@` or contains `/`, unless it is `react` or a `node_modules/` direct path. Fires for every `@vtex/*` scoped package and every relative import (`./foo`, `../bar`).
+
+> **Note:** This warning is noisy — it fires for all legitimate Sales App imports (`@vtex/sales-app`, `@phosphor-icons/react`, relative component paths). Do not surface to the user when the import is from `@vtex/*` or a relative path. Investigate only when the import is from an unexpected third-party package.
+
+**Detection:** `import { … } from 'source'` where `source.startsWith('@')` or `source.includes('/')`, and source is not `'react'` or a `node_modules/` path.
+
+---
+
 ### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+Two detection paths:
 
-**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+1. **Direct API use:** `fetch`, `XMLHttpRequest`, `script.src`, `link.href` used as member expressions.
+2. **Known CDN domains in string literal:** `fetch('https://cdn.jsdelivr.net/...')` or any URL containing `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`, `api.example.com`, or ending with `.js`.
 
 > **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
 
 **Correct**
 ```typescript
-// Always use IO Proxy relative path
 const response = await fetch('/_v/my-loyalty-api/points', {
   credentials: 'include',
 });
@@ -226,6 +239,7 @@ const response = await fetch('/_v/my-loyalty-api/points', {
 **Wrong**
 ```typescript
 const response = await fetch('https://api.example.com/data');
+const response = await fetch('https://cdn.jsdelivr.net/npm/lodash.js'); // CDN — also Violation
 const xhr = new XMLHttpRequest();
 ```
 
@@ -233,14 +247,14 @@ const xhr = new XMLHttpRequest();
 
 ### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
 
-**Severity:** Warning (flag)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. CDN domain fetches are actually reported as `EXTERNAL_RESOURCE_LOADING` (Violation, block) — not as this Warning. Treat any fetch to a CDN domain as a **build-blocking Violation**, not a soft warning.
+
+**Severity:** Warning (flag) — *see note above; actual enforcement is via `EXTERNAL_RESOURCE_LOADING`*  
 **Files:** `.ts`, `.tsx`
 
 Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
 
 **Detection:** `fetch()` first argument literal containing one of these domains.
-
-**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
 
 ---
 
@@ -251,7 +265,7 @@ Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.co
 
 Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
 
-**Detection:** Any call to these methods.
+**Detection:** Any call where the callee matches `document.querySelector`, `document.getElementById`, etc. (the variable must be literally named `document`). Calls via a ref object — e.g. `containerRef.current.querySelector(...)` — are **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
@@ -274,14 +288,14 @@ document.getElementById('cart-container');
 
 Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
 
-**Detection:** Any member expression matching these patterns.
+**Detection:** Matches only when the object is literally named `element` (e.g. `element.style`). Equivalent access through other variable names — e.g. `divRef.current.style`, `el.className` — is **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
-// Use plain CSS with namespaced class names
+// Use plain CSS classes from the component stylesheet
 import './MyExtension.css';
 
-return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
+return <div className={isActive ? 'active' : 'inactive'} />;
 ```
 
 **Wrong**
@@ -298,7 +312,7 @@ element.setAttribute('style', 'display: none');
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+**Detection:** `while(true)` or `do...while(true)` with literal `true` condition.
 
 **Wrong**
 ```typescript
@@ -309,9 +323,22 @@ while (true) {
 
 ---
 
+### `POTENTIAL_INFINITE_LOOP` — Incomplete for-loop
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `for` statement with no `update` expression AND no `test` expression (e.g. `for (let i = 0;;) { … }`).
+
+**Action:** Warn the user and ensure the loop has a proper termination condition.
+
+---
+
 ### `MEMORY_LEAK` — Memory leak patterns
 
-**Severity:** Violation (block)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. The active rule is `POTENTIAL_MEMORY_LEAK` (Warning) below. Event listeners without cleanup **will not block the build**, but remain a Hard Constraint — always add a cleanup return in `useEffect`.
+
+**Severity:** Violation (block) — *see note above; not currently enforced at build time*  
 **Files:** `.ts`, `.tsx`
 
 **Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
@@ -335,23 +362,58 @@ useEffect(() => {
 
 ---
 
+### `POTENTIAL_MEMORY_LEAK` — Likely memory leak patterns
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Three triggers:
+1. Any `addEventListener` call — the analyzer warns regardless of whether a corresponding `removeEventListener` exists in cleanup.
+2. Recursive function call where the callee name matches the parent `FunctionDeclaration` identifier.
+3. `Array.push` inside a `for` or `while` loop.
+
+**Action:** Verify the component has a proper cleanup return in `useEffect` for any event listener, and that recursive functions have a clear base case.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+---
+
 ### `EXCESSIVE_API_CALLS` — Excessive API call patterns
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+**Detection:** `fetch` or `XMLHttpRequest` calls whose parent is a `for` or `while` loop.
 
 **Wrong**
 ```typescript
-// fetch inside render — fires on every re-render
-const data = await fetch('/_v/api/data');
-
 // fetch inside loop — excessive calls
 for (const item of items) {
   await fetch(`/_v/api/item/${item.id}`);
 }
 ```
+
+---
+
+### `FREQUENT_API_CALLS` — API call outside loop / rapid setInterval
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Two triggers:
+1. `fetch` or `XMLHttpRequest` call **outside** a loop (i.e. anywhere else in the component). Fires for every fetch — ensure calls are wrapped in `useEffect` with proper deps and are rate-limited or cached.
+2. `setInterval` with a numeric delay argument below 1000 ms.
+
+> **Note:** Trigger 1 is intentionally broad — it flags every `fetch()` call as a reminder to verify it is not running unintentionally on every render. It does **not** mean every fetch is wrong. Only surface this to the user when the fetch is genuinely outside a `useEffect` or appears to run on each render.
+
+**Action:** Warn the user and suggest wrapping fetches in `useEffect`, using caching, or increasing the polling interval.
 
 ---
 
@@ -383,7 +445,25 @@ import _ from 'lodash';
 
 ## 2. CSS Containment Rules
 
-Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`.
+
+**Sales App analyzer configuration** (from `@vtex/sales-app` build/dev hook):
+
+```typescript
+cssOptions: {
+  allowedNamespaces: ['sales-app-extension-'],
+  defaultNamespace: 'sales-app-extension-',
+  transformNonCompliant: true,
+  overwriteTransformed: true,
+}
+```
+
+Two consequences for the rules below:
+
+1. The configured namespace is **`sales-app-extension-`**, not the analyzer's bare default of `extension-`. Any rule that talks about "the allowed namespace" means `sales-app-extension-` in this project.
+2. `transformNonCompliant: true` softens the namespace rules: when a selector or `@keyframes` name is not prefixed, the analyzer auto-rewrites it into a sibling `*.transformed.css` file and emits a `CSS_TRANSFORMED` **warning** instead of a `CSS_NAMESPACE_REQUIRED` / `CSS_GLOBAL_KEYFRAMES` **violation**. The original `.css` (and the `className` strings in JSX) are left untouched, so the build does not break. This is why the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) ships unprefixed selectors like `.container`, `.title`, `.row` — they are valid in this project.
+
+The other CSS rules (`CSS_GLOBAL_SELECTOR`, `CSS_CONTAINMENT_BREAKOUT`, `CSS_GLOBAL_IMPORT`, `CSS_RESTRICTED_PROPERTY`, `CSS_RESTRICTED_VALUE`, and the inline-style rules) are **not** softened by `transformNonCompliant` — they remain build-blocking violations.
 
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
@@ -396,12 +476,12 @@ Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#_
 
 **Correct**
 ```css
-/* Scope all rules inside the extension container */
-.extension-container {
+/* Scope rules inside the extension container — never target global elements */
+.container {
   font-size: 14px;
 }
 
-.extension-container .title {
+.container .title {
   font-weight: bold;
 }
 ```
@@ -436,7 +516,7 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 **Correct**
 ```css
-.extension-container {
+.container {
   position: relative; /* safe — contained */
 }
 ```
@@ -459,26 +539,27 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
+All CSS selectors should be scoped under an allowed namespace prefix. In the Sales App, that prefix is `sales-app-extension-`. Because the project sets `transformNonCompliant: true`, an unprefixed selector does **not** block the build: the analyzer rewrites it inside a sibling `Component.transformed.css` and emits a `CSS_TRANSFORMED` warning instead of `CSS_NAMESPACE_REQUIRED`. The original `Component.css` (which is what gets bundled) keeps the unprefixed class, so the JSX `className="container"` continues to match.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
+**Detection:** A selector that does not include any value from `allowedNamespaces` (substring check on `.namespace`, `#namespace`, or `[class*="namespace"]`).
 
-**Correct**
+**Correct (and matches the CSS template)**
 ```css
-/* Plain CSS — namespace all classes */
-.extension-container { padding: 8px; }
-.extension-title { font-size: 16px; }
-```
-
-**Wrong**
-```css
-/* Plain CSS — no namespace — pollutes global styles */
+/* Unprefixed top-level classes are accepted because transformNonCompliant=true. */
 .container { padding: 8px; }
-.title { font-size: 16px; }
+.title     { font-size: 16px; }
 ```
+
+**Also correct (explicit prefix, never warns)**
+```css
+.sales-app-extension-container { padding: 8px; }
+.sales-app-extension-title     { font-size: 16px; }
+```
+
+> Prefer the unprefixed form to match the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) and the JSX in the component templates. The `CSS_TRANSFORMED` warning that fires for these is informational only.
 
 ---
 
@@ -506,26 +587,27 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell. As with `CSS_NAMESPACE_REQUIRED`, `transformNonCompliant: true` rewrites the name in `*.transformed.css` and emits `CSS_TRANSFORMED` instead of blocking.
 
-**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix (`sales-app-extension-` in this project).
 
-**Correct**
+The CSS template prefixes keyframes with `${COMPONENT_NAME}-` (e.g. `LoyaltyPoints-spin`). That prefix does **not** start with `sales-app-extension-`, so it triggers a `CSS_TRANSFORMED` warning — the build still succeeds, but the transformed file will rename it to `sales-app-extension-LoyaltyPoints-spin`. Either form is acceptable.
+
+**Correct (no warning)**
 ```css
-@keyframes extension-fade-in {
+@keyframes sales-app-extension-fade-in {
   from { opacity: 0; }
   to   { opacity: 1; }
 }
 ```
 
-**Wrong**
+**Also correct (CSS_TRANSFORMED warning, build passes)**
 ```css
-@keyframes fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+@keyframes LoyaltyPoints-spin {
+  to { transform: rotate(360deg); }
 }
 ```
 
@@ -555,16 +637,59 @@ Certain CSS values (e.g., `!important`) override the cascade and break containme
 
 **Correct**
 ```css
-.extension-button {
-  color: var(--vtex-color-primary);
+.button {
+  color: var(--sa-color-primary);
 }
 ```
 
 **Wrong**
 ```css
-.extension-button {
+.button {
   color: red !important;
 }
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_PROPERTY` — Restricted property in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props in JSX may not use properties that affect layout or containment.
+
+Restricted properties: `position`, `z-index`, `top`, `left`, `right`, `bottom`, `all`, `contain`, `content`, `isolation`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted property names.
+
+**Correct**
+```typescript
+// Use CSS classes for layout properties
+return <div className="overlay" />;
+```
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed', top: 0 }} />;
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_VALUE` — Restricted value in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props may not use values that break containment or cascade.
+
+Restricted values: `fixed`, `absolute`, `!important`, `inherit`, `initial`, `unset`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted values.
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed' }} />;
+return <div style={{ display: 'inherit' }} />;
 ```
 
 ---
@@ -594,33 +719,6 @@ setItems(updatedItems);
 for (const item of items) {
   setCount((c) => c + 1); // re-renders on every iteration
 }
-```
-
----
-
-### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
-
-**Severity:** Violation (block)  
-**Files:** `.tsx`
-
-`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
-
-**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
-
-**Correct**
-```typescript
-const filteredItems = useMemo(() => items.filter(isActive), [items]);
-
-return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
-```
-
-**Wrong**
-```typescript
-return (
-  <ul>
-    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
-  </ul>
-);
 ```
 
 ---

--- a/exports/opencode/sales-app-extensibility/references/static-analysis-rules.md
+++ b/exports/opencode/sales-app-extensibility/references/static-analysis-rules.md
@@ -278,10 +278,10 @@ Restricted expressions: `element.style`, `element.className`, `element.classList
 
 **Correct**
 ```typescript
-// Use CSS modules and conditional class application
-import styles from './MyExtension.module.css';
+// Use plain CSS with namespaced class names
+import './MyExtension.css';
 
-return <div className={isActive ? styles.active : styles.inactive} />;
+return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
 ```
 
 **Wrong**
@@ -388,7 +388,7 @@ Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
 
@@ -426,7 +426,7 @@ body {
 ### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
 
@@ -460,21 +460,15 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
 
 **Correct**
 ```css
-/* CSS Module — all classes are auto-scoped */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-```
-
-```css
-/* Plain CSS — must namespace manually */
+/* Plain CSS — namespace all classes */
 .extension-container { padding: 8px; }
 .extension-title { font-size: 16px; }
 ```
@@ -491,7 +485,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_IMPORT` — CSS @import rules
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@import` pulls external stylesheets that affect global styles and bypass containment.
 
@@ -513,7 +507,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
 
@@ -540,7 +534,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
 
@@ -553,7 +547,7 @@ Certain properties affect layout or rendering globally and are restricted to pre
 ### `CSS_RESTRICTED_VALUE` — Restricted CSS values
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
 

--- a/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -1,6 +1,6 @@
 ---
 name: sales-app-code-templates
-description: Code generation templates for Sales App extensions — simple, hook-based, API (no auth), IO Proxy (secure), Direct Auth (insecure), CSS module, and index.tsx with defineExtensions. Use when generating or scaffolding extension code.
+description: Code generation templates for Sales App extensions — simple, hook-based, API (no auth), IO Proxy (secure), Direct Auth (insecure), CSS stylesheet, and index.tsx with defineExtensions. Use when generating or scaffolding extension code.
 metadata:
   version: "1.0"
 ---
@@ -331,9 +331,11 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 }
 ```
 
-## CSS Module
+## CSS Stylesheet
 
-All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+
+**CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
 
 ```css
 /**
@@ -486,7 +488,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -333,82 +333,115 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Module
 
-All extensions use CSS modules with Admin UI design tokens.
+All extensions use CSS modules with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Admin UI patterns.
+ * Design tokens follow Sales App Design Guidelines.
+ * Reference: references/design-guidelines.md
+ * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
-.container { padding: 16px; background-color: #ffffff; }
-.content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: #1a1a1a; margin: 0; }
-.subtitle { font-size: 14px; color: #666666; margin: 0; }
-.text { font-size: 14px; color: #333333; line-height: 1.5; }
+.container {
+  /* Sales App design tokens — do not replace with hardcoded hex values */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+  --sa-color-bg:        #FFFFFF;
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
-/* Loading State */
+  padding: 16px;
+  background-color: var(--sa-color-bg);
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.content { display: flex; flex-direction: column; gap: 12px; }
+.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
+.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
+.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+
+/* Loading state */
 .loading {
   display: flex; align-items: center; justify-content: center;
-  gap: 8px; padding: 24px; color: #666666;
+  gap: 8px; padding: 24px; color: var(--sa-color-text-secondary);
 }
 .spinner {
   width: 20px; height: 20px;
-  border: 2px solid #e0e0e0; border-top-color: #0066cc;
-  border-radius: 50%; animation: spin 1s linear infinite;
+  border: 2px solid var(--sa-color-border); border-top-color: var(--sa-color-primary);
+  border-radius: 50%; animation: ${COMPONENT_NAME}-spin 1s linear infinite;
 }
-@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes ${COMPONENT_NAME}-spin { to { transform: rotate(360deg); } }
 
-/* Error State */
+/* Error state */
 .error {
-  padding: 16px; background-color: #fff5f5;
-  border: 1px solid #ffcccc; border-radius: 8px;
-  color: #cc0000; font-size: 14px;
+  padding: 16px; background-color: var(--sa-color-error-bg);
+  border: 1px solid var(--sa-color-error-border); border-radius: 8px;
+  color: var(--sa-color-error-text); font-size: 14px;
 }
 
-/* Button Styles */
+/* Button styles */
 .button {
   display: inline-flex; align-items: center; justify-content: center;
-  padding: 10px 16px; font-size: 14px; font-weight: 500;
+  padding: 12px 16px; font-size: 14px; font-weight: 500;
   border: none; border-radius: 6px; cursor: pointer;
   transition: background-color 0.2s ease;
 }
-.buttonPrimary { background-color: #0066cc; color: #ffffff; }
-.buttonPrimary:hover { background-color: #0052a3; }
-.buttonSecondary { background-color: #f0f0f0; color: #333333; }
-.buttonSecondary:hover { background-color: #e0e0e0; }
+.buttonPrimary { background-color: var(--sa-color-primary); color: #FFFFFF; }
+.buttonPrimary:hover { background-color: var(--sa-color-primary-hover); }
+.buttonSecondary { background-color: var(--sa-color-bg-muted); color: var(--sa-color-text-tertiary); }
+.buttonSecondary:hover { background-color: var(--sa-color-border); }
 
-/* Card Styles */
+/* Card */
 .card {
-  padding: 16px; background-color: #f9f9f9;
-  border-radius: 8px; border: 1px solid #e0e0e0;
+  padding: 16px; background-color: var(--sa-color-bg-subtle);
+  border-radius: 8px; border: 1px solid var(--sa-color-border);
 }
 
-/* Badge Styles */
+/* Badges */
 .badge {
   display: inline-block; padding: 4px 8px;
   font-size: 12px; font-weight: 500; border-radius: 4px;
 }
-.badgeSuccess { background-color: #e6f4ea; color: #137333; }
-.badgeWarning { background-color: #fef7e0; color: #b06000; }
-.badgeInfo { background-color: #e8f0fe; color: #1a73e8; }
+.badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
+.badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
+.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
 
-/* Input Styles */
+/* Input */
 .input {
-  width: 100%; padding: 10px 12px; font-size: 14px;
-  border: 1px solid #d0d0d0; border-radius: 6px;
+  width: 100%; padding: 12px; font-size: 14px;
+  border: 1px solid var(--sa-color-border-input); border-radius: 6px;
   outline: none; transition: border-color 0.2s ease;
 }
-.input:focus { border-color: #0066cc; }
+.input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/Flex Helpers */
+/* Row/flex helpers */
 .row { display: flex; align-items: center; gap: 12px; }
 .spaceBetween { justify-content: space-between; }
 
-/* Price Display */
-.price { font-size: 18px; font-weight: 600; color: #1a1a1a; }
-.priceOld { font-size: 14px; color: #999999; text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: #137333; font-weight: 500; }
+/* Price display */
+.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+
+/* Responsive — Sales App breakpoints */
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
 ```
 
 ## index.tsx with defineExtensions
@@ -453,6 +486,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
+12. **Design token compliance** — the CSS module must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
 
 ## API Type Generation from Documentation
 

--- a/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -452,6 +452,7 @@ After generating code, validate for these issues:
 8. **API call handling** — loading state and error handling must be present for any `fetch()` call
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
+11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
 
 ## API Type Generation from Documentation
 

--- a/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/code-templates-and-patterns.md
@@ -333,38 +333,73 @@ export function ${COMPONENT_NAME}(): JSX.Element {
 
 ## CSS Stylesheet
 
-All extensions use **plain CSS** (not CSS modules) with Sales App design tokens. See [design-guidelines.md](design-guidelines.md) for the full token reference.
+All extensions use **plain CSS** (not CSS modules). The full Sales App design system for CSS — tokens, typography, spacing grid, responsive breakpoints, and structure — is inlined below. **Use this template as the single source of truth for any CSS generation.**
 
 **CRITICAL — File naming:** The CSS file MUST be named `${COMPONENT_NAME}.css` — **never** `${COMPONENT_NAME}.module.css`. The Sales App bundler does not support CSS modules. Import as a side-effect: `import './${COMPONENT_NAME}.css';` — never as `import styles from './${COMPONENT_NAME}.module.css';`. Use `className="container"` string literals, not `className={styles.container}`.
+
+### Design system rules baked into this template
+
+These rules apply to **every** generated extension CSS. The template below already complies — keep it that way.
+
+| Topic | Rule |
+|-------|------|
+| Tokens | All colors must reference `--sa-color-*` tokens declared on `.container`. **Never** use hardcoded hex values anywhere else. |
+| Font family | `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif` on `.container`, inherited by descendants. |
+| Font weights | Only Regular (400), Medium (500), Semibold (600), Bold (700). |
+| Font sizes (px) | Allowed scale only: **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**. Never `13`, `15`, `17`, etc. |
+| Typography roles | Section title = 16px/600 · Subtitle/label = 14px/500 · Body = 14px/400 · Caption = 12px/400 · Price = 18px/600. |
+| Spacing | Multiples of **4px** only (4, 8, 12, 16, 20, 24, 32, 40…). Never `10`, `14`, `18`, `22`. Applies to `padding`, `margin`, `gap`, `height`. |
+| Containment | No `position: fixed`, no `z-index: 9999`, no `:host`, no `:global`, no `@import`. `position: relative` and `sticky` are safe. |
+| Selectors | Use the unprefixed utility class names from this template (`.container`, `.content`, `.row`, `.title`, `.button`, etc.). The Sales App `fsp-analyzer` runs with `transformNonCompliant: true`, so unprefixed selectors emit a `CSS_TRANSFORMED` warning rather than a `CSS_NAMESPACE_REQUIRED` violation. Never use `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` — those are caught by `CSS_GLOBAL_SELECTOR` and remain blocking. |
+| Keyframes | Prefix with `${COMPONENT_NAME}-` (e.g., `${COMPONENT_NAME}-spin`). This raises a `CSS_TRANSFORMED` warning (build still passes) — use `sales-app-extension-${COMPONENT_NAME}-spin` if you want a clean run. |
+| `!important` | Never. |
+| Responsive | Use the breakpoint at `(max-width: 743px)` for mobile overrides. Sales App shell handles the rest. |
 
 ```css
 /**
  * ${COMPONENT_NAME} Styles
- * Design tokens follow Sales App Design Guidelines.
- * Reference: references/design-guidelines.md
+ * Sales App design system (tokens + typography + spacing + responsive) is fully inlined.
  * UX writing: Use sentence case for all UI text. Never use ALL-CAPS.
  */
 
 .container {
-  /* Sales App design tokens — do not replace with hardcoded hex values */
+  /* === Sales App design tokens — single source of truth ===
+     Always declare these on .container. Reference via var(--sa-color-*) in all other rules.
+     Never use hardcoded hex values in CSS rules. */
+
+  /* Primary action */
   --sa-color-primary:       #157BF4;   /* Light Blue 800 */
   --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-  --sa-color-bg:        #FFFFFF;
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 — high emphasis */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600  — medium emphasis */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500  — low emphasis */
+  --sa-color-text-muted:     #999999;  /* Neutral 700  — disabled / hint */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
   --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
   --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
   --sa-color-border:       #E0E0E0;    /* Neutral 300 */
   --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
   --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
   --sa-color-error-border: #FFDFD9;    /* Red 200 */
   --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
   --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
   --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow / Orange scale) */
   --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
   --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
   --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
   --sa-color-info-text: #157BF4;       /* Light Blue 800 */
 
@@ -372,10 +407,16 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
   background-color: var(--sa-color-bg);
   font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
 }
+
+/* Layout */
 .content { display: flex; flex-direction: column; gap: 12px; }
-.title { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary); margin: 0; }
-.subtitle { font-size: 14px; color: var(--sa-color-text-secondary); margin: 0; }
-.text { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
+.row { display: flex; align-items: center; gap: 12px; }
+.spaceBetween { justify-content: space-between; }
+
+/* Typography — uses approved size scale (10, 12, 14, 16, 18, 20, 22, 24...) */
+.title    { font-size: 16px; font-weight: 600; color: var(--sa-color-text-primary);   margin: 0; }
+.subtitle { font-size: 14px; font-weight: 500; color: var(--sa-color-text-secondary); margin: 0; }
+.text     { font-size: 14px; color: var(--sa-color-text-tertiary); line-height: 1.5; }
 
 /* Loading state */
 .loading {
@@ -421,7 +462,7 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .badgeSuccess { background-color: var(--sa-color-success-bg); color: var(--sa-color-success-text); }
 .badgeWarning { background-color: var(--sa-color-warning-bg); color: var(--sa-color-warning-text); }
-.badgeInfo { background-color: var(--sa-color-info-bg); color: var(--sa-color-info-text); }
+.badgeInfo    { background-color: var(--sa-color-info-bg);    color: var(--sa-color-info-text); }
 
 /* Input */
 .input {
@@ -431,20 +472,33 @@ All extensions use **plain CSS** (not CSS modules) with Sales App design tokens.
 }
 .input:focus { border-color: var(--sa-color-primary); }
 
-/* Row/flex helpers */
-.row { display: flex; align-items: center; gap: 12px; }
-.spaceBetween { justify-content: space-between; }
-
 /* Price display */
-.price { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
-.priceOld { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
-.priceDiscount { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
+.price          { font-size: 18px; font-weight: 600; color: var(--sa-color-text-primary); }
+.priceOld       { font-size: 14px; color: var(--sa-color-text-muted); text-decoration: line-through; }
+.priceDiscount  { font-size: 14px; color: var(--sa-color-success-text); font-weight: 500; }
 
-/* Responsive — Sales App breakpoints */
+/* Responsive — Sales App breakpoints
+   Small (mobile)  320–743px  → margin: 24px, no column grid
+   Medium (tablet) 744–1279px → host gutters: 16px (no override needed)
+   Large (desktop) 1280–1919px → host gutters: 20px (no override needed)
+   Extra large     1920px+    → host gutters: 20px (no override needed) */
 @media (max-width: 743px) {
   .container { padding: 12px; margin: 0 24px; }
 }
 ```
+
+### CSS file structure
+
+Every extension CSS must follow this order:
+
+1. **Token declarations** — `--sa-color-*` on `.container`
+2. **Layout helpers** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography** — `.title`, `.subtitle`, `.text`
+4. **State** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive** — `@media` queries at the bottom
+
+For UX writing rules (sentence case) and iconography (Phosphor Icons) used in `.tsx`, see [design-guidelines.md](design-guidelines.md).
 
 ## index.tsx with defineExtensions
 
@@ -488,7 +542,7 @@ After generating code, validate for these issues:
 9. **CSS class usage** — CSS classes defined in the stylesheet should be used in the component
 10. **defineExtensions in index.tsx** — entry point must import and call `defineExtensions`
 11. **Static analysis compliance** — generated code must pass all fsp-analyzer sandbox security, CSS containment, and React performance rules. Load the [static analysis reference](static-analysis-rules.md) to run the full check. Fix all violations before presenting code to the user; flag warnings to the user for review.
-12. **Design token compliance** — the CSS file must declare `--sa-color-*` custom properties on `.container` and use only those tokens for all colors. No hardcoded hex values outside the token block. Font family must be `'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif`. All UI text in sentence case. Icons from Phosphor Icons only. Load the [design guidelines reference](design-guidelines.md) for the full token table.
+12. **Design system compliance** — the CSS file must follow the rules table at the top of the "CSS Stylesheet" section above: `--sa-color-*` custom properties declared on `.container` and used in all rules, `'VTEX Trust'` font family, allowed font sizes (10, 12, 14, 16, 18, 20, 22, 24, 28, 32…), 4px-multiple spacing, scoped selectors, and the responsive override at `(max-width: 743px)`. For UI text (sentence case) and icons (Phosphor), see [design-guidelines.md](design-guidelines.md).
 
 ## API Type Generation from Documentation
 

--- a/tracks/sales-app/skills/sales-app-extensibility/references/design-guidelines.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/design-guidelines.md
@@ -1,0 +1,245 @@
+---
+name: sales-app-design-guidelines
+description: Design tokens, typography, iconography, color palette, UX writing rules, and responsive breakpoints for Sales App extensions. Load when generating CSS, choosing colors, typography, or icons for any extension component.
+metadata:
+  version: "1.0"
+---
+
+# Sales App Design Guidelines
+
+All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+
+---
+
+## 1. UX and Writing Rules
+
+Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+
+| Rule | Correct | Wrong |
+|------|---------|-------|
+| Sentence case | "Add to cart" | "ADD TO CART" |
+| Proper nouns | "VTEX account" | "vtex account" |
+| No all-caps | "Loyalty points" | "LOYALTY POINTS" |
+| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+
+These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
+
+---
+
+## 2. Design Tokens (CSS Custom Properties)
+
+Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
+
+```css
+.container {
+  /* Primary action */
+  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
+  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
+
+  /* Text */
+  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
+  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
+  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
+  --sa-color-text-muted:     #999999;  /* Neutral 700 */
+
+  /* Backgrounds */
+  --sa-color-bg:        #FFFFFF;       /* Neutral White */
+  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
+  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
+
+  /* Borders */
+  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
+  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
+
+  /* Error (Red scale) */
+  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
+  --sa-color-error-border: #FFDFD9;    /* Red 200 */
+  --sa-color-error-text:   #EC3727;    /* Red 800 */
+
+  /* Success (Green scale) */
+  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
+  --sa-color-success-text: #01905F;    /* Green 800 */
+
+  /* Warning (Yellow/Orange scale) */
+  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
+  --sa-color-warning-text: #E57001;    /* Orange 700 */
+
+  /* Info (Light Blue scale) */
+  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
+  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
+}
+```
+
+### Token mapping reference
+
+| Semantic role | Token | Hex | Palette origin |
+|--------------|-------|-----|----------------|
+| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
+| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
+| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
+| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
+| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
+| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
+| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
+| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
+| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
+| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
+| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
+| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
+| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
+| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
+| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
+| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
+| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
+| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
+| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
+| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+
+---
+
+## 3. Typography
+
+### Typeface
+
+The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
+
+```css
+font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+```
+
+Set this on the root `.container` class so all descendant elements inherit it.
+
+### Weights
+
+Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
+
+### Allowed font sizes
+
+Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
+
+Do not use arbitrary sizes like 13px, 15px, or 17px.
+
+| Use case | Size | Weight |
+|----------|------|--------|
+| Section title | 16px | Semibold (600) |
+| Subtitle / label | 14px | Medium (500) |
+| Body text | 14px | Regular (400) |
+| Caption / hint | 12px | Regular (400) |
+| Price | 18px | Semibold (600) |
+
+---
+
+## 4. Iconography
+
+### Library
+
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Standard / default | 24px |
+| Compact / inline | 16px |
+| Large / featured | 32–48px |
+
+Always use sizes within the supported range: **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+
+### Installation
+
+```bash
+yarn add @phosphor-icons/react
+```
+
+### Usage example
+
+```typescript
+import { ShoppingCart, Star, Warning } from '@phosphor-icons/react';
+
+export function MyExtension(): JSX.Element {
+  return (
+    <div className="container">
+      <ShoppingCart size={24} />
+      <span>Cart items</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. Spacing and Baseline Grid
+
+All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+
+| Value | Baseline multiple |
+|-------|-----------------|
+| 4px | 1× |
+| 8px | 2× |
+| 12px | 3× |
+| 16px | 4× |
+| 20px | 5× |
+| 24px | 6× |
+| 32px | 8× |
+
+**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
+
+---
+
+## 6. Responsive Breakpoints
+
+Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
+
+| Breakpoint | Resolution range | Notes |
+|-----------|-----------------|-------|
+| Small (mobile) | 320–743px | Margin: 24px, no column grid |
+| Medium (tablet) | 744–1279px | Gutters: 16px |
+| Large (desktop) | 1280–1919px | Gutters: 20px |
+| Extra large (monitor) | 1920px+ | Gutters: 20px |
+
+Recommended mobile override (applied to the responsive section of the CSS module):
+
+```css
+@media (max-width: 743px) {
+  .container { padding: 12px; margin: 0 24px; }
+}
+```
+
+---
+
+## 7. CSS Module Structure
+
+Every extension CSS module must follow this structure:
+
+1. **Token declarations** — CSS custom properties on `.container`
+2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
+3. **Typography classes** — `.title`, `.subtitle`, `.text`
+4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
+5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
+6. **Responsive overrides** — `@media` queries at the bottom
+
+### Critical CSS rules
+
+- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
+- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
+- No `@import`, `position: fixed`, or `z-index: 9999`.
+- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
+
+---
+
+## 8. Quick Compliance Checklist
+
+Before presenting generated CSS to the user, verify:
+
+- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
+- [ ] No hardcoded hex values outside the token declarations block?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
+- [ ] All spacing multiples of 4px?
+- [ ] All icons from Phosphor Icons?
+- [ ] All UI text in sentence case (no ALL-CAPS)?
+- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?

--- a/tracks/sales-app/skills/sales-app-extensibility/references/design-guidelines.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/design-guidelines.md
@@ -1,159 +1,62 @@
 ---
 name: sales-app-design-guidelines
-description: Design tokens, typography, iconography, color palette, UX writing rules, and responsive breakpoints for Sales App extensions. Load when generating CSS, choosing colors, typography, or icons for any extension component.
+description: UX writing rules (sentence case) and Phosphor Icons usage for Sales App extensions. Load when writing JSX text content or when an extension needs icons. CSS-related design rules (tokens, typography, spacing, responsive) are inlined directly in the CSS template — see code-templates-and-patterns.md.
 metadata:
-  version: "1.0"
+  version: "2.0"
 ---
 
-# Sales App Design Guidelines
+# Sales App Design Guidelines (non-CSS)
 
-All extensions must follow the Sales App Design Guidelines to ensure visual consistency with the Sales App shell. These guidelines are authoritative — do not invent colors, fonts, or icon libraries outside this reference.
+This reference covers two topics that apply to **TSX content**, not CSS:
+
+1. **UX writing rules** — for any text rendered in JSX
+2. **Iconography** — when the extension uses icons
+
+> **For CSS:** all design tokens, typography scale, spacing grid, and responsive breakpoints are inlined directly in the CSS template at [code-templates-and-patterns.md](code-templates-and-patterns.md) §"CSS Stylesheet". That template is the single source of truth for any CSS generation. Do not invent or duplicate token values here.
 
 ---
 
-## 1. UX and Writing Rules
+## 1. UX Writing Rules
 
-Apply these rules to every string that appears in the UI (labels, buttons, messages, placeholders).
+Apply to every string that appears in the UI (labels, buttons, messages, placeholders, alt text).
 
 | Rule | Correct | Wrong |
 |------|---------|-------|
 | Sentence case | "Add to cart" | "ADD TO CART" |
-| Proper nouns | "VTEX account" | "vtex account" |
+| Proper nouns capitalized | "VTEX account" | "vtex account" |
 | No all-caps | "Loyalty points" | "LOYALTY POINTS" |
-| No system placeholders | "Your email" | "EMAIL ADDRESS" |
+| No system-style placeholders | "Your email" | "EMAIL ADDRESS" |
+| No CSS uppercase transforms | (omit `text-transform: uppercase`) | `text-transform: uppercase` |
 
-These rules derive from Google Material Design writing principles and Apple Human Interface Guidelines adopted by VTEX.
-
----
-
-## 2. Design Tokens (CSS Custom Properties)
-
-Extensions must declare the following CSS custom properties on the root `.container` class and reference them throughout the component CSS. Never use hardcoded hex values; always use the token variables.
-
-```css
-.container {
-  /* Primary action */
-  --sa-color-primary:       #157BF4;   /* Light Blue 800 */
-  --sa-color-primary-hover: #0366DD;   /* Light Blue 900 */
-
-  /* Text */
-  --sa-color-text-primary:   #1F1F1F;  /* Neutral 1200 */
-  --sa-color-text-secondary: #5C5C5C;  /* Neutral 600 */
-  --sa-color-text-tertiary:  #3D3D3D;  /* Neutral 500 */
-  --sa-color-text-muted:     #999999;  /* Neutral 700 */
-
-  /* Backgrounds */
-  --sa-color-bg:        #FFFFFF;       /* Neutral White */
-  --sa-color-bg-subtle: #F5F5F5;       /* Neutral 100 */
-  --sa-color-bg-muted:  #EBEBEB;       /* Neutral 200 */
-
-  /* Borders */
-  --sa-color-border:       #E0E0E0;    /* Neutral 300 */
-  --sa-color-border-input: #D6D6D6;    /* Neutral 400 */
-
-  /* Error (Red scale) */
-  --sa-color-error-bg:     #FDF6F5;    /* Red 50 */
-  --sa-color-error-border: #FFDFD9;    /* Red 200 */
-  --sa-color-error-text:   #EC3727;    /* Red 800 */
-
-  /* Success (Green scale) */
-  --sa-color-success-bg:   #EDFDF5;    /* Green 50 */
-  --sa-color-success-text: #01905F;    /* Green 800 */
-
-  /* Warning (Yellow/Orange scale) */
-  --sa-color-warning-bg:   #FBF7D4;    /* Yellow 50 */
-  --sa-color-warning-text: #E57001;    /* Orange 700 */
-
-  /* Info (Light Blue scale) */
-  --sa-color-info-bg:   #F1F8FD;       /* Light Blue 50 */
-  --sa-color-info-text: #157BF4;       /* Light Blue 800 */
-}
-```
-
-### Token mapping reference
-
-| Semantic role | Token | Hex | Palette origin |
-|--------------|-------|-----|----------------|
-| Primary action | `--sa-color-primary` | `#157BF4` | Light Blue 800 |
-| Primary hover | `--sa-color-primary-hover` | `#0366DD` | Light Blue 900 |
-| Text — high emphasis | `--sa-color-text-primary` | `#1F1F1F` | Neutral 1200 |
-| Text — medium emphasis | `--sa-color-text-secondary` | `#5C5C5C` | Neutral 600 |
-| Text — low emphasis | `--sa-color-text-tertiary` | `#3D3D3D` | Neutral 500 |
-| Text — disabled/hint | `--sa-color-text-muted` | `#999999` | Neutral 700 |
-| Surface / white | `--sa-color-bg` | `#FFFFFF` | Neutral White |
-| Subtle surface | `--sa-color-bg-subtle` | `#F5F5F5` | Neutral 100 |
-| Muted surface | `--sa-color-bg-muted` | `#EBEBEB` | Neutral 200 |
-| Border default | `--sa-color-border` | `#E0E0E0` | Neutral 300 |
-| Border input | `--sa-color-border-input` | `#D6D6D6` | Neutral 400 |
-| Error background | `--sa-color-error-bg` | `#FDF6F5` | Red 50 |
-| Error border | `--sa-color-error-border` | `#FFDFD9` | Red 200 |
-| Error text | `--sa-color-error-text` | `#EC3727` | Red 800 |
-| Success background | `--sa-color-success-bg` | `#EDFDF5` | Green 50 |
-| Success text | `--sa-color-success-text` | `#01905F` | Green 800 |
-| Warning background | `--sa-color-warning-bg` | `#FBF7D4` | Yellow 50 |
-| Warning text | `--sa-color-warning-text` | `#E57001` | Orange 700 |
-| Info background | `--sa-color-info-bg` | `#F1F8FD` | Light Blue 50 |
-| Info text | `--sa-color-info-text` | `#157BF4` | Light Blue 800 |
+These rules derive from Google Material Design and Apple Human Interface Guidelines, adopted by VTEX.
 
 ---
 
-## 3. Typography
-
-### Typeface
-
-The required typeface is **VTEX Trust** — the proprietary VTEX digital typeface. Always include system font fallbacks for environments where VTEX Trust is not loaded.
-
-```css
-font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-```
-
-Set this on the root `.container` class so all descendant elements inherit it.
-
-### Weights
-
-Use only these four weights: Regular (400), Medium (500), Semibold (600), Bold (700).
-
-### Allowed font sizes
-
-Only use sizes from this scale (px): **10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 44, 48**.
-
-Do not use arbitrary sizes like 13px, 15px, or 17px.
-
-| Use case | Size | Weight |
-|----------|------|--------|
-| Section title | 16px | Semibold (600) |
-| Subtitle / label | 14px | Medium (500) |
-| Body text | 14px | Regular (400) |
-| Caption / hint | 12px | Regular (400) |
-| Price | 18px | Semibold (600) |
-
----
-
-## 4. Iconography
+## 2. Iconography
 
 ### Library
 
-All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use other icon libraries (Material Icons, Font Awesome, Heroicons, etc.).
-
-### Sizes
-
-| Usage | Size |
-|-------|------|
-| Standard / default | 24px |
-| Compact / inline | 16px |
-| Large / featured | 32–48px |
-
-Always use sizes within the supported range: **16px to 48px**.
-
-### Weights
-
-Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
+All icons must come from **[Phosphor Icons](https://phosphoricons.com/)**. Do not use Material Icons, Font Awesome, Heroicons, or any other library.
 
 ### Installation
 
 ```bash
 yarn add @phosphor-icons/react
 ```
+
+### Sizes
+
+| Usage | Size |
+|-------|------|
+| Compact / inline | 16px |
+| Standard / default | 24px |
+| Large / featured | 32–48px |
+
+Always use sizes within **16px to 48px**.
+
+### Weights
+
+Use **Regular** or **Bold** weight variants. Keep the weight consistent within a single component.
 
 ### Usage example
 
@@ -172,74 +75,13 @@ export function MyExtension(): JSX.Element {
 
 ---
 
-## 5. Spacing and Baseline Grid
+## 3. Quick checklist
 
-All spacing values must be multiples of **4px** (the baseline grid). This applies to padding, margin, gap, and height values.
+Before presenting generated `.tsx` to the user, verify:
 
-| Value | Baseline multiple |
-|-------|-----------------|
-| 4px | 1× |
-| 8px | 2× |
-| 12px | 3× |
-| 16px | 4× |
-| 20px | 5× |
-| 24px | 6× |
-| 32px | 8× |
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-style placeholders)?
+- [ ] All icons imported from `@phosphor-icons/react`?
+- [ ] Icon sizes between 16px and 48px (24px default)?
+- [ ] Icon weights consistent within the component?
 
-**Do not use** values like 10px, 14px, 18px, or 22px for spacing. The only exception is font sizes, which follow the typography scale.
-
----
-
-## 6. Responsive Breakpoints
-
-Sales App extensions render within a host container that handles most layout responsiveness. Use these breakpoints only when the extension itself needs layout adjustments.
-
-| Breakpoint | Resolution range | Notes |
-|-----------|-----------------|-------|
-| Small (mobile) | 320–743px | Margin: 24px, no column grid |
-| Medium (tablet) | 744–1279px | Gutters: 16px |
-| Large (desktop) | 1280–1919px | Gutters: 20px |
-| Extra large (monitor) | 1920px+ | Gutters: 20px |
-
-Recommended mobile override (applied to the responsive section of the CSS file):
-
-```css
-@media (max-width: 743px) {
-  .container { padding: 12px; margin: 0 24px; }
-}
-```
-
----
-
-## 7. CSS File Structure
-
-Every extension CSS file must follow this structure:
-
-1. **Token declarations** — CSS custom properties on `.container`
-2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`
-3. **Typography classes** — `.title`, `.subtitle`, `.text`
-4. **State classes** — `.loading`, `.spinner`, `@keyframes`, `.error`
-5. **Component classes** — `.button`, `.card`, `.badge`, `.input`, `.price`
-6. **Responsive overrides** — `@media` queries at the bottom
-
-### Critical CSS rules
-
-- All `@keyframes` names must be prefixed with the component name (e.g., `@keyframes LoyaltyPoints-spin`). The template uses `${COMPONENT_NAME}-spin` as a placeholder.
-- No global selectors (`body`, `html`, `:root`, `*`, `#root`, `#__next`).
-- No `@import`, `position: fixed`, or `z-index: 9999`.
-- No hardcoded hex values — always use the `--sa-color-*` tokens declared on `.container`.
-
----
-
-## 8. Quick Compliance Checklist
-
-Before presenting generated CSS to the user, verify:
-
-- [ ] CSS custom properties (`--sa-color-*`) declared on `.container`?
-- [ ] No hardcoded hex values outside the token declarations block?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All font sizes from the allowed scale (10, 12, 14, 16, 18, 20...)?
-- [ ] All spacing multiples of 4px?
-- [ ] All icons from Phosphor Icons?
-- [ ] All UI text in sentence case (no ALL-CAPS)?
-- [ ] `@keyframes` names prefixed with `${COMPONENT_NAME}`?
+For CSS verification (tokens, fonts, spacing, responsive), see [code-templates-and-patterns.md](code-templates-and-patterns.md) §"Design system rules baked into this template".

--- a/tracks/sales-app/skills/sales-app-extensibility/references/design-guidelines.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/design-guidelines.md
@@ -201,7 +201,7 @@ Sales App extensions render within a host container that handles most layout res
 | Large (desktop) | 1280–1919px | Gutters: 20px |
 | Extra large (monitor) | 1920px+ | Gutters: 20px |
 
-Recommended mobile override (applied to the responsive section of the CSS module):
+Recommended mobile override (applied to the responsive section of the CSS file):
 
 ```css
 @media (max-width: 743px) {
@@ -211,9 +211,9 @@ Recommended mobile override (applied to the responsive section of the CSS module
 
 ---
 
-## 7. CSS Module Structure
+## 7. CSS File Structure
 
-Every extension CSS module must follow this structure:
+Every extension CSS file must follow this structure:
 
 1. **Token declarations** — CSS custom properties on `.container`
 2. **Layout classes** — `.container`, `.content`, `.row`, `.spaceBetween`

--- a/tracks/sales-app/skills/sales-app-extensibility/references/documentation-template.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/documentation-template.md
@@ -1,0 +1,60 @@
+---
+name: sales-app-documentation-template
+description: Markdown template for the docs/<ExtensionName>.md file generated in Step 4. Load when writing extension documentation to ensure all required sections are covered.
+metadata:
+  version: "1.0"
+---
+
+# Extension Documentation Template
+
+Generate `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist.
+
+The document must contain these 9 sections:
+
+1. **Extension name** — title matching the component name.
+2. **Overview** — one-paragraph summary of what the extension does and why it was built.
+3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
+4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
+5. **Component structure** — description of the component tree, props, and state management.
+6. **Styling** — CSS file name and summary of key classes.
+7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
+   - **Source documentation:** URL or file path of the original API documentation, if provided.
+   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
+   - Note which fields are optional (`?`) vs required per the documentation.
+8. **How to test** — dev server command and URL to reach the extension.
+9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+
+```markdown
+# <ExtensionName>
+
+## Overview
+<One-paragraph description of the extension purpose and value.>
+
+## Extension point
+- **Point:** `<extension.point.name>`
+- **Rationale:** <Why this extension point was selected.>
+
+## Hooks used
+| Hook | Purpose |
+|------|---------|
+| `useCart` | <What data it provides here> |
+
+## Component structure
+<Describe the component tree, key props, and internal state.>
+
+## Styling
+- **File:** `<ComponentName>.css`
+- <Summary of key CSS classes and design decisions.>
+
+## API integration
+- **Endpoint:** `/_v/...`
+- **Auth strategy:** IO Proxy / Direct / None
+- **Request/Response:** <Brief shape description.>
+
+## How to test
+Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
+
+## Known constraints
+- <Guard or limitation 1>
+- <Guard or limitation 2>
+```

--- a/tracks/sales-app/skills/sales-app-extensibility/references/static-analysis-rules.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/static-analysis-rules.md
@@ -1,0 +1,915 @@
+---
+name: sales-app-static-analysis-rules
+description: fsp-analyzer rule catalog for Sales App extension validation. Load during Step 3 (Code Generation & Validation) to check generated TypeScript/CSS against sandbox security, CSS containment, and React performance rules enforced at build time.
+metadata:
+  version: "1.0"
+---
+
+# Static Analysis Rules (fsp-analyzer)
+
+Sales App extensions run inside a sandboxed environment enforced by `@vtex/fsp-analyzer`. These rules are checked at `preBuild` and `preDev` hook time. The AI must validate all generated code against these rules before presenting it to the user.
+
+Rule IDs match the `ViolationKind`, `ReactViolationKind`, `WarningKind`, and `ReactWarningKind` types from `@vtex/fsp-analyzer` so developers can cross-reference with real build output.
+
+---
+
+## How to apply these rules
+
+After generating a component, CSS file, and `index.tsx`, check each generated file against the **violation** rules (block generation — fix before presenting) and the **warning** rules (flag to the user with a suggestion). Do not present code that has unresolved violations.
+
+---
+
+## 1. Sandbox Security Rules
+
+Applied to `.ts` and `.tsx` files by `FastStoreSandboxAnalyzer`.
+
+### `RESTRICTED_API` — DOM API access banned
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted identifiers: `document`, `window`, `localStorage`, `sessionStorage`, `navigator`.
+
+**Detection:** Any use of these identifiers as a value (not as a type import).
+
+**Correct**
+```typescript
+// Use React state and props for data; use useExtension() for account context
+const { account } = useExtension();
+```
+
+**Wrong**
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+---
+
+### `VARIABLE_ALIASING` — Aliasing restricted APIs
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Assigning a restricted API to a variable to circumvent detection.
+
+**Detection:** `const x = document`, `const [w, d] = [window, document]`, or any destructuring that aliases a restricted API.
+
+**Correct**
+```typescript
+// Pass data via props or React context, not via aliased globals
+```
+
+**Wrong**
+```typescript
+const doc = document;
+const [w, d] = [window, document];
+doc.querySelector('.item');
+```
+
+---
+
+### `GLOBAL_MANIPULATION` — Global object manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted member expressions: `window.location`, `window.history`.
+
+**Detection:** Member expressions on `window` to access `location` or `history`.
+
+**Correct**
+```typescript
+// Navigation is managed by Sales App shell; do not manipulate location
+```
+
+**Wrong**
+```typescript
+window.location.href = '/new-path';
+window.location.reload();
+```
+
+---
+
+### `HISTORY_MANIPULATION` — Browser history manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `window.history.pushState`, `window.history.replaceState`, `history.pushState`, `history.replaceState`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Let the Sales App shell handle routing
+```
+
+**Wrong**
+```typescript
+history.pushState({}, '', '/cart');
+window.history.replaceState(null, '', '/pdp');
+```
+
+---
+
+### `DYNAMIC_SCRIPT_CREATION` — Dynamic script creation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `document.createElement`, `document.write`, `document.writeln`, `document.body.appendChild`, `document.head.appendChild`.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Render UI via JSX; never inject scripts dynamically
+```
+
+**Wrong**
+```typescript
+const script = document.createElement('script');
+script.src = 'https://cdn.example.com/lib.js';
+document.body.appendChild(script);
+```
+
+---
+
+### `CODE_EXECUTION` — Arbitrary code execution
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `eval`, `Function` (as constructor), `setTimeout` (string form), `setInterval` (string form), `new Function`.
+
+**Detection:** Any call or instantiation of these identifiers.
+
+> **Note on `setTimeout`/`setInterval`:** These are restricted in the sandbox to prevent arbitrary code injection. Use `useEffect` with `AbortController` or cleanup functions for timing-based logic:
+
+**Correct**
+```typescript
+useEffect(() => {
+  const id = window.setTimeout(() => { /* logic */ }, 500);
+  return () => window.clearTimeout(id);
+}, []);
+// Note: even this should be reviewed; prefer event-driven patterns
+```
+
+**Wrong**
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+---
+
+### `RESTRICTED_IMPORT` — Restricted Node.js module imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted modules: `fs`, `path`, `child_process`, `crypto`.
+
+**Detection:** Any `import` statement importing from these module names.
+
+**Correct**
+```typescript
+// Extensions are browser-only React components; do not import Node.js modules
+import { useCart } from '@vtex/sales-app';
+```
+
+**Wrong**
+```typescript
+import fs from 'fs';
+import { resolve } from 'path';
+import crypto from 'crypto';
+```
+
+---
+
+### `RESTRICTED_IMPORT_SOURCE` — Direct node_modules path imports
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Import paths containing `node_modules/`.
+
+**Wrong**
+```typescript
+import something from 'node_modules/lodash/get';
+```
+
+---
+
+### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+
+**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+
+> **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
+
+**Correct**
+```typescript
+// Always use IO Proxy relative path
+const response = await fetch('/_v/my-loyalty-api/points', {
+  credentials: 'include',
+});
+```
+
+**Wrong**
+```typescript
+const response = await fetch('https://api.example.com/data');
+const xhr = new XMLHttpRequest();
+```
+
+---
+
+### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
+
+**Detection:** `fetch()` first argument literal containing one of these domains.
+
+**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
+
+---
+
+### `QUERY_SELECTOR_USAGE` — DOM query selectors
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
+
+**Detection:** Any call to these methods.
+
+**Correct**
+```typescript
+// Use React refs for direct DOM access when absolutely needed
+const ref = useRef<HTMLDivElement>(null);
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.my-class');
+document.getElementById('cart-container');
+```
+
+---
+
+### `STYLE_MANIPULATION` — Direct style manipulation
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
+
+**Detection:** Any member expression matching these patterns.
+
+**Correct**
+```typescript
+// Use CSS modules and conditional class application
+import styles from './MyExtension.module.css';
+
+return <div className={isActive ? styles.active : styles.inactive} />;
+```
+
+**Wrong**
+```typescript
+element.style.color = 'red';
+element.classList.add('active');
+element.setAttribute('style', 'display: none');
+```
+
+---
+
+### `INFINITE_LOOP` — Infinite loops
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+
+**Wrong**
+```typescript
+while (true) {
+  processItem();
+}
+```
+
+---
+
+### `MEMORY_LEAK` — Memory leak patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  window.addEventListener('resize', handler);
+  // Missing cleanup — memory leak
+}, []);
+```
+
+---
+
+### `EXCESSIVE_API_CALLS` — Excessive API call patterns
+
+**Severity:** Violation (block)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+
+**Wrong**
+```typescript
+// fetch inside render — fires on every re-render
+const data = await fetch('/_v/api/data');
+
+// fetch inside loop — excessive calls
+for (const item of items) {
+  await fetch(`/_v/api/item/${item.id}`);
+}
+```
+
+---
+
+### `LARGE_BUNDLE_SIZE_IMPACT` — Bundle size impacts
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:**
+- String literals longer than 1,000 characters
+- Object literals with more than 100 properties
+- Imports from heavyweight libraries: `lodash`, `moment`
+
+**Action:** Warn the user and suggest alternatives (`date-fns` instead of `moment`, native array methods instead of `lodash`).
+
+**Correct**
+```typescript
+import { format } from 'date-fns';
+const formattedDate = format(new Date(), 'yyyy-MM-dd');
+```
+
+**Wrong**
+```typescript
+import moment from 'moment';
+import _ from 'lodash';
+```
+
+---
+
+## 2. CSS Containment Rules
+
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+
+### `CSS_GLOBAL_SELECTOR` — Global element selectors
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
+
+**Detection:** Any CSS rule whose selector matches or contains these elements at the top level.
+
+**Correct**
+```css
+/* Scope all rules inside the extension container */
+.extension-container {
+  font-size: 14px;
+}
+
+.extension-container .title {
+  font-weight: bold;
+}
+```
+
+**Wrong**
+```css
+body {
+  font-size: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --my-color: red;
+}
+```
+
+---
+
+### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
+
+**Detection:** Any rule or declaration matching these patterns.
+
+> **Note on positioning:** `position: relative` and `position: sticky` within the extension container are generally safe. Avoid `fixed` and unbounded `absolute` that escape the extension boundary.
+
+**Correct**
+```css
+.extension-container {
+  position: relative; /* safe — contained */
+}
+```
+
+**Wrong**
+```css
+.overlay {
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+}
+
+:host {
+  display: block;
+}
+```
+
+---
+
+### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+
+**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+
+**Correct**
+```css
+/* CSS Module — all classes are auto-scoped */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+```css
+/* Plain CSS — must namespace manually */
+.extension-container { padding: 8px; }
+.extension-title { font-size: 16px; }
+```
+
+**Wrong**
+```css
+/* Plain CSS — no namespace — pollutes global styles */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+```
+
+---
+
+### `CSS_GLOBAL_IMPORT` — CSS @import rules
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@import` pulls external stylesheets that affect global styles and bypass containment.
+
+**Detection:** Any `@import` at-rule anywhere in the CSS file.
+
+**Correct**
+```css
+/* Import a local CSS variable file via bundler config, not @import */
+```
+
+**Wrong**
+```css
+@import url('https://fonts.googleapis.com/css2?family=Roboto');
+@import './reset.css';
+```
+
+---
+
+### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+
+**Correct**
+```css
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+```css
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+---
+
+### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
+
+**Detection:** Declarations using restricted property names (e.g., properties that set global layout hints).
+
+**Action:** If detected, remove or scope the declaration appropriately.
+
+---
+
+### `CSS_RESTRICTED_VALUE` — Restricted CSS values
+
+**Severity:** Violation (block)  
+**Files:** `.css`, `.module.css`
+
+Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
+
+**Detection:** `!important` in any declaration, or values targeting global layout tokens.
+
+**Correct**
+```css
+.extension-button {
+  color: var(--vtex-color-primary);
+}
+```
+
+**Wrong**
+```css
+.extension-button {
+  color: red !important;
+}
+```
+
+---
+
+## 3. React Performance Rules
+
+Applied to `.tsx` files by `ReactPerformanceAnalyzer`. Violations block presentation; warnings are flagged to the user.
+
+### `REACT_UNNECESSARY_RERENDER` — State update inside loop
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+State setter calls inside `for` or `while` loops trigger a re-render on every iteration.
+
+**Detection:** A `setState` / `set*` call whose parent node is a `for` or `while` statement.
+
+**Correct**
+```typescript
+// Compute derived value, then set once
+const updatedItems = items.map(transform);
+setItems(updatedItems);
+```
+
+**Wrong**
+```typescript
+for (const item of items) {
+  setCount((c) => c + 1); // re-renders on every iteration
+}
+```
+
+---
+
+### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
+
+**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
+
+**Correct**
+```typescript
+const filteredItems = useMemo(() => items.filter(isActive), [items]);
+
+return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
+  </ul>
+);
+```
+
+---
+
+### `REACT_ANONYMOUS_COMPONENT` — Anonymous (lowercase) component
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Components assigned to variables starting with lowercase are treated as HTML tags by React and cannot be used in JSX.
+
+**Detection:** Arrow function or function expression assigned to a variable that does not start with an uppercase letter.
+
+**Correct**
+```typescript
+export function LoyaltyPoints(): JSX.Element { ... }
+export const WarrantyBadge = (): JSX.Element => { ... };
+```
+
+**Wrong**
+```typescript
+const loyaltyPoints = (): JSX.Element => { ... };
+const warrantyBadge = function() { ... };
+```
+
+---
+
+### `REACT_DIRECT_DOM_MANIPULATION` — Direct DOM manipulation in React
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Bypasses the React virtual DOM and causes unpredictable behavior.
+
+**Detection:** Calls to `document.querySelector` or `document.getElementById` inside a React component.
+
+**Correct**
+```typescript
+const containerRef = useRef<HTMLDivElement>(null);
+// Access DOM via containerRef.current
+```
+
+**Wrong**
+```typescript
+const el = document.querySelector('.cart-list');
+el.style.display = 'none'; // bypasses React
+```
+
+---
+
+### `REACT_LAYOUT_EFFECT_MISUSE` — useLayoutEffect usage
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+`useLayoutEffect` blocks the browser paint and can cause performance issues in a sandboxed extension.
+
+**Detection:** Any call to `useLayoutEffect`.
+
+**Correct**
+```typescript
+useEffect(() => {
+  // DOM reading/writing after paint
+}, []);
+```
+
+**Wrong**
+```typescript
+useLayoutEffect(() => {
+  // blocks paint
+}, []);
+```
+
+---
+
+### `REACT_MISSING_DEPS` — Missing dependency array
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useEffect`, `useCallback`, or `useMemo` without a second argument re-runs on every render.
+
+**Detection:** A call to one of these hooks with fewer than 2 arguments, or with a non-array second argument.
+
+**Correct**
+```typescript
+useEffect(() => {
+  fetchData();
+}, [productId]); // explicit deps
+```
+
+**Wrong**
+```typescript
+useEffect(() => {
+  fetchData(); // runs on every render
+});
+```
+
+---
+
+### `REACT_INLINE_FUNCTION` — Inline functions in JSX props
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Arrow functions defined directly in JSX attributes create a new function reference on every render, preventing child memoization.
+
+**Detection:** Function expression or arrow function expression whose parent is a JSX expression container or prop.
+
+**Correct**
+```typescript
+const handleClick = useCallback(() => {
+  doSomething();
+}, []);
+
+return <button onClick={handleClick}>Click</button>;
+```
+
+**Wrong**
+```typescript
+return <button onClick={() => doSomething()}>Click</button>;
+```
+
+---
+
+### `REACT_LARGE_COMPONENT` — Component over 200 lines
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Large components are harder to maintain and test. Threshold: **200 lines**.
+
+**Detection:** A function/arrow function with start/end line difference > 200.
+
+**Action:** Suggest splitting into smaller sub-components or extracting logic into custom hooks.
+
+---
+
+### `REACT_MANY_USESTATE` — More than 5 useState calls
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Many `useState` calls in a single component indicate complex local state. Threshold: **5 calls**.
+
+**Detection:** More than 5 calls to `useState` (or `React.useState`) within a single function component.
+
+**Action:** Suggest consolidating related state into a single `useState` with an object, or extracting to a custom hook.
+
+**Correct**
+```typescript
+const [formState, setFormState] = useState({
+  name: '',
+  email: '',
+  quantity: 1,
+});
+```
+
+**Wrong**
+```typescript
+const [name, setName] = useState('');
+const [email, setEmail] = useState('');
+const [quantity, setQuantity] = useState(1);
+const [loading, setLoading] = useState(false);
+const [error, setError] = useState<string | null>(null);
+const [submitted, setSubmitted] = useState(false); // 6th useState — flagged
+```
+
+---
+
+### `REACT_CONDITIONAL_HOOK` — Hook called conditionally
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a hook inside an `if`, `switch`, or ternary expression violates the Rules of Hooks.
+
+**Detection:** A hook call (useEffect, useState, useMemo, useCallback, useLayoutEffect) whose ancestor is an `IfStatement`, `SwitchStatement`, or `ConditionalExpression`.
+
+**Correct**
+```typescript
+const cart = useCart(); // always called unconditionally
+
+if (!cart) return <></>;
+```
+
+**Wrong**
+```typescript
+if (isEnabled) {
+  const cart = useCart(); // conditional hook call — violates Rules of Hooks
+}
+```
+
+---
+
+### `REACT_COMPLEX_JSX` — Deep JSX nesting
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Deep JSX trees are harder to read and may indicate a need to extract sub-components. Threshold: **5 levels deep**.
+
+**Detection:** A JSX element whose JSX child tree exceeds 5 levels of nesting.
+
+**Action:** Extract inner JSX into a named sub-component.
+
+---
+
+### `REACT_UNOPTIMIZED_LIST` — List rendering without key or large list
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Missing `key` props in list rendering causes React reconciliation issues. Lists over 50 items may need virtualization.
+
+**Detection:**
+- `map()` producing JSX without a `key` attribute on the root element
+- List size exceeding 50 items
+
+**Correct**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li key={item.id}>{item.name}</li>
+    ))}
+  </ul>
+);
+```
+
+**Wrong**
+```typescript
+return (
+  <ul>
+    {items.map((item) => (
+      <li>{item.name}</li> // missing key
+    ))}
+  </ul>
+);
+```
+
+---
+
+### `REACT_COMPLEX_STATE` — useState with complex object
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+`useState` initialized with an object having more than 5 properties suggests a need for `useReducer`. Threshold: **5 properties**.
+
+**Detection:** `useState(obj)` where `obj` is an object literal with > 5 properties.
+
+**Action:** Suggest converting to `useReducer` for complex state.
+
+---
+
+### `REACT_NESTED_UPDATE` — Nested state updates
+
+**Severity:** Warning (flag)  
+**Files:** `.tsx`
+
+Calling a state setter from within another state setter's callback can cause unexpected re-renders.
+
+**Detection:** A `set*` call whose ancestor is another `set*` call expression.
+
+---
+
+## Validation Output Format
+
+When reporting issues after code review, group by file and severity:
+
+```
+### Static Analysis Results
+
+**Violations (must fix before completing Step 3):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Fix: <suggested fix>
+
+**Warnings (review with user):**
+- [RULE_ID] File: ComponentName.tsx, Line ~N — <message>
+  Suggestion: <improvement>
+
+✅ No violations found. N warnings flagged.
+```
+
+Do not proceed with Step 4 (Documentation) until all violations are resolved.

--- a/tracks/sales-app/skills/sales-app-extensibility/references/static-analysis-rules.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/static-analysis-rules.md
@@ -204,20 +204,33 @@ import something from 'node_modules/lodash/get';
 
 ---
 
+### `NON_APPROVED_PACKAGE` — Import from non-approved package
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Any import whose source starts with `@` or contains `/`, unless it is `react` or a `node_modules/` direct path. Fires for every `@vtex/*` scoped package and every relative import (`./foo`, `../bar`).
+
+> **Note:** This warning is noisy — it fires for all legitimate Sales App imports (`@vtex/sales-app`, `@phosphor-icons/react`, relative component paths). Do not surface to the user when the import is from `@vtex/*` or a relative path. Investigate only when the import is from an unexpected third-party package.
+
+**Detection:** `import { … } from 'source'` where `source.startsWith('@')` or `source.includes('/')`, and source is not `'react'` or a `node_modules/` path.
+
+---
+
 ### `EXTERNAL_RESOURCE_LOADING` — Unrestricted external resource loading
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-Restricted expressions: `fetch` (to external URLs), `XMLHttpRequest`, `script.src`, `link.href`.
+Two detection paths:
 
-**Detection:** `fetch` calls where the first argument is a known third-party domain string, or direct use of `XMLHttpRequest`.
+1. **Direct API use:** `fetch`, `XMLHttpRequest`, `script.src`, `link.href` used as member expressions.
+2. **Known CDN domains in string literal:** `fetch('https://cdn.jsdelivr.net/...')` or any URL containing `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`, `api.example.com`, or ending with `.js`.
 
 > **Exception:** `fetch` via the IO Proxy relative path (`/_v/...`) is allowed and required for secure API integration.
 
 **Correct**
 ```typescript
-// Always use IO Proxy relative path
 const response = await fetch('/_v/my-loyalty-api/points', {
   credentials: 'include',
 });
@@ -226,6 +239,7 @@ const response = await fetch('/_v/my-loyalty-api/points', {
 **Wrong**
 ```typescript
 const response = await fetch('https://api.example.com/data');
+const response = await fetch('https://cdn.jsdelivr.net/npm/lodash.js'); // CDN — also Violation
 const xhr = new XMLHttpRequest();
 ```
 
@@ -233,14 +247,14 @@ const xhr = new XMLHttpRequest();
 
 ### `EXTERNAL_RESOURCE_FETCH` — Fetch to known CDN domains
 
-**Severity:** Warning (flag)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. CDN domain fetches are actually reported as `EXTERNAL_RESOURCE_LOADING` (Violation, block) — not as this Warning. Treat any fetch to a CDN domain as a **build-blocking Violation**, not a soft warning.
+
+**Severity:** Warning (flag) — *see note above; actual enforcement is via `EXTERNAL_RESOURCE_LOADING`*  
 **Files:** `.ts`, `.tsx`
 
 Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.com`, `ajax.googleapis.com`, `code.jquery.com`.
 
 **Detection:** `fetch()` first argument literal containing one of these domains.
-
-**Action:** Warn the user. These external fetches bypass the IO Proxy and may expose security risks or fail in the sandbox.
 
 ---
 
@@ -251,7 +265,7 @@ Known third-party domains: `cdn.jsdelivr.net`, `unpkg.com`, `cdnjs.cloudflare.co
 
 Restricted calls: `document.getElementById`, `document.getElementsByClassName`, `document.getElementsByTagName`, `document.querySelector`, `document.querySelectorAll`, and element-scoped variants.
 
-**Detection:** Any call to these methods.
+**Detection:** Any call where the callee matches `document.querySelector`, `document.getElementById`, etc. (the variable must be literally named `document`). Calls via a ref object — e.g. `containerRef.current.querySelector(...)` — are **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
@@ -274,14 +288,14 @@ document.getElementById('cart-container');
 
 Restricted expressions: `element.style`, `element.className`, `element.classList`, `element.setAttribute.style`, `element.setAttribute.class`, `element.hidden`, `element.display`, `element.visibility`.
 
-**Detection:** Any member expression matching these patterns.
+**Detection:** Matches only when the object is literally named `element` (e.g. `element.style`). Equivalent access through other variable names — e.g. `divRef.current.style`, `el.className` — is **not** caught by the analyzer and must be avoided as a Hard Constraint.
 
 **Correct**
 ```typescript
-// Use plain CSS with namespaced class names
+// Use plain CSS classes from the component stylesheet
 import './MyExtension.css';
 
-return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
+return <div className={isActive ? 'active' : 'inactive'} />;
 ```
 
 **Wrong**
@@ -298,7 +312,7 @@ element.setAttribute('style', 'display: none');
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `while(true)`, `for(;;)` with no update/test, or `do...while(true)` without a termination condition.
+**Detection:** `while(true)` or `do...while(true)` with literal `true` condition.
 
 **Wrong**
 ```typescript
@@ -309,9 +323,22 @@ while (true) {
 
 ---
 
+### `POTENTIAL_INFINITE_LOOP` — Incomplete for-loop
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+**Detection:** `for` statement with no `update` expression AND no `test` expression (e.g. `for (let i = 0;;) { … }`).
+
+**Action:** Warn the user and ensure the loop has a proper termination condition.
+
+---
+
 ### `MEMORY_LEAK` — Memory leak patterns
 
-**Severity:** Violation (block)  
+> **Note:** This rule ID is declared in the analyzer type system but is never raised by any handler. The active rule is `POTENTIAL_MEMORY_LEAK` (Warning) below. Event listeners without cleanup **will not block the build**, but remain a Hard Constraint — always add a cleanup return in `useEffect`.
+
+**Severity:** Violation (block) — *see note above; not currently enforced at build time*  
 **Files:** `.ts`, `.tsx`
 
 **Detection:** Event listeners, subscriptions, or timers added without cleanup in `useEffect`.
@@ -335,23 +362,58 @@ useEffect(() => {
 
 ---
 
+### `POTENTIAL_MEMORY_LEAK` — Likely memory leak patterns
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Three triggers:
+1. Any `addEventListener` call — the analyzer warns regardless of whether a corresponding `removeEventListener` exists in cleanup.
+2. Recursive function call where the callee name matches the parent `FunctionDeclaration` identifier.
+3. `Array.push` inside a `for` or `while` loop.
+
+**Action:** Verify the component has a proper cleanup return in `useEffect` for any event listener, and that recursive functions have a clear base case.
+
+**Correct**
+```typescript
+useEffect(() => {
+  const handler = () => { /* ... */ };
+  window.addEventListener('resize', handler);
+  return () => window.removeEventListener('resize', handler);
+}, []);
+```
+
+---
+
 ### `EXCESSIVE_API_CALLS` — Excessive API call patterns
 
 **Severity:** Violation (block)  
 **Files:** `.ts`, `.tsx`
 
-**Detection:** `fetch` calls or API calls triggered inside render (outside `useEffect`) or inside loops.
+**Detection:** `fetch` or `XMLHttpRequest` calls whose parent is a `for` or `while` loop.
 
 **Wrong**
 ```typescript
-// fetch inside render — fires on every re-render
-const data = await fetch('/_v/api/data');
-
 // fetch inside loop — excessive calls
 for (const item of items) {
   await fetch(`/_v/api/item/${item.id}`);
 }
 ```
+
+---
+
+### `FREQUENT_API_CALLS` — API call outside loop / rapid setInterval
+
+**Severity:** Warning (flag)  
+**Files:** `.ts`, `.tsx`
+
+Two triggers:
+1. `fetch` or `XMLHttpRequest` call **outside** a loop (i.e. anywhere else in the component). Fires for every fetch — ensure calls are wrapped in `useEffect` with proper deps and are rate-limited or cached.
+2. `setInterval` with a numeric delay argument below 1000 ms.
+
+> **Note:** Trigger 1 is intentionally broad — it flags every `fetch()` call as a reminder to verify it is not running unintentionally on every render. It does **not** mean every fetch is wrong. Only surface this to the user when the fetch is genuinely outside a `useEffect` or appears to run on each render.
+
+**Action:** Warn the user and suggest wrapping fetches in `useEffect`, using caching, or increasing the polling interval.
 
 ---
 
@@ -383,7 +445,25 @@ import _ from 'lodash';
 
 ## 2. CSS Containment Rules
 
-Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix defaults to `extension-` (configured via `allowedNamespaces`).
+Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`.
+
+**Sales App analyzer configuration** (from `@vtex/sales-app` build/dev hook):
+
+```typescript
+cssOptions: {
+  allowedNamespaces: ['sales-app-extension-'],
+  defaultNamespace: 'sales-app-extension-',
+  transformNonCompliant: true,
+  overwriteTransformed: true,
+}
+```
+
+Two consequences for the rules below:
+
+1. The configured namespace is **`sales-app-extension-`**, not the analyzer's bare default of `extension-`. Any rule that talks about "the allowed namespace" means `sales-app-extension-` in this project.
+2. `transformNonCompliant: true` softens the namespace rules: when a selector or `@keyframes` name is not prefixed, the analyzer auto-rewrites it into a sibling `*.transformed.css` file and emits a `CSS_TRANSFORMED` **warning** instead of a `CSS_NAMESPACE_REQUIRED` / `CSS_GLOBAL_KEYFRAMES` **violation**. The original `.css` (and the `className` strings in JSX) are left untouched, so the build does not break. This is why the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) ships unprefixed selectors like `.container`, `.title`, `.row` — they are valid in this project.
+
+The other CSS rules (`CSS_GLOBAL_SELECTOR`, `CSS_CONTAINMENT_BREAKOUT`, `CSS_GLOBAL_IMPORT`, `CSS_RESTRICTED_PROPERTY`, `CSS_RESTRICTED_VALUE`, and the inline-style rules) are **not** softened by `transformNonCompliant` — they remain build-blocking violations.
 
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
@@ -396,12 +476,12 @@ Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#_
 
 **Correct**
 ```css
-/* Scope all rules inside the extension container */
-.extension-container {
+/* Scope rules inside the extension container — never target global elements */
+.container {
   font-size: 14px;
 }
 
-.extension-container .title {
+.container .title {
   font-weight: bold;
 }
 ```
@@ -436,7 +516,7 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 **Correct**
 ```css
-.extension-container {
+.container {
   position: relative; /* safe — contained */
 }
 ```
@@ -459,26 +539,27 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
+All CSS selectors should be scoped under an allowed namespace prefix. In the Sales App, that prefix is `sales-app-extension-`. Because the project sets `transformNonCompliant: true`, an unprefixed selector does **not** block the build: the analyzer rewrites it inside a sibling `Component.transformed.css` and emits a `CSS_TRANSFORMED` warning instead of `CSS_NAMESPACE_REQUIRED`. The original `Component.css` (which is what gets bundled) keeps the unprefixed class, so the JSX `className="container"` continues to match.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
+**Detection:** A selector that does not include any value from `allowedNamespaces` (substring check on `.namespace`, `#namespace`, or `[class*="namespace"]`).
 
-**Correct**
+**Correct (and matches the CSS template)**
 ```css
-/* Plain CSS — namespace all classes */
-.extension-container { padding: 8px; }
-.extension-title { font-size: 16px; }
-```
-
-**Wrong**
-```css
-/* Plain CSS — no namespace — pollutes global styles */
+/* Unprefixed top-level classes are accepted because transformNonCompliant=true. */
 .container { padding: 8px; }
-.title { font-size: 16px; }
+.title     { font-size: 16px; }
 ```
+
+**Also correct (explicit prefix, never warns)**
+```css
+.sales-app-extension-container { padding: 8px; }
+.sales-app-extension-title     { font-size: 16px; }
+```
+
+> Prefer the unprefixed form to match the CSS template in [code-templates-and-patterns.md](code-templates-and-patterns.md) and the JSX in the component templates. The `CSS_TRANSFORMED` warning that fires for these is informational only.
 
 ---
 
@@ -506,26 +587,27 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
-**Severity:** Violation (block)  
+**Severity:** Warning in this project (auto-transformed) — would be Violation if `transformNonCompliant` were `false`  
 **Files:** `.css`
 
-`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
+`@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell. As with `CSS_NAMESPACE_REQUIRED`, `transformNonCompliant: true` rewrites the name in `*.transformed.css` and emits `CSS_TRANSFORMED` instead of blocking.
 
-**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix.
+**Detection:** `@keyframes` whose name does not start with an allowed namespace prefix (`sales-app-extension-` in this project).
 
-**Correct**
+The CSS template prefixes keyframes with `${COMPONENT_NAME}-` (e.g. `LoyaltyPoints-spin`). That prefix does **not** start with `sales-app-extension-`, so it triggers a `CSS_TRANSFORMED` warning — the build still succeeds, but the transformed file will rename it to `sales-app-extension-LoyaltyPoints-spin`. Either form is acceptable.
+
+**Correct (no warning)**
 ```css
-@keyframes extension-fade-in {
+@keyframes sales-app-extension-fade-in {
   from { opacity: 0; }
   to   { opacity: 1; }
 }
 ```
 
-**Wrong**
+**Also correct (CSS_TRANSFORMED warning, build passes)**
 ```css
-@keyframes fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+@keyframes LoyaltyPoints-spin {
+  to { transform: rotate(360deg); }
 }
 ```
 
@@ -555,16 +637,59 @@ Certain CSS values (e.g., `!important`) override the cascade and break containme
 
 **Correct**
 ```css
-.extension-button {
-  color: var(--vtex-color-primary);
+.button {
+  color: var(--sa-color-primary);
 }
 ```
 
 **Wrong**
 ```css
-.extension-button {
+.button {
   color: red !important;
 }
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_PROPERTY` — Restricted property in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props in JSX may not use properties that affect layout or containment.
+
+Restricted properties: `position`, `z-index`, `top`, `left`, `right`, `bottom`, `all`, `contain`, `content`, `isolation`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted property names.
+
+**Correct**
+```typescript
+// Use CSS classes for layout properties
+return <div className="overlay" />;
+```
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed', top: 0 }} />;
+```
+
+---
+
+### `CSS_RESTRICTED_INLINE_VALUE` — Restricted value in inline style
+
+**Severity:** Violation (block)  
+**Files:** `.tsx`
+
+Inline `style={{ … }}` props may not use values that break containment or cascade.
+
+Restricted values: `fixed`, `absolute`, `!important`, `inherit`, `initial`, `unset`.
+
+**Detection:** A JSX `style` prop object containing one of the restricted values.
+
+**Wrong**
+```typescript
+return <div style={{ position: 'fixed' }} />;
+return <div style={{ display: 'inherit' }} />;
 ```
 
 ---
@@ -594,33 +719,6 @@ setItems(updatedItems);
 for (const item of items) {
   setCount((c) => c + 1); // re-renders on every iteration
 }
-```
-
----
-
-### `REACT_EXPENSIVE_OPERATION` — Expensive array operations in render
-
-**Severity:** Violation (block)  
-**Files:** `.tsx`
-
-`Array.map`, `Array.filter`, `Array.reduce` called inside JSX expressions or as direct prop values fire on every render.
-
-**Detection:** A call to these methods whose parent is a JSX expression container or a prop value.
-
-**Correct**
-```typescript
-const filteredItems = useMemo(() => items.filter(isActive), [items]);
-
-return <ul>{filteredItems.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;
-```
-
-**Wrong**
-```typescript
-return (
-  <ul>
-    {items.filter(isActive).map((i) => <li key={i.id}>{i.name}</li>)}
-  </ul>
-);
 ```
 
 ---

--- a/tracks/sales-app/skills/sales-app-extensibility/references/static-analysis-rules.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/references/static-analysis-rules.md
@@ -278,10 +278,10 @@ Restricted expressions: `element.style`, `element.className`, `element.classList
 
 **Correct**
 ```typescript
-// Use CSS modules and conditional class application
-import styles from './MyExtension.module.css';
+// Use plain CSS with namespaced class names
+import './MyExtension.css';
 
-return <div className={isActive ? styles.active : styles.inactive} />;
+return <div className={isActive ? 'extension-active' : 'extension-inactive'} />;
 ```
 
 **Wrong**
@@ -388,7 +388,7 @@ Applied to `.css`, `.scss`, `.less` files by `CSSAnalyzer`. CSS namespace prefix
 ### `CSS_GLOBAL_SELECTOR` — Global element selectors
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted selectors: `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next`.
 
@@ -426,7 +426,7 @@ body {
 ### `CSS_CONTAINMENT_BREAKOUT` — CSS containment breakout
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position: fixed`, `position: absolute`, `z-index: 9999`.
 
@@ -460,21 +460,15 @@ Restricted patterns: `:host`, `:host-context`, `::slotted`, `:global`, `position
 ### `CSS_NAMESPACE_REQUIRED` — Missing CSS namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
-All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). A CSS Module file that uses `styles.someClass` in JSX automatically scopes classes — this is the recommended pattern.
+All CSS selectors must be scoped under an allowed namespace prefix (default: `extension-`). The project uses plain CSS (not CSS modules), so all classes must be manually namespaced.
 
-**Detection:** A selector not prefixed with any value from `allowedNamespaces` (when not using CSS Modules).
+**Detection:** A selector not prefixed with any value from `allowedNamespaces`.
 
 **Correct**
 ```css
-/* CSS Module — all classes are auto-scoped */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-```
-
-```css
-/* Plain CSS — must namespace manually */
+/* Plain CSS — namespace all classes */
 .extension-container { padding: 8px; }
 .extension-title { font-size: 16px; }
 ```
@@ -491,7 +485,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_IMPORT` — CSS @import rules
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@import` pulls external stylesheets that affect global styles and bypass containment.
 
@@ -513,7 +507,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_GLOBAL_KEYFRAMES` — Keyframes without namespace
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 `@keyframes` names are global. Without a namespace they may conflict with other extensions or the Sales App shell.
 
@@ -540,7 +534,7 @@ All CSS selectors must be scoped under an allowed namespace prefix (default: `ex
 ### `CSS_RESTRICTED_PROPERTY` — Restricted CSS properties
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain properties affect layout or rendering globally and are restricted to prevent layout shift or containment breakout.
 
@@ -553,7 +547,7 @@ Certain properties affect layout or rendering globally and are restricted to pre
 ### `CSS_RESTRICTED_VALUE` — Restricted CSS values
 
 **Severity:** Violation (block)  
-**Files:** `.css`, `.module.css`
+**Files:** `.css`
 
 Certain CSS values (e.g., `!important`) override the cascade and break containment guarantees.
 

--- a/tracks/sales-app/skills/sales-app-extensibility/skill.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/skill.md
@@ -348,6 +348,114 @@ Discovery → Requirements → Present plan → **User approves** → Generate c
 **Wrong**
 Discovery → Generate code immediately.
 
+### Constraint: Never access DOM APIs directly
+
+Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
+
+**Why this matters**
+Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
+
+**Detection**
+Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
+
+**Correct**
+
+```typescript
+// Use React state, props, and Sales App hooks for data
+const { account } = useExtension();
+const cart = useCart();
+```
+
+**Wrong**
+
+```typescript
+const userId = localStorage.getItem('userId');
+const width = window.innerWidth;
+document.title = 'My Extension';
+```
+
+### Constraint: Never import restricted Node.js modules
+
+Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
+
+**Why this matters**
+Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
+
+**Detection**
+`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
+
+**Correct**
+
+```typescript
+import { useCart } from '@vtex/sales-app';
+import React, { useState, useEffect } from 'react';
+```
+
+**Wrong**
+
+```typescript
+import fs from 'fs';
+import crypto from 'crypto';
+```
+
+### Constraint: Never use eval or the Function constructor
+
+Arbitrary code execution is banned in the sandbox.
+
+**Why this matters**
+`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
+
+**Detection**
+Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
+
+**Correct**
+
+```typescript
+const result = computeValue(input); // deterministic logic only
+```
+
+**Wrong**
+
+```typescript
+eval('doSomething()');
+const fn = new Function('return 42');
+setTimeout('doSomething()', 1000);
+```
+
+### Constraint: CSS must use namespaced selectors — no global elements
+
+Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
+
+**Why this matters**
+Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
+
+**Detection**
+Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
+
+**Correct**
+
+```css
+/* CSS Module — classes are auto-scoped by the bundler */
+.container { padding: 8px; }
+.title { font-size: 16px; }
+
+@keyframes extension-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+```
+
+**Wrong**
+
+```css
+body { font-size: 14px; }
+* { box-sizing: border-box; }
+:root { --my-color: red; }
+@import './reset.css';
+.overlay { position: fixed; z-index: 9999; }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -358,7 +466,7 @@ Discovery → Generate code immediately.
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 10-point checklist. If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, and the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -426,6 +534,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
+| [references/static-analysis-rules.md](references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
 
 ## Common failure modes
 
@@ -443,6 +552,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
+- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
+- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
+- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
+- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
 
 ## Review checklist
 
@@ -463,6 +576,16 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
 - [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
 - [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
+- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
+- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
+- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
+- [ ] No @import rules in CSS?
+- [ ] No position: fixed or z-index: 9999 in CSS?
+- [ ] @keyframes names prefixed with extension namespace?
+- [ ] No useLayoutEffect (use useEffect instead)?
+- [ ] No heavyweight library imports (lodash, moment)?
+- [ ] Components under 200 lines?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 

--- a/tracks/sales-app/skills/sales-app-extensibility/skill.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/skill.md
@@ -18,21 +18,6 @@ metadata:
     - "packages/sales-app/**/*.css"
     - "packages/sales-app/src/index.tsx"
   version: "1.0"
-  purpose: Guide the complete lifecycle of Sales App extension development from discovery through deployment
-  applies_to:
-    - creating Sales App extensions
-    - customizing cart, PDP, or menu in Sales App
-    - integrating APIs in Sales App extensions
-  excludes:
-    - regular FastStore storefront customization
-    - VTEX IO app development
-    - Sales App core development
-  decision_scope:
-    - extension-point-selection
-    - hook-selection
-    - api-auth-strategy
-    - template-selection
-  vtex_docs_verified: "2026-04-13"
 ---
 
 # Sales App Extensibility
@@ -84,7 +69,7 @@ Documentation: https://beta.fast.store/sales-app/setting-up
 
 ## Decision rules
 
-Follow the mandatory 6-step workflow in order. Do not skip steps.
+Follow the mandatory 7-step workflow (Steps 0–6) in order. Do not skip steps.
 
 | Step | Purpose | Gate |
 |------|---------|------|
@@ -212,55 +197,6 @@ const { item } = useCartItem();
 return <div>{item.name}</div>;
 ```
 
-### Constraint: Never expose authentication keys in frontend code
-
-API keys in `fetch` headers are visible in the browser network tab.
-
-**Why this matters**
-Leaked keys compromise the external service.
-
-**Detection**
-Literal auth header values in `fetch()`: `'x-api-key': '...'`, `'Authorization': 'Bearer ...'`.
-
-**Correct**
-
-```typescript
-const response = await fetch('/_v/my-api/data', {
-  credentials: 'include',
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-**Wrong**
-
-```typescript
-const response = await fetch('https://api.example.com/data', {
-  headers: { 'x-api-key': 'sk-secret-key-12345' },
-});
-```
-
-### Constraint: IO Proxy must use relative paths only
-
-The Sales App internal proxy resolves the domain automatically.
-
-**Why this matters**
-A full URL bypasses the proxy, breaking session cookies and causing CORS errors.
-
-**Detection**
-`fetch('https://{account}.myvtex.com/...')` in IO proxy components.
-
-**Correct**
-
-```typescript
-await fetch('/_v/my-loyalty-api/points', { credentials: 'include' });
-```
-
-**Wrong**
-
-```typescript
-await fetch('https://myaccount.myvtex.com/_v/my-loyalty-api/points');
-```
-
 ### Constraint: defineExtensions is required in index.tsx
 
 Entry point must use `defineExtensions` from `@vtex/sales-app`.
@@ -332,186 +268,6 @@ defineExtensions({ 'cart.cart-item.after': ItemWarranty });
 defineExtensions({ 'pdp.sidebar.after': ItemWarranty });
 ```
 
-### Constraint: Always present execution plan and wait for approval
-
-Do not generate code until the user confirms the plan.
-
-**Why this matters**
-Generating without agreement wastes effort and may produce the wrong extension.
-
-**Detection**
-Jumping from discovery to code generation without presenting a plan.
-
-**Correct**
-Discovery → Requirements → Present plan → **User approves** → Generate code.
-
-**Wrong**
-Discovery → Generate code immediately.
-
-### Constraint: Never access DOM APIs directly
-
-Extensions run in a sandboxed environment enforced by `@vtex/fsp-analyzer`. DOM APIs bypass the sandbox.
-
-**Why this matters**
-Accessing `document`, `window`, `localStorage`, `sessionStorage`, or `navigator` causes a `RESTRICTED_API` violation. The build fails.
-
-**Detection**
-Any use of these identifiers as a value: `document.querySelector`, `window.innerWidth`, `localStorage.getItem`, etc.
-
-**Correct**
-
-```typescript
-// Use React state, props, and Sales App hooks for data
-const { account } = useExtension();
-const cart = useCart();
-```
-
-**Wrong**
-
-```typescript
-const userId = localStorage.getItem('userId');
-const width = window.innerWidth;
-document.title = 'My Extension';
-```
-
-### Constraint: Never import restricted Node.js modules
-
-Extensions are browser-only React components. Node.js modules are unavailable at runtime and banned by the sandbox.
-
-**Why this matters**
-Importing `fs`, `path`, `child_process`, or `crypto` causes a `RESTRICTED_IMPORT` violation. The build fails.
-
-**Detection**
-`import fs from 'fs'`, `import { resolve } from 'path'`, `import crypto from 'crypto'`, `import child_process from 'child_process'`.
-
-**Correct**
-
-```typescript
-import { useCart } from '@vtex/sales-app';
-import React, { useState, useEffect } from 'react';
-```
-
-**Wrong**
-
-```typescript
-import fs from 'fs';
-import crypto from 'crypto';
-```
-
-### Constraint: Never use eval or the Function constructor
-
-Arbitrary code execution is banned in the sandbox.
-
-**Why this matters**
-`eval`, `new Function`, and string-form `setTimeout`/`setInterval` cause a `CODE_EXECUTION` violation. The build fails and is a critical security risk.
-
-**Detection**
-Any call to `eval(...)`, `new Function(...)`, or `setTimeout('code', delay)` / `setInterval('code', delay)` with a string first argument.
-
-**Correct**
-
-```typescript
-const result = computeValue(input); // deterministic logic only
-```
-
-**Wrong**
-
-```typescript
-eval('doSomething()');
-const fn = new Function('return 42');
-setTimeout('doSomething()', 1000);
-```
-
-### Constraint: CSS files must use plain .css extension, never .module.css
-
-The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
-
-**Why this matters**
-A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
-
-**Detection**
-Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
-
-**Correct**
-
-```typescript
-import './CashbackWidget.css';
-// Use className strings directly
-<div className="container">
-```
-
-**Wrong**
-
-```typescript
-import styles from './CashbackWidget.module.css';
-// CSS modules object access
-<div className={styles.container}>
-```
-
-### Constraint: CSS must use namespaced selectors — no global elements
-
-Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
-
-**Why this matters**
-Selectors like `*`, `body`, `html`, `:root`, `head`, `main`, `#root`, `#__next` cause `CSS_GLOBAL_SELECTOR` or `CSS_CONTAINMENT_BREAKOUT` violations. CSS also must not use `@import`, `position: fixed`, `z-index: 9999`, or un-namespaced `@keyframes`.
-
-**Detection**
-Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@import`, `:host`, `position: fixed`, `z-index: 9999`. Any `@keyframes` name not prefixed with the extension namespace.
-
-**Correct**
-
-```css
-/* Plain CSS — use namespace prefix to scope classes */
-.container { padding: 8px; }
-.title { font-size: 16px; }
-
-@keyframes extension-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-```
-
-**Wrong**
-
-```css
-body { font-size: 14px; }
-* { box-sizing: border-box; }
-:root { --my-color: red; }
-@import './reset.css';
-.overlay { position: fixed; z-index: 9999; }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-```
-
-### Constraint: CSS must follow Sales App Design Guidelines
-
-Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
-
-**Why this matters**
-Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
-
-**Detection**
-Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
-
-**Correct**
-
-```css
-.container {
-  --sa-color-primary: #157BF4;
-  --sa-color-text-primary: #1F1F1F;
-  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
-}
-.title { color: var(--sa-color-text-primary); font-size: 16px; }
-.buttonPrimary { background-color: var(--sa-color-primary); }
-```
-
-**Wrong**
-
-```css
-.container { font-family: Arial; }
-.title { color: #1a1a1a; font-size: 15px; }
-.buttonPrimary { background-color: #0066cc; }
-```
-
 ## Preferred pattern
 
 ### Workflow overview
@@ -522,59 +278,17 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`.
 
-**Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
+Required references for this step (load before generating):
+- [code-templates-and-patterns.md](references/code-templates-and-patterns.md) — all component templates, the CSS template (with the full Sales App design system inlined: tokens, typography, spacing, responsive), the `index.tsx` template, type generation rules, and the custom fetch hook pattern.
+- [extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) — hook return types and TypeScript definitions.
+- [static-analysis-rules.md](references/static-analysis-rules.md) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`. Run these checks on all generated files.
+- [design-guidelines.md](references/design-guidelines.md) — load when the extension renders any UI text (sentence case rule) or uses icons (Phosphor Icons).
 
-1. **Extension name** — title matching the component name.
-2. **Overview** — one-paragraph summary of what the extension does and why it was built.
-3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
-4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
-5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS file name and summary of key classes.
-7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
-   - **Source documentation:** URL or file path of the original API documentation, if provided.
-   - **Generated types:** list of TypeScript interfaces generated from the API documentation.
-   - Note which fields are optional (`?`) vs required per the documentation.
-8. **How to test** — dev server command and URL to reach the extension.
-9. **Known constraints** — any guards, edge cases, or limitations (e.g., `useCartItem().item` may be undefined).
+If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Validate against the 12-point checklist in code-templates-and-patterns.md. Fix all violations before presenting code; surface warnings to the user.
 
-Template for the documentation file:
-
-````markdown
-# <ExtensionName>
-
-## Overview
-<One-paragraph description of the extension purpose and value.>
-
-## Extension point
-- **Point:** `<extension.point.name>`
-- **Rationale:** <Why this extension point was selected.>
-
-## Hooks used
-| Hook | Purpose |
-|------|---------|
-| `useCart` | <What data it provides here> |
-
-## Component structure
-<Describe the component tree, key props, and internal state.>
-
-## Styling
-- **File:** `<ComponentName>.css`
-- <Summary of key CSS classes and design decisions.>
-
-## API integration
-- **Endpoint:** `/_v/...`
-- **Auth strategy:** IO Proxy / Direct / None
-- **Request/Response:** <Brief shape description.>
-
-## How to test
-Run `yarn fsp dev {account}` and navigate to `https://{account}.myvtex.com/sales-app/...` to verify the extension renders.
-
-## Known constraints
-- <Guard or limitation 1>
-- <Guard or limitation 2>
-````
+**Step 4** — Generate `docs/<ExtensionName>.md` inside the Sales App package (create the `docs/` folder if needed). Load the [documentation template reference](references/documentation-template.md) for the required 9-section structure and the markdown skeleton to fill in.
 
 **Step 5** — Provide local dev commands and test URLs. Load the [dev/build/deploy reference](references/local-dev-build-and-deploy.md).
 
@@ -587,73 +301,47 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; **CSS template with the full Sales App design system inlined (tokens, typography, spacing, responsive)**; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
-| [references/design-guidelines.md](references/design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
+| [references/design-guidelines.md](references/design-guidelines.md) | Writing UI text (sentence case rule) or using icons (Phosphor Icons). **CSS-related design rules — tokens, typography, spacing, responsive — are inlined directly in the CSS template inside code-templates-and-patterns.md, so this file is not needed for CSS generation.** |
+| [references/documentation-template.md](references/documentation-template.md) | Writing the `docs/<ExtensionName>.md` file in Step 4 — the 9-section structure and markdown skeleton |
 
 ## Common failure modes
 
-- **Returning null instead of empty fragment** — `return null` not allowed; use `return (<></>)`. Build fails.
-- **Accessing item.manualPrice without guard** — TypeScript "possibly undefined" error. Use `??`.
-- **Using useCartItem outside cart.cart-item.after** — Hook context only exists there. Runtime error.
-- **Hardcoding auth tokens in frontend fetch** — Keys visible in browser. Use VTEX IO proxy.
-- **Using full URL with IO Proxy** — Bypasses internal proxy. Use relative path `/_v/...`.
-- **Placing code outside packages/sales-app/src/** — Not included in build.
-- **Missing defineExtensions in index.tsx** — Extension compiles but never renders.
-- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed.
-- **Not presenting plan** — User may want a different approach. Always confirm.
-- **Invented extension point names** — `cart.list.after` instead of `cart.cart-list.after` fails silently.
-- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Future developers won't understand the extension's purpose, hooks, or constraints.
+- **Skipping prerequisite checks** — Generating code without FastStore/Sales App installed. Always confirm both before Step 1.
+- **Not presenting plan** — User may want a different approach. Always confirm at Step 2 before generating code.
+- **Skipping documentation** — Extension generated without `docs/<ExtensionName>.md`. Load documentation-template.md for the required structure.
 - **Inventing API response types** — Generated interface doesn't match actual API. If documentation was provided, derive types from it; if not, ask the user for a sample JSON response.
 - **Ignoring provided API documentation** — User provided a URL or file but agent asked manual questions anyway. Always check for documentation first and use the API Documentation Ingestion flow.
 - **Inline fetch with 2+ endpoints** — Multiple `fetch` calls inside the component body. Extract into custom hook(s) in `hooks/use{Purpose}.ts`.
-- **Accessing DOM APIs directly** — `document`, `window`, `localStorage` cause a `RESTRICTED_API` violation at build time. The sandbox blocks this.
-- **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
-- **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
-- **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
-- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
-- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
-- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
-- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
+- **Placing code outside packages/sales-app/src/** — Files outside this path are not included in the build.
+
+> Code-level violations (DOM APIs, Node imports, eval, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and caught during Step 3 validation. See [static-analysis-rules.md](references/static-analysis-rules.md) and [design-guidelines.md](references/design-guidelines.md).
 
 ## Review checklist
 
+**Workflow gates**
 - [ ] FastStore installed (biome.json, faststore.json, package.json, tsconfig.json, turbo.json)?
 - [ ] Sales App module installed (src/, package.json, tsconfig.json in sales-app directory)?
 - [ ] Discovery completed and use case identified?
 - [ ] Execution plan approved by user?
 - [ ] Extension point is valid (from the 8-point reference)?
 - [ ] Hooks compatible with chosen extension point?
+- [ ] Documentation generated at `docs/<ExtensionName>.md` (9 sections, using documentation-template.md)?
+- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
+- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
+- [ ] Build passes: `yarn fsp build {account} sales-app`?
+- [ ] Tested locally: `yarn fsp dev {account}`?
+
+**TypeScript / runtime guards** (not caught by fsp-analyzer)
 - [ ] Component returns JSX.Element, never null?
 - [ ] Optional properties guarded (manualPrice, productRefId, attachments)?
 - [ ] useCartItem().item checked for undefined?
-- [ ] No auth credentials exposed in frontend code?
-- [ ] IO Proxy uses relative path (/_v/...)?
 - [ ] defineExtensions configured in index.tsx?
-- [ ] CSS file path matches component name?
-- [ ] Documentation generated at `docs/<ExtensionName>.md`?
-- [ ] Documentation covers overview, extension point, hooks, structure, and constraints?
-- [ ] If API documentation was provided, TypeScript interfaces match the documented response shape?
-- [ ] If 2+ API endpoints used, fetch logic extracted into custom hook(s) in `hooks/`?
-- [ ] No DOM API access (document, window, localStorage, sessionStorage, navigator)?
-- [ ] No restricted Node.js imports (fs, path, child_process, crypto)?
-- [ ] No eval(), new Function(), or string-form setTimeout/setInterval?
-- [ ] CSS selectors scoped — no global *, body, html, :root, #root, #__next?
-- [ ] No @import rules in CSS?
-- [ ] No position: fixed or z-index: 9999 in CSS?
-- [ ] @keyframes names prefixed with extension namespace?
-- [ ] No useLayoutEffect (use useEffect instead)?
-- [ ] No heavyweight library imports (lodash, moment)?
-- [ ] Components under 200 lines?
-- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
-- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
-- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
-- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
-- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
-- [ ] Build passes: `yarn fsp build {account} sales-app`?
-- [ ] Tested locally: `yarn fsp dev {account}`?
+
+> All other code-level rules (sandbox APIs, CSS containment, React performance, design tokens) are enforced by `@vtex/fsp-analyzer` and checked during Step 3. See [static-analysis-rules.md](references/static-analysis-rules.md) and [design-guidelines.md](references/design-guidelines.md).
 
 ## Related skills
 

--- a/tracks/sales-app/skills/sales-app-extensibility/skill.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/skill.md
@@ -91,7 +91,7 @@ Follow the mandatory 6-step workflow in order. Do not skip steps.
 | 0 | Check prerequisites | FastStore + Sales App installed → proceed; otherwise STOP |
 | 1 | Discovery | Understand what the user wants to build |
 | 2 | Requirements & Plan | Map requirements → generate plan → **wait for user approval** |
-| 3 | Code Generation & Validation | Generate component + CSS + index.tsx → validate |
+| 3 | Code Generation & Validation | Generate `Component.tsx` + `Component.css` (plain CSS, never `.module.css`) + `index.tsx` → validate |
 | 4 | Documentation | Generate `docs/<ExtensionName>.md` explaining the extension |
 | 5 | Local Testing | Provide dev commands and URLs |
 | 6 | Build & Deploy | Build command → deployment guide |
@@ -422,6 +422,32 @@ const fn = new Function('return 42');
 setTimeout('doSomething()', 1000);
 ```
 
+### Constraint: CSS files must use plain .css extension, never .module.css
+
+The Sales App bundler does not support CSS modules. All stylesheets must use plain `.css` extension and be imported as side-effect imports.
+
+**Why this matters**
+A `.module.css` file will not be processed correctly by the bundler. Styles will not be applied and the build may fail.
+
+**Detection**
+Any file named `*.module.css` or any import like `import styles from './*.module.css'`.
+
+**Correct**
+
+```typescript
+import './CashbackWidget.css';
+// Use className strings directly
+<div className="container">
+```
+
+**Wrong**
+
+```typescript
+import styles from './CashbackWidget.module.css';
+// CSS modules object access
+<div className={styles.container}>
+```
+
 ### Constraint: CSS must use namespaced selectors — no global elements
 
 Extension CSS is injected into the Sales App shell. Global selectors pollute the cascade and break containment.
@@ -435,7 +461,7 @@ Any CSS rule targeting global elements, `:root`, `#root`, `#__next`, or using `@
 **Correct**
 
 ```css
-/* CSS Module — classes are auto-scoped by the bundler */
+/* Plain CSS — use namespace prefix to scope classes */
 .container { padding: 8px; }
 .title { font-size: 16px; }
 
@@ -494,9 +520,9 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 
 **Step 1** — Discovery. Detect use case from keywords, ask follow-up questions, determine API auth strategy. If the user provides API documentation (URL, OpenAPI/Swagger file, Markdown, or inline text), ingest it to extract endpoint details and response shapes — skip the equivalent manual questions. Validate extracted information with the user. Load the [discovery reference](references/discovery-and-use-cases.md) for detailed question flows and the API Documentation Ingestion section.
 
-**Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
+**Step 2** — Map requirements to extension point + hooks + template. Present plan listing the files to be created: `components/<ComponentName>.tsx`, `components/<ComponentName>.css` (plain CSS — **never** `.module.css`), and `index.tsx`. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate `<ComponentName>.tsx`, `<ComponentName>.css` (plain CSS, **never** `.module.css`), and `index.tsx`. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -505,7 +531,7 @@ Hardcoded hex values outside the `--sa-color-*` token declarations block; missin
 3. **Extension point** — which extension point it registers on (e.g., `cart.cart-list.after`) and why that point was chosen.
 4. **Hooks used** — list each hook (`useCart`, `usePDP`, etc.) with a brief explanation of what data it provides to this extension.
 5. **Component structure** — description of the component tree, props, and state management.
-6. **Styling** — CSS module file name and summary of key classes.
+6. **Styling** — CSS file name and summary of key classes.
 7. **API integration** (if applicable) — endpoint, auth strategy (IO Proxy or direct), request/response shape.
    - **Source documentation:** URL or file path of the original API documentation, if provided.
    - **Generated types:** list of TypeScript interfaces generated from the API documentation.
@@ -534,7 +560,7 @@ Template for the documentation file:
 <Describe the component tree, key props, and internal state.>
 
 ## Styling
-- **File:** `<ComponentName>.module.css`
+- **File:** `<ComponentName>.css`
 - <Summary of key CSS classes and design decisions.>
 
 ## API integration
@@ -561,7 +587,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | File | Load when… |
 |------|-----------|
 | [references/extension-points-hooks-and-types.md](references/extension-points-hooks-and-types.md) | Choosing an extension point, selecting hooks, looking up TypeScript types (`CartItem`, `ProductSku`, `Totalizers`, `Attachment`), or checking hook return values and availability per extension point |
-| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS module pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
+| [references/code-templates-and-patterns.md](references/code-templates-and-patterns.md) | Generating extension code — simple, hook, API, IO Proxy, or Direct Auth templates; CSS pattern; `index.tsx` with `defineExtensions`; hook initialization; validation checklist |
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |

--- a/tracks/sales-app/skills/sales-app-extensibility/skill.md
+++ b/tracks/sales-app/skills/sales-app-extensibility/skill.md
@@ -456,6 +456,36 @@ body { font-size: 14px; }
 @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
 ```
 
+### Constraint: CSS must follow Sales App Design Guidelines
+
+Generated CSS must use the approved `--sa-color-*` design tokens, `VTEX Trust` as the base font, and Phosphor Icons when icons are needed. All UI text must use sentence case.
+
+**Why this matters**
+Custom hex values and arbitrary fonts break visual consistency with the Sales App shell. All-caps text violates the adopted UX writing standards.
+
+**Detection**
+Hardcoded hex values outside the `--sa-color-*` token declarations block; missing `font-family: 'VTEX Trust'` on `.container`; ALL-CAPS strings in JSX text nodes; icons from non-Phosphor libraries.
+
+**Correct**
+
+```css
+.container {
+  --sa-color-primary: #157BF4;
+  --sa-color-text-primary: #1F1F1F;
+  font-family: 'VTEX Trust', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+.title { color: var(--sa-color-text-primary); font-size: 16px; }
+.buttonPrimary { background-color: var(--sa-color-primary); }
+```
+
+**Wrong**
+
+```css
+.container { font-family: Arial; }
+.title { color: #1a1a1a; font-size: 15px; }
+.buttonPrimary { background-color: #0066cc; }
+```
+
 ## Preferred pattern
 
 ### Workflow overview
@@ -466,7 +496,7 @@ body { font-size: 14px; }
 
 **Step 2** — Map requirements to extension point + hooks + template. Present plan. Wait for approval.
 
-**Step 3** — Generate component, CSS, and index.tsx. Validate against the 11-point checklist (items 1–10 from the code templates reference plus static analysis compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, and the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files. Fix all violations before presenting code; surface warnings to the user.
+**Step 3** — Generate component, CSS, and index.tsx. Validate against the 12-point checklist (items 1–10 from the code templates reference, static analysis compliance, and design token compliance). If API documentation was ingested in Step 1, generate TypeScript interfaces from the extracted response shapes and use them in the component instead of the `${DATA_INTERFACE}` placeholder. If the extension calls 2+ endpoints, extract fetch logic into custom hook(s). Load the [code templates reference](references/code-templates-and-patterns.md) for all template patterns, the type generation rules, the custom fetch hook pattern, the [types reference](references/extension-points-hooks-and-types.md) for hook return types and TypeScript definitions, the [static analysis reference](references/static-analysis-rules.md) to run sandbox security, CSS containment, and React performance checks on all generated files, and the [design guidelines reference](references/design-guidelines.md) for approved color tokens, typography, iconography, and UX writing rules. All generated CSS must use `--sa-color-*` tokens, `VTEX Trust` font family, and sentence-case text. Fix all violations before presenting code; surface warnings to the user.
 
 **Step 4** — Generate documentation file at `docs/<ExtensionName>.md` inside the Sales App package. Create the `docs/` folder if it does not exist. The document must contain:
 
@@ -535,6 +565,7 @@ Load these on demand based on what the task requires. Do not load all of them up
 | [references/discovery-and-use-cases.md](references/discovery-and-use-cases.md) | Running Step 1 (Discovery) — use case detection keywords, follow-up questions, API auth decision tree, IO Proxy vs Direct Auth flow |
 | [references/local-dev-build-and-deploy.md](references/local-dev-build-and-deploy.md) | Running Steps 5–6 — dev server commands, test URLs, build command, common build errors, FastStore WebOps deployment, monitoring, rollback |
 | [references/static-analysis-rules.md](references/static-analysis-rules.md) | Validating generated code (Step 3) — sandbox security, CSS containment, and React performance rules from `@vtex/fsp-analyzer`; full rule catalog with violation IDs, detection patterns, and correct/wrong examples |
+| [references/design-guidelines.md](references/design-guidelines.md) | Generating CSS for any extension — approved `--sa-color-*` design tokens, VTEX Trust font, Phosphor Icons, allowed font sizes, 4px spacing grid, UX writing rules (sentence case), and responsive breakpoints |
 
 ## Common failure modes
 
@@ -556,6 +587,10 @@ Load these on demand based on what the task requires. Do not load all of them up
 - **Using global CSS selectors** — `body`, `html`, `:root`, `*`, `#root` in extension CSS cause `CSS_GLOBAL_SELECTOR` / `CSS_CONTAINMENT_BREAKOUT` violations. Always scope to the component container.
 - **useLayoutEffect usage** — Blocked by the sandbox (`REACT_LAYOUT_EFFECT_MISUSE`). Use `useEffect` instead.
 - **Heavyweight library imports** — Importing `lodash` or `moment` triggers `LARGE_BUNDLE_SIZE_IMPACT` warnings. Use native array methods or `date-fns` instead.
+- **Hardcoded colors instead of design tokens** — Using hex values like `#0066cc` or `#1a1a1a` directly in CSS breaks visual consistency with the Sales App shell. Declare `--sa-color-*` tokens on `.container` and reference only those.
+- **Missing VTEX Trust font** — Not setting `font-family: 'VTEX Trust', ...` on `.container` causes the extension to render with the browser default font, inconsistent with the rest of Sales App.
+- **ALL-CAPS text in UI** — Any uppercase-transformed text (via CSS `text-transform: uppercase` or hardcoded ALL-CAPS strings) violates the Sales App UX writing guidelines.
+- **Non-Phosphor icons** — Using Material Icons, Font Awesome, or any other icon library breaks the Sales App iconography system. Import icons from `@phosphor-icons/react` only.
 
 ## Review checklist
 
@@ -586,6 +621,11 @@ Load these on demand based on what the task requires. Do not load all of them up
 - [ ] No useLayoutEffect (use useEffect instead)?
 - [ ] No heavyweight library imports (lodash, moment)?
 - [ ] Components under 200 lines?
+- [ ] CSS declares `--sa-color-*` design tokens on `.container` (no hardcoded hex values in rules)?
+- [ ] `font-family: 'VTEX Trust', ...` set on `.container`?
+- [ ] All CSS font sizes from the allowed scale (10, 12, 14, 16, 18, 20, 22, 24, 28, 32...)?
+- [ ] All UI text in sentence case (no ALL-CAPS, no system-like placeholders)?
+- [ ] Icons use Phosphor Icons (`@phosphor-icons/react`) if icons are present?
 - [ ] Build passes: `yarn fsp build {account} sales-app`?
 - [ ] Tested locally: `yarn fsp dev {account}`?
 


### PR DESCRIPTION
## Description

Add Static Analysis rules to validate extension created by sales-app-extensibility skill

---

## Contribution Checklist

Before submitting, please verify:

- [x] **Source files only**: Edited skill files in `tracks/{track}/skills/{name}/skill.md`, not in `skills/`, `exports/`, or `rules/` directories
- [x] **Correct file name**: Skill file is named `skill.md` (lowercase), not `SKILL.md` or other variants
- [x] **Frontmatter complete**: Includes `name`, `description`, and `metadata` with `track` and `tags` fields
- [x] **Validation passed**: Ran `bun run validate` and all hard checks pass
- [x] **Exports regenerated**: Ran `bun run export` and committed both source and generated files
- [x] **Skill name format**: Uses kebab-case and is unique across the repository
- [x] **Track directory correct**: Track name in frontmatter matches the directory structure

---

## Related Issues

<!-- Link to related issues if applicable -->
