### PR TITLE
chore: add .prettierignore for skill sources and generated outputs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,22 @@
+# Skill sources are the canonical content edited by hand.
+# The repo does not yet enforce a shared formatter (no .prettierrc, no
+# prettier in devDependencies, no format step in CI). Until a
+# repo-wide formatter is adopted, contributors with format-on-save
+# enabled would otherwise reflow markdown tables, blank lines, and
+# JSON arrays in skill sources on every save, producing noisy,
+# unrelated diffs in content PRs. Ignore them defensively.
+tracks/**/*.md
+
+# Auto-generated exports — never edit these by hand.
+# `bun run export` regenerates them from `tracks/`.
+exports/
+skills/
+rules/
+
+# Release-please owns this file. Local Prettier passes have produced
+# noisy diffs when contributors open it.
+CHANGELOG.md
+
+# Lockfiles and build artifacts.
+bun.lock
+node_modules/


### PR DESCRIPTION
## Summary

The repo does not currently adopt a shared formatter — no `.prettierrc`, no `prettier` in `devDependencies`, no format step in CI or in the existing `bun run validate` pre-commit hook. Contributors who happen to have format-on-save enabled in Cursor/VSCode reflow markdown tables, blank lines, and JSON arrays in skill sources on every save, producing noisy diffs that pollute content PRs (we hit this three times in the last week on \`tracks/vtex-io/skills/vtex-io-app-contract/skill.md\`).

This PR adds a defensive \`.prettierignore\` so any locally-installed Prettier skips:

- \`tracks/**/*.md\` — canonical hand-edited skill sources
- \`exports/\`, \`skills/\`, \`rules/\` — auto-generated by \`bun run export\`
- \`CHANGELOG.md\` — owned by release-please
- \`bun.lock\`, \`node_modules/\` — build artifacts

## What this PR does NOT do

- It does not add Prettier to the project, prescribe a style, or run any reformat.
- It does not change a single line of any existing skill, export, or rule.
- It does not modify CI, the pre-commit hook, or `package.json`.

## Why this and not a full Prettier adoption

A repo-wide Prettier adoption is the proper systemic fix (commit \`.prettierrc\` + add \`prettier\` to devDependencies + run \`prettier --write .\` once + add \`format:check\` to CI). That is a much bigger PR — it touches every markdown file in the repo and is worth its own review. This PR is just the immediate stop-the-bleeding step so content PRs stop accumulating unrelated formatting churn.

## Test plan

- [ ] \`bun run validate\` passes (40 skills checked, no change vs main).
- [ ] No content files are modified by this PR; only \`.prettierignore\` is added.