### PR TITLE
fix io skills: upgrade all Builder Node references from 6.x to 7.x

### DIFF
--- a/exports/agents-md/payment/AGENTS.md
+++ b/exports/agents-md/payment/AGENTS.md
@@ -2029,7 +2029,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/exports/claude/payment-payment-provider-framework.md
+++ b/exports/claude/payment-payment-provider-framework.md
@@ -498,7 +498,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/exports/claude/payment.md
+++ b/exports/claude/payment.md
@@ -2016,7 +2016,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -7818,7 +7818,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/exports/copilot/payment.md
+++ b/exports/copilot/payment.md
@@ -2010,7 +2010,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/exports/cursor/payment-all.mdc
+++ b/exports/cursor/payment-all.mdc
@@ -2014,7 +2014,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/exports/cursor/payment-payment-provider-framework.mdc
+++ b/exports/cursor/payment-payment-provider-framework.mdc
@@ -502,7 +502,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/exports/kiro/steering/payment-all.md
+++ b/exports/kiro/steering/payment-all.md
@@ -2010,7 +2010,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/exports/kiro/steering/payment-payment-provider-framework.md
+++ b/exports/kiro/steering/payment-payment-provider-framework.md
@@ -498,7 +498,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/exports/opencode/payment-provider-framework/SKILL.md
+++ b/exports/opencode/payment-provider-framework/SKILL.md
@@ -501,7 +501,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/rules/payment-all.mdc
+++ b/rules/payment-all.mdc
@@ -2014,7 +2014,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/rules/payment-payment-provider-framework.mdc
+++ b/rules/payment-payment-provider-framework.mdc
@@ -502,7 +502,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/skills/payment-provider-framework/SKILL.md
+++ b/skills/payment-provider-framework/SKILL.md
@@ -501,7 +501,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [

--- a/tracks/payment/skills/payment-provider-framework/skill.md
+++ b/tracks/payment/skills/payment-provider-framework/skill.md
@@ -529,7 +529,7 @@ async settle(settlement: SettlementRequest) {
 ```json
 {
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "paymentProvider": "1.x"
   },
   "policies": [


### PR DESCRIPTION
## Summary

- Updates all `"builders": { "node": "6.x" }` references to `"node": "7.x"` across the payment skill and all its exports
- Affects 14 files including source skill, track, rules, and all IDE exports (Claude, Copilot, Cursor, Kiro, Opencode, Agents.md)

## Test plan

- [ ] Verify all `"builders"` blocks now reference `"node": "7.x"`
- [ ] Confirm `@vtex/api` `6.x` devDependency references are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)