### PR TITLE
fix(ci): unblock Generate Skill Exports by using default GITHUB_TOKEN for checkout

### DIFF
--- a/.github/workflows/generate-exports.yml
+++ b/.github/workflows/generate-exports.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.REPO_TOKEN || github.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

`Generate Skill Exports` (`.github/workflows/generate-exports.yml`) has been failing on every PR run and every push to `main` since **2026-05-06**. The failure is in the `Checkout repository` step itself, before any of the validate/export logic runs:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
The process '/usr/bin/git' failed with exit code 128
```

## Root cause

The checkout step is configured as:

```yaml
- name: Checkout repository
  uses: actions/checkout@v4
  with:
    token: ${{ secrets.REPO_TOKEN || github.token }}
```

The `||` fallback is evaluated at **template-expansion time**, not at runtime. As long as `REPO_TOKEN` is *set* — even to an expired value — that string is what `actions/checkout` receives. The intended fallback to `github.token` never fires.

`REPO_TOKEN` was last rotated on **2026-04-06** and stopped working around **2026-05-06**, consistent with a 30-day fine-grained PAT expiring. Since then, every run of this workflow has failed at checkout (verified across runs `25454770252`, `25454931705`, `25456628621`, `25510326954`, `25510439832`, and `25714741437`).

This affects every contributor's PR and blocks the auto-regeneration commit on `main`.

## Fix in this PR

Drop the explicit `token:` from the checkout step so it uses the default `GITHUB_TOKEN`:

```diff
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          token: \${{ secrets.REPO_TOKEN || github.token }}
```

The workflow already declares `permissions: contents: write` at the job level, so the default `GITHUB_TOKEN` has the write access the push-to-main auto-commit step needs.

### Why this is safe

- **No branch protection blocks the bot push.** I verified `repos/vtex/skills/branches/main/protection` (404) and `repos/vtex/skills/rules/branches/main` (`[]`).
- **No downstream workflow depends on a PAT-triggered auto-commit.** `release-please.yml` uses `secrets.GITHUB_TOKEN` explicitly, and `notify-agent-plugin.yml` triggers on `release: published`, which is emitted by `release-please-action` regardless of the trigger token.
- **PR runs no longer need the PAT.** The auto-commit step is gated to `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so PR runs only validate and export — for which the default `GITHUB_TOKEN` is sufficient (PR validation already works the same way in `pr-validation.yml`).

## Alternatives considered

| Option | Description | Why not chosen |
|---|---|---|
| **A. Rotate or delete `REPO_TOKEN`** | Repo admin re-issues the PAT or removes the secret entirely (so the `\|\|` fallback engages). | Pure repo-admin action, fastest — but breaks again the next time the PAT expires. Doesn't fix the latent bug in the `\|\|` fallback. |
| **B. Drop `token:` from checkout, keep `REPO_TOKEN` only on the auto-commit step** | Use default `GITHUB_TOKEN` for checkout; pass `REPO_TOKEN` only where it is needed to bypass policy or trigger downstream workflows. | Adds complexity and still depends on the PAT staying alive. Useful only if a downstream workflow requires PAT-triggered events — none does today. |
| **C. (this PR) Use default `GITHUB_TOKEN` everywhere with `permissions: contents: write`** | No PAT in the workflow at all. Default token has the rights it needs from the workflow-level `permissions` block. | Selected — minimal diff, removes the failure mode permanently, no recurring secret rotation, no downstream impact. |
| **D. Replace `REPO_TOKEN` with a GitHub App installation token** (`actions/create-github-app-token`) | Most durable identity for bot pushes; tokens auto-renew per workflow run. | Needs an org-level GitHub App registered and a private key stored as an org secret. Overkill while the default `GITHUB_TOKEN` is sufficient. Worth revisiting if branch protection is added later or if downstream workflows must be PAT-triggered. |

## Test plan

- [ ] After this PR is merged, confirm the next push to `main` succeeds end-to-end through `validate-and-export` (validate → export → optional auto-commit).
- [ ] Confirm the next contributor PR triggers `validate-and-export` and the checkout step succeeds.
- [ ] Optional: a repo admin can delete the `REPO_TOKEN` secret since no workflow references it anymore.