### PR TITLE
docs(faststore-storefront): updates v3 to v4 migration reference

### DIFF
--- a/exports/agents-md/faststore/AGENTS.md
+++ b/exports/agents-md/faststore/AGENTS.md
@@ -106,7 +106,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -124,7 +124,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/exports/agents-md/faststore/faststore-storefront/references/cms-schema-and-section-registration.md
+++ b/exports/agents-md/faststore/faststore-storefront/references/cms-schema-and-section-registration.md
@@ -233,7 +233,7 @@ Follow this EXACT sequence. Do NOT skip steps.
 
 ### Phase 4: Schema Management (SAME SESSION)
 
-- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4`
+- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json  `
 - [ ] Verify: `grep -A 5 '"<ComponentName>"' cms/faststore/schema.json` (search for the `$componentKey` string)
   - If it does not appear, fix JSONC or registration — **do not** edit `schema.json` manually
 - [ ] **Account check** (before upload): read `api.storeId` from `discovery.config.js` and run `vtex whoami` — confirm both match. If they differ, ask the user to run `vtex login <correct-account>` and **stop**.
@@ -292,7 +292,7 @@ From the **project root**:
 1. **Generate** (canonical command — matches the storefront skill):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 ```
 
 2. **Validate** — for new or renamed sections, grep or read `cms/faststore/schema.json` and confirm the `"$componentKey"` is present.

--- a/exports/agents-md/faststore/faststore-storefront/references/faststore-v3-v4-migration.md
+++ b/exports/agents-md/faststore/faststore-storefront/references/faststore-v3-v4-migration.md
@@ -38,7 +38,7 @@ FastStore v4's dependency tree (e.g. `eslint-visitor-keys@5`) declares
 older Node (e.g. 20.12) fails with `Found incompatible module`.
 
 - Use Node 24 for install, build and dev.
-- Set `volta.node` to `"24"` in `packages/discovery/package.json`.
+- Set `volta.node` to `"24.0.2"` (or the latest Node 24 patch) in `packages/discovery/package.json`.
 - Set `experimental.nodeVersion: 24` in `discovery.config.js`.
 
 ---
@@ -56,15 +56,33 @@ app dependencies — e.g. `crypto-js`, `draft-js` — alongside these):
 {
   "@faststore/cli": "<published v4 release>",
   "@vtex/faststore-plugin-buyer-portal": "<published v4 release>",
-  "next": "^16.2.6",
+  "graphql": "^16.11.0",
   "react": "^18.2.0",
   "react-dom": "^18.2.0",
   "react-router-dom": "^6.24.1"
 }
 ```
 
+**Important:** do **not** declare `next` in `dependencies` — Next.js is now
+managed internally by `@faststore/cli`, and declaring it separately causes
+version conflicts. Also update `typescript` in `devDependencies` to `^5.9.3`.
+
+`graphql` must be declared explicitly because it is a `peerDependency` of
+`@faststore/cli` — yarn v1 does not install peer dependencies automatically.
+
 Root `package.json`: `@faststore/cli` (devDependency) +
 `@vtex/faststore-plugin-buyer-portal` (dependency).
+
+**Monorepo stores only:** add `@inquirer/type` to the `resolutions` field in
+the root `package.json` to avoid version conflicts with the `inquirer` package:
+
+```json
+{
+  "resolutions": {
+    "@inquirer/type": "^1.5.5"
+  }
+}
+```
 
 **Pin npm releases, not pkg.pr.new / pkg.csb.dev tarballs.** The faststore v4
 monorepo uses pnpm `catalog:` / `workspace:*` specs. `npm publish` (via
@@ -201,7 +219,32 @@ partial actually contributes CSS/members before keeping it.
 
 ---
 
-## 5. v3 patches
+## 5. GraphQL import migration
+
+`@faststore/graphql-utils` is **deprecated** in v4. The `gql` tag used for
+GraphQL documents must be imported from `@faststore/core/api` instead.
+
+Search for all usages in `src/`:
+
+```bash
+grep -r "faststore/graphql-utils" src/
+```
+
+Replace every occurrence:
+
+```ts
+// before
+import { gql } from '@faststore/graphql-utils'
+
+// after
+import { gql } from '@faststore/core/api'
+```
+
+If the grep returns no matches, skip this step.
+
+---
+
+## 6. v3 patches
 
 `patch-package` patches are version-tagged (`@faststore+core+<v3>.patch`) and
 will not apply to v4. Inspect each:
@@ -313,10 +356,11 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 
 ## Appendix — migration checklist
 
-- [ ] Node 24 (`volta.node`, `experimental.nodeVersion`).
+- [ ] Node 24 (`volta.node` must be a full semver e.g. "24.0.2", `experimental.nodeVersion: 24`).
 - [ ] `package.json` (root + discovery): `@faststore/cli` + plugin pinned to
-      published v4 releases; v3 transitive deps removed; `next ^16.2.6`,
-      `react-router-dom` added.
+      published v4 releases; v3 transitive deps removed; `next` **removed**
+      from dependencies (managed by cli); `graphql ^16.11.0` and
+      `react-router-dom ^6.24.1` added; `typescript ^5.9.3` in devDependencies.
 - [ ] `discovery.config.js`: no `path`/`dotenv` requires; no `webpack()`
       callback; `nodeVersion: 24`; `transpilePackages` if needed.
 - [ ] Every `.scss`: top-level `@import` → `@use`; nested `@import` kept;
@@ -327,3 +371,162 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
       `patches/`.
 - [ ] `yarn build` and `yarn dev` verified (§8).
 - [ ] Local-linking machinery (§9) reverted before committing.
+- [ ] CMS type detected via `contentSource` in `discovery.config.js` (§11.1).
+- [ ] CMS sync instructions shown to user (§10 next steps): case detected from `discovery.config.js` + `cms/faststore/`; commands presented for manual execution (never run automatically).
+- [ ] New CMS fields configured in Admin → Storefront → Headless CMS / Content and pages republished (§11.4 — human step).
+- [ ] Tested locally with `yarn dev` — no empty labels/buttons/toasts.
+- [ ] Only then: v4 deployed to production + Node.js v24 set in WebOps.
+
+---
+
+## 10. Post-migration summary (mandatory output)
+
+> **MANDATORY prerequisite — do NOT display this summary until `yarn build`
+> passes.**
+>
+> Before showing the summary, run (using Node 24):
+> ```bash
+> yarn install
+> yarn build
+> ```
+> Fix any build errors first. Only after a successful build should you
+> proceed to display the summary below.
+
+After the build passes, display the following two sections.
+
+---
+
+### What was done
+
+A table covering every file touched and the change applied. Adapt rows to
+what actually changed; mark items that were not applicable as `—`.
+
+| File | Change | Status |
+|------|--------|--------|
+| `package.json` | `@faststore/cli` bumped to v4; `next` removed; `graphql`, `react-router-dom` added; `typescript` bumped to `^5.9.3`; `volta.node` set to `24` | ✅ Done |
+| `discovery.config.js` | `experimental.nodeVersion` → `24` | ✅ Done |
+| `src/**/*.scss` | Top-level `@import` → `@use`; `@include media/layout-content` namespaced to `u.*` | ✅ Done |
+| `patches/` | Stale v3 patches assessed / moved | ✅ Done / N/A |
+
+---
+
+### Important next steps
+
+#### 1. CMS sync (run manually in your terminal)
+
+> **Do NOT run `vtex content` commands automatically.** These require
+> interactive authentication and may have CLI plugin issues in Homebrew
+> environments.
+
+Check `discovery.config.js` and `cms/faststore/` to identify the case,
+then present the matching instructions to the user.
+
+**Headless CMS (legacy)** — `contentSource` field absent in `discovery.config.js`:
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+> If `cms-sync` errors with `Cannot find module 'vtex'`, run
+> `vtex plugins install @vtex/cli-plugin-cms` or `vtex update`.
+
+**Content Platform (CP)** — `contentSource: { type: 'CP' }` present.
+Identify the sub-case by inspecting `cms/faststore/`:
+
+| Case | Signal | Commands to run |
+|------|--------|-----------------|
+| **A** — no custom schemas | No `.jsonc` files, no `components/` folder | Create `cms/faststore/schema.json` with `{ "$base": "vtex.faststore" }`, then `vtex content upload-schema cms/faststore/schema.json` |
+| **B** — already split | `cms/faststore/components/*.jsonc` exists | `vtex content generate-schema cms/faststore/components cms/faststore/pages -o cms/faststore/schema.json` then `vtex content upload-schema cms/faststore/schema.json` |
+| **C** — legacy format | Only `sections.json` / `content-types.json` | Split first (see §11), then generate + upload |
+
+For the full command listing of each case see §11.
+
+---
+
+#### 2. Fill in new CMS fields and republish
+
+After the CMS sync, v4 exposes new configurable fields that were previously
+hardcoded. Configure them in **Admin → Storefront → Headless CMS / Content**
+and republish the affected pages:
+
+| Page | Fields to configure |
+|------|---------------------|
+| **All pages** | `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel` |
+| **Home** (product shelf) | `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`, `includeTaxesLabel`, `sponsoredLabel` |
+| **PLP** | `Breadcrumb → Fallback label`, `ProductGallery → sortBySelector`, `Filter → FilterSlider / FilterDesktop labels`, `ProductCard / ProductCardContent` |
+| **Search** | `SearchInput`, `SearchTop`, `SearchHistory`, `EmptyGallery → labels`, `ProductCard / ProductCardContent` |
+| **PDP** | `Breadcrumb → Fallback label`, `ProductDetails → invalidQuantityToast / buyButtonTitle` |
+| **Cart** | `EmptyCart → title / buttonLabel` |
+
+Full field reference: [developers.vtex.com → Upgrading FastStore to v4](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4)
+
+> Do not deploy v4 to production before filling these fields — they render
+> blank until configured.
+
+---
+
+#### 3. Update Node.js v24 in WebOps
+
+In VTEX Admin → **Storefront → FastStore WebOps → Settings → Node.js
+version** → set to `v24` → Save → trigger a new deploy.
+
+---
+
+#### 4. Check Sass `@import` deprecation warnings
+
+`@import` inside selector blocks emits Dart Sass deprecation warnings.
+
+---
+
+## 11. CMS sync — command reference
+
+This section is a command reference. The agent must **not** run these
+commands automatically — always present them to the user to run manually.
+
+### 11.1 Headless CMS (legacy)
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+`cms-sync` is safe while v3 is live — it only pushes the schema.
+
+### 11.2 Content Platform — Case A (no custom schemas)
+
+```bash
+# 1. Create the minimal schema (if not already present)
+# cms/faststore/schema.json content:
+# { "$base": "vtex.faststore" }
+# (use "vtex.faststore@4.1.0" to pin an explicit version)
+
+vtex login <accountName>
+vtex content upload-schema cms/faststore/schema.json
+# The local schema.json can be deleted after upload
+```
+
+### 11.3 Content Platform — Case B (components already in .jsonc format)
+
+```bash
+vtex login <accountName>
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```
+
+### 11.4 Content Platform — Case C (legacy sections.json)
+
+```bash
+vtex login <accountName>
+
+vtex content split-components -i cms/faststore/sections.json \
+                              -o cms/faststore/components
+vtex content split-content-types -i cms/faststore/content-types.json \
+                                 -s cms/faststore/sections.json \
+                                 -o cms/faststore/pages
+
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```

--- a/exports/agents-md/faststore/faststore-storefront/scripts/cms-sync.sh
+++ b/exports/agents-md/faststore/faststore-storefront/scripts/cms-sync.sh
@@ -2,14 +2,14 @@
 #
 # DEPRECATED — Headless CMS schema publishing
 # Prefer running from the project root (global VTEX CLI):
-#   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+#   vtex content generate-schema -o cms/faststore/schema.json  
 #   vtex content upload-schema cms/faststore/schema.json
 # Do not use yarn/npm cms-sync or faststore cms-sync for this workflow.
 # See references/cms-schema-and-section-registration.md and skill.md.
 #
 
 # Generate final schema.json for Headless CMS (canonical flags — matches skill.md)
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 
 # Upload final schema.json to Headless CMS (expects interactive prompts or use expect — see reference)
 expect -c 'spawn vtex content upload-schema cms/faststore/schema.json; expect "store ID"; send "faststore\r"; expect "uploaded with"; send "y\r"; expect "Are you sure"; send "y\r"; expect eof' 2>&1

--- a/exports/claude/faststore-faststore-storefront-ref-cms-schema-and-section-registration.md
+++ b/exports/claude/faststore-faststore-storefront-ref-cms-schema-and-section-registration.md
@@ -225,7 +225,7 @@ Follow this EXACT sequence. Do NOT skip steps.
 
 ### Phase 4: Schema Management (SAME SESSION)
 
-- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4`
+- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json  `
 - [ ] Verify: `grep -A 5 '"<ComponentName>"' cms/faststore/schema.json` (search for the `$componentKey` string)
   - If it does not appear, fix JSONC or registration — **do not** edit `schema.json` manually
 - [ ] **Account check** (before upload): read `api.storeId` from `discovery.config.js` and run `vtex whoami` — confirm both match. If they differ, ask the user to run `vtex login <correct-account>` and **stop**.
@@ -284,7 +284,7 @@ From the **project root**:
 1. **Generate** (canonical command — matches the storefront skill):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 ```
 
 2. **Validate** — for new or renamed sections, grep or read `cms/faststore/schema.json` and confirm the `"$componentKey"` is present.

--- a/exports/claude/faststore-faststore-storefront-ref-faststore-v3-v4-migration.md
+++ b/exports/claude/faststore-faststore-storefront-ref-faststore-v3-v4-migration.md
@@ -38,7 +38,7 @@ FastStore v4's dependency tree (e.g. `eslint-visitor-keys@5`) declares
 older Node (e.g. 20.12) fails with `Found incompatible module`.
 
 - Use Node 24 for install, build and dev.
-- Set `volta.node` to `"24"` in `packages/discovery/package.json`.
+- Set `volta.node` to `"24.0.2"` (or the latest Node 24 patch) in `packages/discovery/package.json`.
 - Set `experimental.nodeVersion: 24` in `discovery.config.js`.
 
 ---
@@ -56,15 +56,33 @@ app dependencies — e.g. `crypto-js`, `draft-js` — alongside these):
 {
   "@faststore/cli": "<published v4 release>",
   "@vtex/faststore-plugin-buyer-portal": "<published v4 release>",
-  "next": "^16.2.6",
+  "graphql": "^16.11.0",
   "react": "^18.2.0",
   "react-dom": "^18.2.0",
   "react-router-dom": "^6.24.1"
 }
 ```
 
+**Important:** do **not** declare `next` in `dependencies` — Next.js is now
+managed internally by `@faststore/cli`, and declaring it separately causes
+version conflicts. Also update `typescript` in `devDependencies` to `^5.9.3`.
+
+`graphql` must be declared explicitly because it is a `peerDependency` of
+`@faststore/cli` — yarn v1 does not install peer dependencies automatically.
+
 Root `package.json`: `@faststore/cli` (devDependency) +
 `@vtex/faststore-plugin-buyer-portal` (dependency).
+
+**Monorepo stores only:** add `@inquirer/type` to the `resolutions` field in
+the root `package.json` to avoid version conflicts with the `inquirer` package:
+
+```json
+{
+  "resolutions": {
+    "@inquirer/type": "^1.5.5"
+  }
+}
+```
 
 **Pin npm releases, not pkg.pr.new / pkg.csb.dev tarballs.** The faststore v4
 monorepo uses pnpm `catalog:` / `workspace:*` specs. `npm publish` (via
@@ -201,7 +219,32 @@ partial actually contributes CSS/members before keeping it.
 
 ---
 
-## 5. v3 patches
+## 5. GraphQL import migration
+
+`@faststore/graphql-utils` is **deprecated** in v4. The `gql` tag used for
+GraphQL documents must be imported from `@faststore/core/api` instead.
+
+Search for all usages in `src/`:
+
+```bash
+grep -r "faststore/graphql-utils" src/
+```
+
+Replace every occurrence:
+
+```ts
+// before
+import { gql } from '@faststore/graphql-utils'
+
+// after
+import { gql } from '@faststore/core/api'
+```
+
+If the grep returns no matches, skip this step.
+
+---
+
+## 6. v3 patches
 
 `patch-package` patches are version-tagged (`@faststore+core+<v3>.patch`) and
 will not apply to v4. Inspect each:
@@ -313,10 +356,11 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 
 ## Appendix — migration checklist
 
-- [ ] Node 24 (`volta.node`, `experimental.nodeVersion`).
+- [ ] Node 24 (`volta.node` must be a full semver e.g. "24.0.2", `experimental.nodeVersion: 24`).
 - [ ] `package.json` (root + discovery): `@faststore/cli` + plugin pinned to
-      published v4 releases; v3 transitive deps removed; `next ^16.2.6`,
-      `react-router-dom` added.
+      published v4 releases; v3 transitive deps removed; `next` **removed**
+      from dependencies (managed by cli); `graphql ^16.11.0` and
+      `react-router-dom ^6.24.1` added; `typescript ^5.9.3` in devDependencies.
 - [ ] `discovery.config.js`: no `path`/`dotenv` requires; no `webpack()`
       callback; `nodeVersion: 24`; `transpilePackages` if needed.
 - [ ] Every `.scss`: top-level `@import` → `@use`; nested `@import` kept;
@@ -327,3 +371,162 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
       `patches/`.
 - [ ] `yarn build` and `yarn dev` verified (§8).
 - [ ] Local-linking machinery (§9) reverted before committing.
+- [ ] CMS type detected via `contentSource` in `discovery.config.js` (§11.1).
+- [ ] CMS sync instructions shown to user (§10 next steps): case detected from `discovery.config.js` + `cms/faststore/`; commands presented for manual execution (never run automatically).
+- [ ] New CMS fields configured in Admin → Storefront → Headless CMS / Content and pages republished (§11.4 — human step).
+- [ ] Tested locally with `yarn dev` — no empty labels/buttons/toasts.
+- [ ] Only then: v4 deployed to production + Node.js v24 set in WebOps.
+
+---
+
+## 10. Post-migration summary (mandatory output)
+
+> **MANDATORY prerequisite — do NOT display this summary until `yarn build`
+> passes.**
+>
+> Before showing the summary, run (using Node 24):
+> ```bash
+> yarn install
+> yarn build
+> ```
+> Fix any build errors first. Only after a successful build should you
+> proceed to display the summary below.
+
+After the build passes, display the following two sections.
+
+---
+
+### What was done
+
+A table covering every file touched and the change applied. Adapt rows to
+what actually changed; mark items that were not applicable as `—`.
+
+| File | Change | Status |
+|------|--------|--------|
+| `package.json` | `@faststore/cli` bumped to v4; `next` removed; `graphql`, `react-router-dom` added; `typescript` bumped to `^5.9.3`; `volta.node` set to `24` | ✅ Done |
+| `discovery.config.js` | `experimental.nodeVersion` → `24` | ✅ Done |
+| `src/**/*.scss` | Top-level `@import` → `@use`; `@include media/layout-content` namespaced to `u.*` | ✅ Done |
+| `patches/` | Stale v3 patches assessed / moved | ✅ Done / N/A |
+
+---
+
+### Important next steps
+
+#### 1. CMS sync (run manually in your terminal)
+
+> **Do NOT run `vtex content` commands automatically.** These require
+> interactive authentication and may have CLI plugin issues in Homebrew
+> environments.
+
+Check `discovery.config.js` and `cms/faststore/` to identify the case,
+then present the matching instructions to the user.
+
+**Headless CMS (legacy)** — `contentSource` field absent in `discovery.config.js`:
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+> If `cms-sync` errors with `Cannot find module 'vtex'`, run
+> `vtex plugins install @vtex/cli-plugin-cms` or `vtex update`.
+
+**Content Platform (CP)** — `contentSource: { type: 'CP' }` present.
+Identify the sub-case by inspecting `cms/faststore/`:
+
+| Case | Signal | Commands to run |
+|------|--------|-----------------|
+| **A** — no custom schemas | No `.jsonc` files, no `components/` folder | Create `cms/faststore/schema.json` with `{ "$base": "vtex.faststore" }`, then `vtex content upload-schema cms/faststore/schema.json` |
+| **B** — already split | `cms/faststore/components/*.jsonc` exists | `vtex content generate-schema cms/faststore/components cms/faststore/pages -o cms/faststore/schema.json` then `vtex content upload-schema cms/faststore/schema.json` |
+| **C** — legacy format | Only `sections.json` / `content-types.json` | Split first (see §11), then generate + upload |
+
+For the full command listing of each case see §11.
+
+---
+
+#### 2. Fill in new CMS fields and republish
+
+After the CMS sync, v4 exposes new configurable fields that were previously
+hardcoded. Configure them in **Admin → Storefront → Headless CMS / Content**
+and republish the affected pages:
+
+| Page | Fields to configure |
+|------|---------------------|
+| **All pages** | `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel` |
+| **Home** (product shelf) | `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`, `includeTaxesLabel`, `sponsoredLabel` |
+| **PLP** | `Breadcrumb → Fallback label`, `ProductGallery → sortBySelector`, `Filter → FilterSlider / FilterDesktop labels`, `ProductCard / ProductCardContent` |
+| **Search** | `SearchInput`, `SearchTop`, `SearchHistory`, `EmptyGallery → labels`, `ProductCard / ProductCardContent` |
+| **PDP** | `Breadcrumb → Fallback label`, `ProductDetails → invalidQuantityToast / buyButtonTitle` |
+| **Cart** | `EmptyCart → title / buttonLabel` |
+
+Full field reference: [developers.vtex.com → Upgrading FastStore to v4](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4)
+
+> Do not deploy v4 to production before filling these fields — they render
+> blank until configured.
+
+---
+
+#### 3. Update Node.js v24 in WebOps
+
+In VTEX Admin → **Storefront → FastStore WebOps → Settings → Node.js
+version** → set to `v24` → Save → trigger a new deploy.
+
+---
+
+#### 4. Check Sass `@import` deprecation warnings
+
+`@import` inside selector blocks emits Dart Sass deprecation warnings.
+
+---
+
+## 11. CMS sync — command reference
+
+This section is a command reference. The agent must **not** run these
+commands automatically — always present them to the user to run manually.
+
+### 11.1 Headless CMS (legacy)
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+`cms-sync` is safe while v3 is live — it only pushes the schema.
+
+### 11.2 Content Platform — Case A (no custom schemas)
+
+```bash
+# 1. Create the minimal schema (if not already present)
+# cms/faststore/schema.json content:
+# { "$base": "vtex.faststore" }
+# (use "vtex.faststore@4.1.0" to pin an explicit version)
+
+vtex login <accountName>
+vtex content upload-schema cms/faststore/schema.json
+# The local schema.json can be deleted after upload
+```
+
+### 11.3 Content Platform — Case B (components already in .jsonc format)
+
+```bash
+vtex login <accountName>
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```
+
+### 11.4 Content Platform — Case C (legacy sections.json)
+
+```bash
+vtex login <accountName>
+
+vtex content split-components -i cms/faststore/sections.json \
+                              -o cms/faststore/components
+vtex content split-content-types -i cms/faststore/content-types.json \
+                                 -s cms/faststore/sections.json \
+                                 -o cms/faststore/pages
+
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```

--- a/exports/claude/faststore-faststore-storefront.md
+++ b/exports/claude/faststore-faststore-storefront.md
@@ -99,7 +99,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -117,7 +117,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/exports/claude/faststore.md
+++ b/exports/claude/faststore.md
@@ -99,7 +99,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -117,7 +117,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/exports/copilot/copilot-instructions.md
+++ b/exports/copilot/copilot-instructions.md
@@ -304,7 +304,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -322,7 +322,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/exports/copilot/faststore-faststore-storefront-ref-cms-schema-and-section-registration.md
+++ b/exports/copilot/faststore-faststore-storefront-ref-cms-schema-and-section-registration.md
@@ -225,7 +225,7 @@ Follow this EXACT sequence. Do NOT skip steps.
 
 ### Phase 4: Schema Management (SAME SESSION)
 
-- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4`
+- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json  `
 - [ ] Verify: `grep -A 5 '"<ComponentName>"' cms/faststore/schema.json` (search for the `$componentKey` string)
   - If it does not appear, fix JSONC or registration — **do not** edit `schema.json` manually
 - [ ] **Account check** (before upload): read `api.storeId` from `discovery.config.js` and run `vtex whoami` — confirm both match. If they differ, ask the user to run `vtex login <correct-account>` and **stop**.
@@ -284,7 +284,7 @@ From the **project root**:
 1. **Generate** (canonical command — matches the storefront skill):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 ```
 
 2. **Validate** — for new or renamed sections, grep or read `cms/faststore/schema.json` and confirm the `"$componentKey"` is present.

--- a/exports/copilot/faststore-faststore-storefront-ref-faststore-v3-v4-migration.md
+++ b/exports/copilot/faststore-faststore-storefront-ref-faststore-v3-v4-migration.md
@@ -38,7 +38,7 @@ FastStore v4's dependency tree (e.g. `eslint-visitor-keys@5`) declares
 older Node (e.g. 20.12) fails with `Found incompatible module`.
 
 - Use Node 24 for install, build and dev.
-- Set `volta.node` to `"24"` in `packages/discovery/package.json`.
+- Set `volta.node` to `"24.0.2"` (or the latest Node 24 patch) in `packages/discovery/package.json`.
 - Set `experimental.nodeVersion: 24` in `discovery.config.js`.
 
 ---
@@ -56,15 +56,33 @@ app dependencies — e.g. `crypto-js`, `draft-js` — alongside these):
 {
   "@faststore/cli": "<published v4 release>",
   "@vtex/faststore-plugin-buyer-portal": "<published v4 release>",
-  "next": "^16.2.6",
+  "graphql": "^16.11.0",
   "react": "^18.2.0",
   "react-dom": "^18.2.0",
   "react-router-dom": "^6.24.1"
 }
 ```
 
+**Important:** do **not** declare `next` in `dependencies` — Next.js is now
+managed internally by `@faststore/cli`, and declaring it separately causes
+version conflicts. Also update `typescript` in `devDependencies` to `^5.9.3`.
+
+`graphql` must be declared explicitly because it is a `peerDependency` of
+`@faststore/cli` — yarn v1 does not install peer dependencies automatically.
+
 Root `package.json`: `@faststore/cli` (devDependency) +
 `@vtex/faststore-plugin-buyer-portal` (dependency).
+
+**Monorepo stores only:** add `@inquirer/type` to the `resolutions` field in
+the root `package.json` to avoid version conflicts with the `inquirer` package:
+
+```json
+{
+  "resolutions": {
+    "@inquirer/type": "^1.5.5"
+  }
+}
+```
 
 **Pin npm releases, not pkg.pr.new / pkg.csb.dev tarballs.** The faststore v4
 monorepo uses pnpm `catalog:` / `workspace:*` specs. `npm publish` (via
@@ -201,7 +219,32 @@ partial actually contributes CSS/members before keeping it.
 
 ---
 
-## 5. v3 patches
+## 5. GraphQL import migration
+
+`@faststore/graphql-utils` is **deprecated** in v4. The `gql` tag used for
+GraphQL documents must be imported from `@faststore/core/api` instead.
+
+Search for all usages in `src/`:
+
+```bash
+grep -r "faststore/graphql-utils" src/
+```
+
+Replace every occurrence:
+
+```ts
+// before
+import { gql } from '@faststore/graphql-utils'
+
+// after
+import { gql } from '@faststore/core/api'
+```
+
+If the grep returns no matches, skip this step.
+
+---
+
+## 6. v3 patches
 
 `patch-package` patches are version-tagged (`@faststore+core+<v3>.patch`) and
 will not apply to v4. Inspect each:
@@ -313,10 +356,11 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 
 ## Appendix — migration checklist
 
-- [ ] Node 24 (`volta.node`, `experimental.nodeVersion`).
+- [ ] Node 24 (`volta.node` must be a full semver e.g. "24.0.2", `experimental.nodeVersion: 24`).
 - [ ] `package.json` (root + discovery): `@faststore/cli` + plugin pinned to
-      published v4 releases; v3 transitive deps removed; `next ^16.2.6`,
-      `react-router-dom` added.
+      published v4 releases; v3 transitive deps removed; `next` **removed**
+      from dependencies (managed by cli); `graphql ^16.11.0` and
+      `react-router-dom ^6.24.1` added; `typescript ^5.9.3` in devDependencies.
 - [ ] `discovery.config.js`: no `path`/`dotenv` requires; no `webpack()`
       callback; `nodeVersion: 24`; `transpilePackages` if needed.
 - [ ] Every `.scss`: top-level `@import` → `@use`; nested `@import` kept;
@@ -327,3 +371,162 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
       `patches/`.
 - [ ] `yarn build` and `yarn dev` verified (§8).
 - [ ] Local-linking machinery (§9) reverted before committing.
+- [ ] CMS type detected via `contentSource` in `discovery.config.js` (§11.1).
+- [ ] CMS sync instructions shown to user (§10 next steps): case detected from `discovery.config.js` + `cms/faststore/`; commands presented for manual execution (never run automatically).
+- [ ] New CMS fields configured in Admin → Storefront → Headless CMS / Content and pages republished (§11.4 — human step).
+- [ ] Tested locally with `yarn dev` — no empty labels/buttons/toasts.
+- [ ] Only then: v4 deployed to production + Node.js v24 set in WebOps.
+
+---
+
+## 10. Post-migration summary (mandatory output)
+
+> **MANDATORY prerequisite — do NOT display this summary until `yarn build`
+> passes.**
+>
+> Before showing the summary, run (using Node 24):
+> ```bash
+> yarn install
+> yarn build
+> ```
+> Fix any build errors first. Only after a successful build should you
+> proceed to display the summary below.
+
+After the build passes, display the following two sections.
+
+---
+
+### What was done
+
+A table covering every file touched and the change applied. Adapt rows to
+what actually changed; mark items that were not applicable as `—`.
+
+| File | Change | Status |
+|------|--------|--------|
+| `package.json` | `@faststore/cli` bumped to v4; `next` removed; `graphql`, `react-router-dom` added; `typescript` bumped to `^5.9.3`; `volta.node` set to `24` | ✅ Done |
+| `discovery.config.js` | `experimental.nodeVersion` → `24` | ✅ Done |
+| `src/**/*.scss` | Top-level `@import` → `@use`; `@include media/layout-content` namespaced to `u.*` | ✅ Done |
+| `patches/` | Stale v3 patches assessed / moved | ✅ Done / N/A |
+
+---
+
+### Important next steps
+
+#### 1. CMS sync (run manually in your terminal)
+
+> **Do NOT run `vtex content` commands automatically.** These require
+> interactive authentication and may have CLI plugin issues in Homebrew
+> environments.
+
+Check `discovery.config.js` and `cms/faststore/` to identify the case,
+then present the matching instructions to the user.
+
+**Headless CMS (legacy)** — `contentSource` field absent in `discovery.config.js`:
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+> If `cms-sync` errors with `Cannot find module 'vtex'`, run
+> `vtex plugins install @vtex/cli-plugin-cms` or `vtex update`.
+
+**Content Platform (CP)** — `contentSource: { type: 'CP' }` present.
+Identify the sub-case by inspecting `cms/faststore/`:
+
+| Case | Signal | Commands to run |
+|------|--------|-----------------|
+| **A** — no custom schemas | No `.jsonc` files, no `components/` folder | Create `cms/faststore/schema.json` with `{ "$base": "vtex.faststore" }`, then `vtex content upload-schema cms/faststore/schema.json` |
+| **B** — already split | `cms/faststore/components/*.jsonc` exists | `vtex content generate-schema cms/faststore/components cms/faststore/pages -o cms/faststore/schema.json` then `vtex content upload-schema cms/faststore/schema.json` |
+| **C** — legacy format | Only `sections.json` / `content-types.json` | Split first (see §11), then generate + upload |
+
+For the full command listing of each case see §11.
+
+---
+
+#### 2. Fill in new CMS fields and republish
+
+After the CMS sync, v4 exposes new configurable fields that were previously
+hardcoded. Configure them in **Admin → Storefront → Headless CMS / Content**
+and republish the affected pages:
+
+| Page | Fields to configure |
+|------|---------------------|
+| **All pages** | `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel` |
+| **Home** (product shelf) | `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`, `includeTaxesLabel`, `sponsoredLabel` |
+| **PLP** | `Breadcrumb → Fallback label`, `ProductGallery → sortBySelector`, `Filter → FilterSlider / FilterDesktop labels`, `ProductCard / ProductCardContent` |
+| **Search** | `SearchInput`, `SearchTop`, `SearchHistory`, `EmptyGallery → labels`, `ProductCard / ProductCardContent` |
+| **PDP** | `Breadcrumb → Fallback label`, `ProductDetails → invalidQuantityToast / buyButtonTitle` |
+| **Cart** | `EmptyCart → title / buttonLabel` |
+
+Full field reference: [developers.vtex.com → Upgrading FastStore to v4](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4)
+
+> Do not deploy v4 to production before filling these fields — they render
+> blank until configured.
+
+---
+
+#### 3. Update Node.js v24 in WebOps
+
+In VTEX Admin → **Storefront → FastStore WebOps → Settings → Node.js
+version** → set to `v24` → Save → trigger a new deploy.
+
+---
+
+#### 4. Check Sass `@import` deprecation warnings
+
+`@import` inside selector blocks emits Dart Sass deprecation warnings.
+
+---
+
+## 11. CMS sync — command reference
+
+This section is a command reference. The agent must **not** run these
+commands automatically — always present them to the user to run manually.
+
+### 11.1 Headless CMS (legacy)
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+`cms-sync` is safe while v3 is live — it only pushes the schema.
+
+### 11.2 Content Platform — Case A (no custom schemas)
+
+```bash
+# 1. Create the minimal schema (if not already present)
+# cms/faststore/schema.json content:
+# { "$base": "vtex.faststore" }
+# (use "vtex.faststore@4.1.0" to pin an explicit version)
+
+vtex login <accountName>
+vtex content upload-schema cms/faststore/schema.json
+# The local schema.json can be deleted after upload
+```
+
+### 11.3 Content Platform — Case B (components already in .jsonc format)
+
+```bash
+vtex login <accountName>
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```
+
+### 11.4 Content Platform — Case C (legacy sections.json)
+
+```bash
+vtex login <accountName>
+
+vtex content split-components -i cms/faststore/sections.json \
+                              -o cms/faststore/components
+vtex content split-content-types -i cms/faststore/content-types.json \
+                                 -s cms/faststore/sections.json \
+                                 -o cms/faststore/pages
+
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```

--- a/exports/copilot/faststore.md
+++ b/exports/copilot/faststore.md
@@ -99,7 +99,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -117,7 +117,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/exports/cursor/faststore-all.mdc
+++ b/exports/cursor/faststore-all.mdc
@@ -103,7 +103,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -121,7 +121,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/exports/cursor/faststore-faststore-storefront-ref-cms-schema-and-section-registration.mdc
+++ b/exports/cursor/faststore-faststore-storefront-ref-cms-schema-and-section-registration.mdc
@@ -231,7 +231,7 @@ Follow this EXACT sequence. Do NOT skip steps.
 
 ### Phase 4: Schema Management (SAME SESSION)
 
-- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4`
+- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json  `
 - [ ] Verify: `grep -A 5 '"<ComponentName>"' cms/faststore/schema.json` (search for the `$componentKey` string)
   - If it does not appear, fix JSONC or registration — **do not** edit `schema.json` manually
 - [ ] **Account check** (before upload): read `api.storeId` from `discovery.config.js` and run `vtex whoami` — confirm both match. If they differ, ask the user to run `vtex login <correct-account>` and **stop**.
@@ -290,7 +290,7 @@ From the **project root**:
 1. **Generate** (canonical command — matches the storefront skill):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 ```
 
 2. **Validate** — for new or renamed sections, grep or read `cms/faststore/schema.json` and confirm the `"$componentKey"` is present.

--- a/exports/cursor/faststore-faststore-storefront-ref-faststore-v3-v4-migration.mdc
+++ b/exports/cursor/faststore-faststore-storefront-ref-faststore-v3-v4-migration.mdc
@@ -44,7 +44,7 @@ FastStore v4's dependency tree (e.g. `eslint-visitor-keys@5`) declares
 older Node (e.g. 20.12) fails with `Found incompatible module`.
 
 - Use Node 24 for install, build and dev.
-- Set `volta.node` to `"24"` in `packages/discovery/package.json`.
+- Set `volta.node` to `"24.0.2"` (or the latest Node 24 patch) in `packages/discovery/package.json`.
 - Set `experimental.nodeVersion: 24` in `discovery.config.js`.
 
 ---
@@ -62,15 +62,33 @@ app dependencies — e.g. `crypto-js`, `draft-js` — alongside these):
 {
   "@faststore/cli": "<published v4 release>",
   "@vtex/faststore-plugin-buyer-portal": "<published v4 release>",
-  "next": "^16.2.6",
+  "graphql": "^16.11.0",
   "react": "^18.2.0",
   "react-dom": "^18.2.0",
   "react-router-dom": "^6.24.1"
 }
 ```
 
+**Important:** do **not** declare `next` in `dependencies` — Next.js is now
+managed internally by `@faststore/cli`, and declaring it separately causes
+version conflicts. Also update `typescript` in `devDependencies` to `^5.9.3`.
+
+`graphql` must be declared explicitly because it is a `peerDependency` of
+`@faststore/cli` — yarn v1 does not install peer dependencies automatically.
+
 Root `package.json`: `@faststore/cli` (devDependency) +
 `@vtex/faststore-plugin-buyer-portal` (dependency).
+
+**Monorepo stores only:** add `@inquirer/type` to the `resolutions` field in
+the root `package.json` to avoid version conflicts with the `inquirer` package:
+
+```json
+{
+  "resolutions": {
+    "@inquirer/type": "^1.5.5"
+  }
+}
+```
 
 **Pin npm releases, not pkg.pr.new / pkg.csb.dev tarballs.** The faststore v4
 monorepo uses pnpm `catalog:` / `workspace:*` specs. `npm publish` (via
@@ -207,7 +225,32 @@ partial actually contributes CSS/members before keeping it.
 
 ---
 
-## 5. v3 patches
+## 5. GraphQL import migration
+
+`@faststore/graphql-utils` is **deprecated** in v4. The `gql` tag used for
+GraphQL documents must be imported from `@faststore/core/api` instead.
+
+Search for all usages in `src/`:
+
+```bash
+grep -r "faststore/graphql-utils" src/
+```
+
+Replace every occurrence:
+
+```ts
+// before
+import { gql } from '@faststore/graphql-utils'
+
+// after
+import { gql } from '@faststore/core/api'
+```
+
+If the grep returns no matches, skip this step.
+
+---
+
+## 6. v3 patches
 
 `patch-package` patches are version-tagged (`@faststore+core+<v3>.patch`) and
 will not apply to v4. Inspect each:
@@ -319,10 +362,11 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 
 ## Appendix — migration checklist
 
-- [ ] Node 24 (`volta.node`, `experimental.nodeVersion`).
+- [ ] Node 24 (`volta.node` must be a full semver e.g. "24.0.2", `experimental.nodeVersion: 24`).
 - [ ] `package.json` (root + discovery): `@faststore/cli` + plugin pinned to
-      published v4 releases; v3 transitive deps removed; `next ^16.2.6`,
-      `react-router-dom` added.
+      published v4 releases; v3 transitive deps removed; `next` **removed**
+      from dependencies (managed by cli); `graphql ^16.11.0` and
+      `react-router-dom ^6.24.1` added; `typescript ^5.9.3` in devDependencies.
 - [ ] `discovery.config.js`: no `path`/`dotenv` requires; no `webpack()`
       callback; `nodeVersion: 24`; `transpilePackages` if needed.
 - [ ] Every `.scss`: top-level `@import` → `@use`; nested `@import` kept;
@@ -333,3 +377,162 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
       `patches/`.
 - [ ] `yarn build` and `yarn dev` verified (§8).
 - [ ] Local-linking machinery (§9) reverted before committing.
+- [ ] CMS type detected via `contentSource` in `discovery.config.js` (§11.1).
+- [ ] CMS sync instructions shown to user (§10 next steps): case detected from `discovery.config.js` + `cms/faststore/`; commands presented for manual execution (never run automatically).
+- [ ] New CMS fields configured in Admin → Storefront → Headless CMS / Content and pages republished (§11.4 — human step).
+- [ ] Tested locally with `yarn dev` — no empty labels/buttons/toasts.
+- [ ] Only then: v4 deployed to production + Node.js v24 set in WebOps.
+
+---
+
+## 10. Post-migration summary (mandatory output)
+
+> **MANDATORY prerequisite — do NOT display this summary until `yarn build`
+> passes.**
+>
+> Before showing the summary, run (using Node 24):
+> ```bash
+> yarn install
+> yarn build
+> ```
+> Fix any build errors first. Only after a successful build should you
+> proceed to display the summary below.
+
+After the build passes, display the following two sections.
+
+---
+
+### What was done
+
+A table covering every file touched and the change applied. Adapt rows to
+what actually changed; mark items that were not applicable as `—`.
+
+| File | Change | Status |
+|------|--------|--------|
+| `package.json` | `@faststore/cli` bumped to v4; `next` removed; `graphql`, `react-router-dom` added; `typescript` bumped to `^5.9.3`; `volta.node` set to `24` | ✅ Done |
+| `discovery.config.js` | `experimental.nodeVersion` → `24` | ✅ Done |
+| `src/**/*.scss` | Top-level `@import` → `@use`; `@include media/layout-content` namespaced to `u.*` | ✅ Done |
+| `patches/` | Stale v3 patches assessed / moved | ✅ Done / N/A |
+
+---
+
+### Important next steps
+
+#### 1. CMS sync (run manually in your terminal)
+
+> **Do NOT run `vtex content` commands automatically.** These require
+> interactive authentication and may have CLI plugin issues in Homebrew
+> environments.
+
+Check `discovery.config.js` and `cms/faststore/` to identify the case,
+then present the matching instructions to the user.
+
+**Headless CMS (legacy)** — `contentSource` field absent in `discovery.config.js`:
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+> If `cms-sync` errors with `Cannot find module 'vtex'`, run
+> `vtex plugins install @vtex/cli-plugin-cms` or `vtex update`.
+
+**Content Platform (CP)** — `contentSource: { type: 'CP' }` present.
+Identify the sub-case by inspecting `cms/faststore/`:
+
+| Case | Signal | Commands to run |
+|------|--------|-----------------|
+| **A** — no custom schemas | No `.jsonc` files, no `components/` folder | Create `cms/faststore/schema.json` with `{ "$base": "vtex.faststore" }`, then `vtex content upload-schema cms/faststore/schema.json` |
+| **B** — already split | `cms/faststore/components/*.jsonc` exists | `vtex content generate-schema cms/faststore/components cms/faststore/pages -o cms/faststore/schema.json` then `vtex content upload-schema cms/faststore/schema.json` |
+| **C** — legacy format | Only `sections.json` / `content-types.json` | Split first (see §11), then generate + upload |
+
+For the full command listing of each case see §11.
+
+---
+
+#### 2. Fill in new CMS fields and republish
+
+After the CMS sync, v4 exposes new configurable fields that were previously
+hardcoded. Configure them in **Admin → Storefront → Headless CMS / Content**
+and republish the affected pages:
+
+| Page | Fields to configure |
+|------|---------------------|
+| **All pages** | `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel` |
+| **Home** (product shelf) | `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`, `includeTaxesLabel`, `sponsoredLabel` |
+| **PLP** | `Breadcrumb → Fallback label`, `ProductGallery → sortBySelector`, `Filter → FilterSlider / FilterDesktop labels`, `ProductCard / ProductCardContent` |
+| **Search** | `SearchInput`, `SearchTop`, `SearchHistory`, `EmptyGallery → labels`, `ProductCard / ProductCardContent` |
+| **PDP** | `Breadcrumb → Fallback label`, `ProductDetails → invalidQuantityToast / buyButtonTitle` |
+| **Cart** | `EmptyCart → title / buttonLabel` |
+
+Full field reference: [developers.vtex.com → Upgrading FastStore to v4](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4)
+
+> Do not deploy v4 to production before filling these fields — they render
+> blank until configured.
+
+---
+
+#### 3. Update Node.js v24 in WebOps
+
+In VTEX Admin → **Storefront → FastStore WebOps → Settings → Node.js
+version** → set to `v24` → Save → trigger a new deploy.
+
+---
+
+#### 4. Check Sass `@import` deprecation warnings
+
+`@import` inside selector blocks emits Dart Sass deprecation warnings.
+
+---
+
+## 11. CMS sync — command reference
+
+This section is a command reference. The agent must **not** run these
+commands automatically — always present them to the user to run manually.
+
+### 11.1 Headless CMS (legacy)
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+`cms-sync` is safe while v3 is live — it only pushes the schema.
+
+### 11.2 Content Platform — Case A (no custom schemas)
+
+```bash
+# 1. Create the minimal schema (if not already present)
+# cms/faststore/schema.json content:
+# { "$base": "vtex.faststore" }
+# (use "vtex.faststore@4.1.0" to pin an explicit version)
+
+vtex login <accountName>
+vtex content upload-schema cms/faststore/schema.json
+# The local schema.json can be deleted after upload
+```
+
+### 11.3 Content Platform — Case B (components already in .jsonc format)
+
+```bash
+vtex login <accountName>
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```
+
+### 11.4 Content Platform — Case C (legacy sections.json)
+
+```bash
+vtex login <accountName>
+
+vtex content split-components -i cms/faststore/sections.json \
+                              -o cms/faststore/components
+vtex content split-content-types -i cms/faststore/content-types.json \
+                                 -s cms/faststore/sections.json \
+                                 -o cms/faststore/pages
+
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```

--- a/exports/cursor/faststore-faststore-storefront.mdc
+++ b/exports/cursor/faststore-faststore-storefront.mdc
@@ -103,7 +103,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -121,7 +121,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/exports/kiro/steering/faststore-all.md
+++ b/exports/kiro/steering/faststore-all.md
@@ -99,7 +99,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -117,7 +117,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/exports/kiro/steering/faststore-faststore-storefront-ref-cms-schema-and-section-registration.md
+++ b/exports/kiro/steering/faststore-faststore-storefront-ref-cms-schema-and-section-registration.md
@@ -225,7 +225,7 @@ Follow this EXACT sequence. Do NOT skip steps.
 
 ### Phase 4: Schema Management (SAME SESSION)
 
-- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4`
+- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json  `
 - [ ] Verify: `grep -A 5 '"<ComponentName>"' cms/faststore/schema.json` (search for the `$componentKey` string)
   - If it does not appear, fix JSONC or registration — **do not** edit `schema.json` manually
 - [ ] **Account check** (before upload): read `api.storeId` from `discovery.config.js` and run `vtex whoami` — confirm both match. If they differ, ask the user to run `vtex login <correct-account>` and **stop**.
@@ -284,7 +284,7 @@ From the **project root**:
 1. **Generate** (canonical command — matches the storefront skill):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 ```
 
 2. **Validate** — for new or renamed sections, grep or read `cms/faststore/schema.json` and confirm the `"$componentKey"` is present.

--- a/exports/kiro/steering/faststore-faststore-storefront-ref-faststore-v3-v4-migration.md
+++ b/exports/kiro/steering/faststore-faststore-storefront-ref-faststore-v3-v4-migration.md
@@ -38,7 +38,7 @@ FastStore v4's dependency tree (e.g. `eslint-visitor-keys@5`) declares
 older Node (e.g. 20.12) fails with `Found incompatible module`.
 
 - Use Node 24 for install, build and dev.
-- Set `volta.node` to `"24"` in `packages/discovery/package.json`.
+- Set `volta.node` to `"24.0.2"` (or the latest Node 24 patch) in `packages/discovery/package.json`.
 - Set `experimental.nodeVersion: 24` in `discovery.config.js`.
 
 ---
@@ -56,15 +56,33 @@ app dependencies — e.g. `crypto-js`, `draft-js` — alongside these):
 {
   "@faststore/cli": "<published v4 release>",
   "@vtex/faststore-plugin-buyer-portal": "<published v4 release>",
-  "next": "^16.2.6",
+  "graphql": "^16.11.0",
   "react": "^18.2.0",
   "react-dom": "^18.2.0",
   "react-router-dom": "^6.24.1"
 }
 ```
 
+**Important:** do **not** declare `next` in `dependencies` — Next.js is now
+managed internally by `@faststore/cli`, and declaring it separately causes
+version conflicts. Also update `typescript` in `devDependencies` to `^5.9.3`.
+
+`graphql` must be declared explicitly because it is a `peerDependency` of
+`@faststore/cli` — yarn v1 does not install peer dependencies automatically.
+
 Root `package.json`: `@faststore/cli` (devDependency) +
 `@vtex/faststore-plugin-buyer-portal` (dependency).
+
+**Monorepo stores only:** add `@inquirer/type` to the `resolutions` field in
+the root `package.json` to avoid version conflicts with the `inquirer` package:
+
+```json
+{
+  "resolutions": {
+    "@inquirer/type": "^1.5.5"
+  }
+}
+```
 
 **Pin npm releases, not pkg.pr.new / pkg.csb.dev tarballs.** The faststore v4
 monorepo uses pnpm `catalog:` / `workspace:*` specs. `npm publish` (via
@@ -201,7 +219,32 @@ partial actually contributes CSS/members before keeping it.
 
 ---
 
-## 5. v3 patches
+## 5. GraphQL import migration
+
+`@faststore/graphql-utils` is **deprecated** in v4. The `gql` tag used for
+GraphQL documents must be imported from `@faststore/core/api` instead.
+
+Search for all usages in `src/`:
+
+```bash
+grep -r "faststore/graphql-utils" src/
+```
+
+Replace every occurrence:
+
+```ts
+// before
+import { gql } from '@faststore/graphql-utils'
+
+// after
+import { gql } from '@faststore/core/api'
+```
+
+If the grep returns no matches, skip this step.
+
+---
+
+## 6. v3 patches
 
 `patch-package` patches are version-tagged (`@faststore+core+<v3>.patch`) and
 will not apply to v4. Inspect each:
@@ -313,10 +356,11 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 
 ## Appendix — migration checklist
 
-- [ ] Node 24 (`volta.node`, `experimental.nodeVersion`).
+- [ ] Node 24 (`volta.node` must be a full semver e.g. "24.0.2", `experimental.nodeVersion: 24`).
 - [ ] `package.json` (root + discovery): `@faststore/cli` + plugin pinned to
-      published v4 releases; v3 transitive deps removed; `next ^16.2.6`,
-      `react-router-dom` added.
+      published v4 releases; v3 transitive deps removed; `next` **removed**
+      from dependencies (managed by cli); `graphql ^16.11.0` and
+      `react-router-dom ^6.24.1` added; `typescript ^5.9.3` in devDependencies.
 - [ ] `discovery.config.js`: no `path`/`dotenv` requires; no `webpack()`
       callback; `nodeVersion: 24`; `transpilePackages` if needed.
 - [ ] Every `.scss`: top-level `@import` → `@use`; nested `@import` kept;
@@ -327,3 +371,162 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
       `patches/`.
 - [ ] `yarn build` and `yarn dev` verified (§8).
 - [ ] Local-linking machinery (§9) reverted before committing.
+- [ ] CMS type detected via `contentSource` in `discovery.config.js` (§11.1).
+- [ ] CMS sync instructions shown to user (§10 next steps): case detected from `discovery.config.js` + `cms/faststore/`; commands presented for manual execution (never run automatically).
+- [ ] New CMS fields configured in Admin → Storefront → Headless CMS / Content and pages republished (§11.4 — human step).
+- [ ] Tested locally with `yarn dev` — no empty labels/buttons/toasts.
+- [ ] Only then: v4 deployed to production + Node.js v24 set in WebOps.
+
+---
+
+## 10. Post-migration summary (mandatory output)
+
+> **MANDATORY prerequisite — do NOT display this summary until `yarn build`
+> passes.**
+>
+> Before showing the summary, run (using Node 24):
+> ```bash
+> yarn install
+> yarn build
+> ```
+> Fix any build errors first. Only after a successful build should you
+> proceed to display the summary below.
+
+After the build passes, display the following two sections.
+
+---
+
+### What was done
+
+A table covering every file touched and the change applied. Adapt rows to
+what actually changed; mark items that were not applicable as `—`.
+
+| File | Change | Status |
+|------|--------|--------|
+| `package.json` | `@faststore/cli` bumped to v4; `next` removed; `graphql`, `react-router-dom` added; `typescript` bumped to `^5.9.3`; `volta.node` set to `24` | ✅ Done |
+| `discovery.config.js` | `experimental.nodeVersion` → `24` | ✅ Done |
+| `src/**/*.scss` | Top-level `@import` → `@use`; `@include media/layout-content` namespaced to `u.*` | ✅ Done |
+| `patches/` | Stale v3 patches assessed / moved | ✅ Done / N/A |
+
+---
+
+### Important next steps
+
+#### 1. CMS sync (run manually in your terminal)
+
+> **Do NOT run `vtex content` commands automatically.** These require
+> interactive authentication and may have CLI plugin issues in Homebrew
+> environments.
+
+Check `discovery.config.js` and `cms/faststore/` to identify the case,
+then present the matching instructions to the user.
+
+**Headless CMS (legacy)** — `contentSource` field absent in `discovery.config.js`:
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+> If `cms-sync` errors with `Cannot find module 'vtex'`, run
+> `vtex plugins install @vtex/cli-plugin-cms` or `vtex update`.
+
+**Content Platform (CP)** — `contentSource: { type: 'CP' }` present.
+Identify the sub-case by inspecting `cms/faststore/`:
+
+| Case | Signal | Commands to run |
+|------|--------|-----------------|
+| **A** — no custom schemas | No `.jsonc` files, no `components/` folder | Create `cms/faststore/schema.json` with `{ "$base": "vtex.faststore" }`, then `vtex content upload-schema cms/faststore/schema.json` |
+| **B** — already split | `cms/faststore/components/*.jsonc` exists | `vtex content generate-schema cms/faststore/components cms/faststore/pages -o cms/faststore/schema.json` then `vtex content upload-schema cms/faststore/schema.json` |
+| **C** — legacy format | Only `sections.json` / `content-types.json` | Split first (see §11), then generate + upload |
+
+For the full command listing of each case see §11.
+
+---
+
+#### 2. Fill in new CMS fields and republish
+
+After the CMS sync, v4 exposes new configurable fields that were previously
+hardcoded. Configure them in **Admin → Storefront → Headless CMS / Content**
+and republish the affected pages:
+
+| Page | Fields to configure |
+|------|---------------------|
+| **All pages** | `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel` |
+| **Home** (product shelf) | `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`, `includeTaxesLabel`, `sponsoredLabel` |
+| **PLP** | `Breadcrumb → Fallback label`, `ProductGallery → sortBySelector`, `Filter → FilterSlider / FilterDesktop labels`, `ProductCard / ProductCardContent` |
+| **Search** | `SearchInput`, `SearchTop`, `SearchHistory`, `EmptyGallery → labels`, `ProductCard / ProductCardContent` |
+| **PDP** | `Breadcrumb → Fallback label`, `ProductDetails → invalidQuantityToast / buyButtonTitle` |
+| **Cart** | `EmptyCart → title / buttonLabel` |
+
+Full field reference: [developers.vtex.com → Upgrading FastStore to v4](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4)
+
+> Do not deploy v4 to production before filling these fields — they render
+> blank until configured.
+
+---
+
+#### 3. Update Node.js v24 in WebOps
+
+In VTEX Admin → **Storefront → FastStore WebOps → Settings → Node.js
+version** → set to `v24` → Save → trigger a new deploy.
+
+---
+
+#### 4. Check Sass `@import` deprecation warnings
+
+`@import` inside selector blocks emits Dart Sass deprecation warnings.
+
+---
+
+## 11. CMS sync — command reference
+
+This section is a command reference. The agent must **not** run these
+commands automatically — always present them to the user to run manually.
+
+### 11.1 Headless CMS (legacy)
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+`cms-sync` is safe while v3 is live — it only pushes the schema.
+
+### 11.2 Content Platform — Case A (no custom schemas)
+
+```bash
+# 1. Create the minimal schema (if not already present)
+# cms/faststore/schema.json content:
+# { "$base": "vtex.faststore" }
+# (use "vtex.faststore@4.1.0" to pin an explicit version)
+
+vtex login <accountName>
+vtex content upload-schema cms/faststore/schema.json
+# The local schema.json can be deleted after upload
+```
+
+### 11.3 Content Platform — Case B (components already in .jsonc format)
+
+```bash
+vtex login <accountName>
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```
+
+### 11.4 Content Platform — Case C (legacy sections.json)
+
+```bash
+vtex login <accountName>
+
+vtex content split-components -i cms/faststore/sections.json \
+                              -o cms/faststore/components
+vtex content split-content-types -i cms/faststore/content-types.json \
+                                 -s cms/faststore/sections.json \
+                                 -o cms/faststore/pages
+
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```

--- a/exports/kiro/steering/faststore-faststore-storefront.md
+++ b/exports/kiro/steering/faststore-faststore-storefront.md
@@ -99,7 +99,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -117,7 +117,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/exports/opencode/faststore-storefront/SKILL.md
+++ b/exports/opencode/faststore-storefront/SKILL.md
@@ -102,7 +102,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -120,7 +120,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/exports/opencode/faststore-storefront/references/cms-schema-and-section-registration.md
+++ b/exports/opencode/faststore-storefront/references/cms-schema-and-section-registration.md
@@ -233,7 +233,7 @@ Follow this EXACT sequence. Do NOT skip steps.
 
 ### Phase 4: Schema Management (SAME SESSION)
 
-- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4`
+- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json  `
 - [ ] Verify: `grep -A 5 '"<ComponentName>"' cms/faststore/schema.json` (search for the `$componentKey` string)
   - If it does not appear, fix JSONC or registration — **do not** edit `schema.json` manually
 - [ ] **Account check** (before upload): read `api.storeId` from `discovery.config.js` and run `vtex whoami` — confirm both match. If they differ, ask the user to run `vtex login <correct-account>` and **stop**.
@@ -292,7 +292,7 @@ From the **project root**:
 1. **Generate** (canonical command — matches the storefront skill):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 ```
 
 2. **Validate** — for new or renamed sections, grep or read `cms/faststore/schema.json` and confirm the `"$componentKey"` is present.

--- a/exports/opencode/faststore-storefront/references/faststore-v3-v4-migration.md
+++ b/exports/opencode/faststore-storefront/references/faststore-v3-v4-migration.md
@@ -38,7 +38,7 @@ FastStore v4's dependency tree (e.g. `eslint-visitor-keys@5`) declares
 older Node (e.g. 20.12) fails with `Found incompatible module`.
 
 - Use Node 24 for install, build and dev.
-- Set `volta.node` to `"24"` in `packages/discovery/package.json`.
+- Set `volta.node` to `"24.0.2"` (or the latest Node 24 patch) in `packages/discovery/package.json`.
 - Set `experimental.nodeVersion: 24` in `discovery.config.js`.
 
 ---
@@ -56,15 +56,33 @@ app dependencies — e.g. `crypto-js`, `draft-js` — alongside these):
 {
   "@faststore/cli": "<published v4 release>",
   "@vtex/faststore-plugin-buyer-portal": "<published v4 release>",
-  "next": "^16.2.6",
+  "graphql": "^16.11.0",
   "react": "^18.2.0",
   "react-dom": "^18.2.0",
   "react-router-dom": "^6.24.1"
 }
 ```
 
+**Important:** do **not** declare `next` in `dependencies` — Next.js is now
+managed internally by `@faststore/cli`, and declaring it separately causes
+version conflicts. Also update `typescript` in `devDependencies` to `^5.9.3`.
+
+`graphql` must be declared explicitly because it is a `peerDependency` of
+`@faststore/cli` — yarn v1 does not install peer dependencies automatically.
+
 Root `package.json`: `@faststore/cli` (devDependency) +
 `@vtex/faststore-plugin-buyer-portal` (dependency).
+
+**Monorepo stores only:** add `@inquirer/type` to the `resolutions` field in
+the root `package.json` to avoid version conflicts with the `inquirer` package:
+
+```json
+{
+  "resolutions": {
+    "@inquirer/type": "^1.5.5"
+  }
+}
+```
 
 **Pin npm releases, not pkg.pr.new / pkg.csb.dev tarballs.** The faststore v4
 monorepo uses pnpm `catalog:` / `workspace:*` specs. `npm publish` (via
@@ -201,7 +219,32 @@ partial actually contributes CSS/members before keeping it.
 
 ---
 
-## 5. v3 patches
+## 5. GraphQL import migration
+
+`@faststore/graphql-utils` is **deprecated** in v4. The `gql` tag used for
+GraphQL documents must be imported from `@faststore/core/api` instead.
+
+Search for all usages in `src/`:
+
+```bash
+grep -r "faststore/graphql-utils" src/
+```
+
+Replace every occurrence:
+
+```ts
+// before
+import { gql } from '@faststore/graphql-utils'
+
+// after
+import { gql } from '@faststore/core/api'
+```
+
+If the grep returns no matches, skip this step.
+
+---
+
+## 6. v3 patches
 
 `patch-package` patches are version-tagged (`@faststore+core+<v3>.patch`) and
 will not apply to v4. Inspect each:
@@ -313,10 +356,11 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 
 ## Appendix — migration checklist
 
-- [ ] Node 24 (`volta.node`, `experimental.nodeVersion`).
+- [ ] Node 24 (`volta.node` must be a full semver e.g. "24.0.2", `experimental.nodeVersion: 24`).
 - [ ] `package.json` (root + discovery): `@faststore/cli` + plugin pinned to
-      published v4 releases; v3 transitive deps removed; `next ^16.2.6`,
-      `react-router-dom` added.
+      published v4 releases; v3 transitive deps removed; `next` **removed**
+      from dependencies (managed by cli); `graphql ^16.11.0` and
+      `react-router-dom ^6.24.1` added; `typescript ^5.9.3` in devDependencies.
 - [ ] `discovery.config.js`: no `path`/`dotenv` requires; no `webpack()`
       callback; `nodeVersion: 24`; `transpilePackages` if needed.
 - [ ] Every `.scss`: top-level `@import` → `@use`; nested `@import` kept;
@@ -327,3 +371,162 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
       `patches/`.
 - [ ] `yarn build` and `yarn dev` verified (§8).
 - [ ] Local-linking machinery (§9) reverted before committing.
+- [ ] CMS type detected via `contentSource` in `discovery.config.js` (§11.1).
+- [ ] CMS sync instructions shown to user (§10 next steps): case detected from `discovery.config.js` + `cms/faststore/`; commands presented for manual execution (never run automatically).
+- [ ] New CMS fields configured in Admin → Storefront → Headless CMS / Content and pages republished (§11.4 — human step).
+- [ ] Tested locally with `yarn dev` — no empty labels/buttons/toasts.
+- [ ] Only then: v4 deployed to production + Node.js v24 set in WebOps.
+
+---
+
+## 10. Post-migration summary (mandatory output)
+
+> **MANDATORY prerequisite — do NOT display this summary until `yarn build`
+> passes.**
+>
+> Before showing the summary, run (using Node 24):
+> ```bash
+> yarn install
+> yarn build
+> ```
+> Fix any build errors first. Only after a successful build should you
+> proceed to display the summary below.
+
+After the build passes, display the following two sections.
+
+---
+
+### What was done
+
+A table covering every file touched and the change applied. Adapt rows to
+what actually changed; mark items that were not applicable as `—`.
+
+| File | Change | Status |
+|------|--------|--------|
+| `package.json` | `@faststore/cli` bumped to v4; `next` removed; `graphql`, `react-router-dom` added; `typescript` bumped to `^5.9.3`; `volta.node` set to `24` | ✅ Done |
+| `discovery.config.js` | `experimental.nodeVersion` → `24` | ✅ Done |
+| `src/**/*.scss` | Top-level `@import` → `@use`; `@include media/layout-content` namespaced to `u.*` | ✅ Done |
+| `patches/` | Stale v3 patches assessed / moved | ✅ Done / N/A |
+
+---
+
+### Important next steps
+
+#### 1. CMS sync (run manually in your terminal)
+
+> **Do NOT run `vtex content` commands automatically.** These require
+> interactive authentication and may have CLI plugin issues in Homebrew
+> environments.
+
+Check `discovery.config.js` and `cms/faststore/` to identify the case,
+then present the matching instructions to the user.
+
+**Headless CMS (legacy)** — `contentSource` field absent in `discovery.config.js`:
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+> If `cms-sync` errors with `Cannot find module 'vtex'`, run
+> `vtex plugins install @vtex/cli-plugin-cms` or `vtex update`.
+
+**Content Platform (CP)** — `contentSource: { type: 'CP' }` present.
+Identify the sub-case by inspecting `cms/faststore/`:
+
+| Case | Signal | Commands to run |
+|------|--------|-----------------|
+| **A** — no custom schemas | No `.jsonc` files, no `components/` folder | Create `cms/faststore/schema.json` with `{ "$base": "vtex.faststore" }`, then `vtex content upload-schema cms/faststore/schema.json` |
+| **B** — already split | `cms/faststore/components/*.jsonc` exists | `vtex content generate-schema cms/faststore/components cms/faststore/pages -o cms/faststore/schema.json` then `vtex content upload-schema cms/faststore/schema.json` |
+| **C** — legacy format | Only `sections.json` / `content-types.json` | Split first (see §11), then generate + upload |
+
+For the full command listing of each case see §11.
+
+---
+
+#### 2. Fill in new CMS fields and republish
+
+After the CMS sync, v4 exposes new configurable fields that were previously
+hardcoded. Configure them in **Admin → Storefront → Headless CMS / Content**
+and republish the affected pages:
+
+| Page | Fields to configure |
+|------|---------------------|
+| **All pages** | `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel` |
+| **Home** (product shelf) | `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`, `includeTaxesLabel`, `sponsoredLabel` |
+| **PLP** | `Breadcrumb → Fallback label`, `ProductGallery → sortBySelector`, `Filter → FilterSlider / FilterDesktop labels`, `ProductCard / ProductCardContent` |
+| **Search** | `SearchInput`, `SearchTop`, `SearchHistory`, `EmptyGallery → labels`, `ProductCard / ProductCardContent` |
+| **PDP** | `Breadcrumb → Fallback label`, `ProductDetails → invalidQuantityToast / buyButtonTitle` |
+| **Cart** | `EmptyCart → title / buttonLabel` |
+
+Full field reference: [developers.vtex.com → Upgrading FastStore to v4](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4)
+
+> Do not deploy v4 to production before filling these fields — they render
+> blank until configured.
+
+---
+
+#### 3. Update Node.js v24 in WebOps
+
+In VTEX Admin → **Storefront → FastStore WebOps → Settings → Node.js
+version** → set to `v24` → Save → trigger a new deploy.
+
+---
+
+#### 4. Check Sass `@import` deprecation warnings
+
+`@import` inside selector blocks emits Dart Sass deprecation warnings.
+
+---
+
+## 11. CMS sync — command reference
+
+This section is a command reference. The agent must **not** run these
+commands automatically — always present them to the user to run manually.
+
+### 11.1 Headless CMS (legacy)
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+`cms-sync` is safe while v3 is live — it only pushes the schema.
+
+### 11.2 Content Platform — Case A (no custom schemas)
+
+```bash
+# 1. Create the minimal schema (if not already present)
+# cms/faststore/schema.json content:
+# { "$base": "vtex.faststore" }
+# (use "vtex.faststore@4.1.0" to pin an explicit version)
+
+vtex login <accountName>
+vtex content upload-schema cms/faststore/schema.json
+# The local schema.json can be deleted after upload
+```
+
+### 11.3 Content Platform — Case B (components already in .jsonc format)
+
+```bash
+vtex login <accountName>
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```
+
+### 11.4 Content Platform — Case C (legacy sections.json)
+
+```bash
+vtex login <accountName>
+
+vtex content split-components -i cms/faststore/sections.json \
+                              -o cms/faststore/components
+vtex content split-content-types -i cms/faststore/content-types.json \
+                                 -s cms/faststore/sections.json \
+                                 -o cms/faststore/pages
+
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```

--- a/exports/opencode/faststore-storefront/scripts/cms-sync.sh
+++ b/exports/opencode/faststore-storefront/scripts/cms-sync.sh
@@ -2,14 +2,14 @@
 #
 # DEPRECATED — Headless CMS schema publishing
 # Prefer running from the project root (global VTEX CLI):
-#   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+#   vtex content generate-schema -o cms/faststore/schema.json  
 #   vtex content upload-schema cms/faststore/schema.json
 # Do not use yarn/npm cms-sync or faststore cms-sync for this workflow.
 # See references/cms-schema-and-section-registration.md and skill.md.
 #
 
 # Generate final schema.json for Headless CMS (canonical flags — matches skill.md)
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 
 # Upload final schema.json to Headless CMS (expects interactive prompts or use expect — see reference)
 expect -c 'spawn vtex content upload-schema cms/faststore/schema.json; expect "store ID"; send "faststore\r"; expect "uploaded with"; send "y\r"; expect "Are you sure"; send "y\r"; expect eof' 2>&1

--- a/rules/faststore-all.mdc
+++ b/rules/faststore-all.mdc
@@ -103,7 +103,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -121,7 +121,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/rules/faststore-faststore-storefront-ref-cms-schema-and-section-registration.mdc
+++ b/rules/faststore-faststore-storefront-ref-cms-schema-and-section-registration.mdc
@@ -231,7 +231,7 @@ Follow this EXACT sequence. Do NOT skip steps.
 
 ### Phase 4: Schema Management (SAME SESSION)
 
-- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4`
+- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json  `
 - [ ] Verify: `grep -A 5 '"<ComponentName>"' cms/faststore/schema.json` (search for the `$componentKey` string)
   - If it does not appear, fix JSONC or registration — **do not** edit `schema.json` manually
 - [ ] **Account check** (before upload): read `api.storeId` from `discovery.config.js` and run `vtex whoami` — confirm both match. If they differ, ask the user to run `vtex login <correct-account>` and **stop**.
@@ -290,7 +290,7 @@ From the **project root**:
 1. **Generate** (canonical command — matches the storefront skill):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 ```
 
 2. **Validate** — for new or renamed sections, grep or read `cms/faststore/schema.json` and confirm the `"$componentKey"` is present.

--- a/rules/faststore-faststore-storefront-ref-faststore-v3-v4-migration.mdc
+++ b/rules/faststore-faststore-storefront-ref-faststore-v3-v4-migration.mdc
@@ -44,7 +44,7 @@ FastStore v4's dependency tree (e.g. `eslint-visitor-keys@5`) declares
 older Node (e.g. 20.12) fails with `Found incompatible module`.
 
 - Use Node 24 for install, build and dev.
-- Set `volta.node` to `"24"` in `packages/discovery/package.json`.
+- Set `volta.node` to `"24.0.2"` (or the latest Node 24 patch) in `packages/discovery/package.json`.
 - Set `experimental.nodeVersion: 24` in `discovery.config.js`.
 
 ---
@@ -62,15 +62,33 @@ app dependencies — e.g. `crypto-js`, `draft-js` — alongside these):
 {
   "@faststore/cli": "<published v4 release>",
   "@vtex/faststore-plugin-buyer-portal": "<published v4 release>",
-  "next": "^16.2.6",
+  "graphql": "^16.11.0",
   "react": "^18.2.0",
   "react-dom": "^18.2.0",
   "react-router-dom": "^6.24.1"
 }
 ```
 
+**Important:** do **not** declare `next` in `dependencies` — Next.js is now
+managed internally by `@faststore/cli`, and declaring it separately causes
+version conflicts. Also update `typescript` in `devDependencies` to `^5.9.3`.
+
+`graphql` must be declared explicitly because it is a `peerDependency` of
+`@faststore/cli` — yarn v1 does not install peer dependencies automatically.
+
 Root `package.json`: `@faststore/cli` (devDependency) +
 `@vtex/faststore-plugin-buyer-portal` (dependency).
+
+**Monorepo stores only:** add `@inquirer/type` to the `resolutions` field in
+the root `package.json` to avoid version conflicts with the `inquirer` package:
+
+```json
+{
+  "resolutions": {
+    "@inquirer/type": "^1.5.5"
+  }
+}
+```
 
 **Pin npm releases, not pkg.pr.new / pkg.csb.dev tarballs.** The faststore v4
 monorepo uses pnpm `catalog:` / `workspace:*` specs. `npm publish` (via
@@ -207,7 +225,32 @@ partial actually contributes CSS/members before keeping it.
 
 ---
 
-## 5. v3 patches
+## 5. GraphQL import migration
+
+`@faststore/graphql-utils` is **deprecated** in v4. The `gql` tag used for
+GraphQL documents must be imported from `@faststore/core/api` instead.
+
+Search for all usages in `src/`:
+
+```bash
+grep -r "faststore/graphql-utils" src/
+```
+
+Replace every occurrence:
+
+```ts
+// before
+import { gql } from '@faststore/graphql-utils'
+
+// after
+import { gql } from '@faststore/core/api'
+```
+
+If the grep returns no matches, skip this step.
+
+---
+
+## 6. v3 patches
 
 `patch-package` patches are version-tagged (`@faststore+core+<v3>.patch`) and
 will not apply to v4. Inspect each:
@@ -319,10 +362,11 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 
 ## Appendix — migration checklist
 
-- [ ] Node 24 (`volta.node`, `experimental.nodeVersion`).
+- [ ] Node 24 (`volta.node` must be a full semver e.g. "24.0.2", `experimental.nodeVersion: 24`).
 - [ ] `package.json` (root + discovery): `@faststore/cli` + plugin pinned to
-      published v4 releases; v3 transitive deps removed; `next ^16.2.6`,
-      `react-router-dom` added.
+      published v4 releases; v3 transitive deps removed; `next` **removed**
+      from dependencies (managed by cli); `graphql ^16.11.0` and
+      `react-router-dom ^6.24.1` added; `typescript ^5.9.3` in devDependencies.
 - [ ] `discovery.config.js`: no `path`/`dotenv` requires; no `webpack()`
       callback; `nodeVersion: 24`; `transpilePackages` if needed.
 - [ ] Every `.scss`: top-level `@import` → `@use`; nested `@import` kept;
@@ -333,3 +377,162 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
       `patches/`.
 - [ ] `yarn build` and `yarn dev` verified (§8).
 - [ ] Local-linking machinery (§9) reverted before committing.
+- [ ] CMS type detected via `contentSource` in `discovery.config.js` (§11.1).
+- [ ] CMS sync instructions shown to user (§10 next steps): case detected from `discovery.config.js` + `cms/faststore/`; commands presented for manual execution (never run automatically).
+- [ ] New CMS fields configured in Admin → Storefront → Headless CMS / Content and pages republished (§11.4 — human step).
+- [ ] Tested locally with `yarn dev` — no empty labels/buttons/toasts.
+- [ ] Only then: v4 deployed to production + Node.js v24 set in WebOps.
+
+---
+
+## 10. Post-migration summary (mandatory output)
+
+> **MANDATORY prerequisite — do NOT display this summary until `yarn build`
+> passes.**
+>
+> Before showing the summary, run (using Node 24):
+> ```bash
+> yarn install
+> yarn build
+> ```
+> Fix any build errors first. Only after a successful build should you
+> proceed to display the summary below.
+
+After the build passes, display the following two sections.
+
+---
+
+### What was done
+
+A table covering every file touched and the change applied. Adapt rows to
+what actually changed; mark items that were not applicable as `—`.
+
+| File | Change | Status |
+|------|--------|--------|
+| `package.json` | `@faststore/cli` bumped to v4; `next` removed; `graphql`, `react-router-dom` added; `typescript` bumped to `^5.9.3`; `volta.node` set to `24` | ✅ Done |
+| `discovery.config.js` | `experimental.nodeVersion` → `24` | ✅ Done |
+| `src/**/*.scss` | Top-level `@import` → `@use`; `@include media/layout-content` namespaced to `u.*` | ✅ Done |
+| `patches/` | Stale v3 patches assessed / moved | ✅ Done / N/A |
+
+---
+
+### Important next steps
+
+#### 1. CMS sync (run manually in your terminal)
+
+> **Do NOT run `vtex content` commands automatically.** These require
+> interactive authentication and may have CLI plugin issues in Homebrew
+> environments.
+
+Check `discovery.config.js` and `cms/faststore/` to identify the case,
+then present the matching instructions to the user.
+
+**Headless CMS (legacy)** — `contentSource` field absent in `discovery.config.js`:
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+> If `cms-sync` errors with `Cannot find module 'vtex'`, run
+> `vtex plugins install @vtex/cli-plugin-cms` or `vtex update`.
+
+**Content Platform (CP)** — `contentSource: { type: 'CP' }` present.
+Identify the sub-case by inspecting `cms/faststore/`:
+
+| Case | Signal | Commands to run |
+|------|--------|-----------------|
+| **A** — no custom schemas | No `.jsonc` files, no `components/` folder | Create `cms/faststore/schema.json` with `{ "$base": "vtex.faststore" }`, then `vtex content upload-schema cms/faststore/schema.json` |
+| **B** — already split | `cms/faststore/components/*.jsonc` exists | `vtex content generate-schema cms/faststore/components cms/faststore/pages -o cms/faststore/schema.json` then `vtex content upload-schema cms/faststore/schema.json` |
+| **C** — legacy format | Only `sections.json` / `content-types.json` | Split first (see §11), then generate + upload |
+
+For the full command listing of each case see §11.
+
+---
+
+#### 2. Fill in new CMS fields and republish
+
+After the CMS sync, v4 exposes new configurable fields that were previously
+hardcoded. Configure them in **Admin → Storefront → Headless CMS / Content**
+and republish the affected pages:
+
+| Page | Fields to configure |
+|------|---------------------|
+| **All pages** | `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel` |
+| **Home** (product shelf) | `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`, `includeTaxesLabel`, `sponsoredLabel` |
+| **PLP** | `Breadcrumb → Fallback label`, `ProductGallery → sortBySelector`, `Filter → FilterSlider / FilterDesktop labels`, `ProductCard / ProductCardContent` |
+| **Search** | `SearchInput`, `SearchTop`, `SearchHistory`, `EmptyGallery → labels`, `ProductCard / ProductCardContent` |
+| **PDP** | `Breadcrumb → Fallback label`, `ProductDetails → invalidQuantityToast / buyButtonTitle` |
+| **Cart** | `EmptyCart → title / buttonLabel` |
+
+Full field reference: [developers.vtex.com → Upgrading FastStore to v4](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4)
+
+> Do not deploy v4 to production before filling these fields — they render
+> blank until configured.
+
+---
+
+#### 3. Update Node.js v24 in WebOps
+
+In VTEX Admin → **Storefront → FastStore WebOps → Settings → Node.js
+version** → set to `v24` → Save → trigger a new deploy.
+
+---
+
+#### 4. Check Sass `@import` deprecation warnings
+
+`@import` inside selector blocks emits Dart Sass deprecation warnings.
+
+---
+
+## 11. CMS sync — command reference
+
+This section is a command reference. The agent must **not** run these
+commands automatically — always present them to the user to run manually.
+
+### 11.1 Headless CMS (legacy)
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+`cms-sync` is safe while v3 is live — it only pushes the schema.
+
+### 11.2 Content Platform — Case A (no custom schemas)
+
+```bash
+# 1. Create the minimal schema (if not already present)
+# cms/faststore/schema.json content:
+# { "$base": "vtex.faststore" }
+# (use "vtex.faststore@4.1.0" to pin an explicit version)
+
+vtex login <accountName>
+vtex content upload-schema cms/faststore/schema.json
+# The local schema.json can be deleted after upload
+```
+
+### 11.3 Content Platform — Case B (components already in .jsonc format)
+
+```bash
+vtex login <accountName>
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```
+
+### 11.4 Content Platform — Case C (legacy sections.json)
+
+```bash
+vtex login <accountName>
+
+vtex content split-components -i cms/faststore/sections.json \
+                              -o cms/faststore/components
+vtex content split-content-types -i cms/faststore/content-types.json \
+                                 -s cms/faststore/sections.json \
+                                 -o cms/faststore/pages
+
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```

--- a/rules/faststore-faststore-storefront.mdc
+++ b/rules/faststore-faststore-storefront.mdc
@@ -103,7 +103,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -121,7 +121,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/skills/faststore-storefront/SKILL.md
+++ b/skills/faststore-storefront/SKILL.md
@@ -102,7 +102,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -120,7 +120,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 

--- a/skills/faststore-storefront/references/cms-schema-and-section-registration.md
+++ b/skills/faststore-storefront/references/cms-schema-and-section-registration.md
@@ -233,7 +233,7 @@ Follow this EXACT sequence. Do NOT skip steps.
 
 ### Phase 4: Schema Management (SAME SESSION)
 
-- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4`
+- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json  `
 - [ ] Verify: `grep -A 5 '"<ComponentName>"' cms/faststore/schema.json` (search for the `$componentKey` string)
   - If it does not appear, fix JSONC or registration — **do not** edit `schema.json` manually
 - [ ] **Account check** (before upload): read `api.storeId` from `discovery.config.js` and run `vtex whoami` — confirm both match. If they differ, ask the user to run `vtex login <correct-account>` and **stop**.
@@ -292,7 +292,7 @@ From the **project root**:
 1. **Generate** (canonical command — matches the storefront skill):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 ```
 
 2. **Validate** — for new or renamed sections, grep or read `cms/faststore/schema.json` and confirm the `"$componentKey"` is present.

--- a/skills/faststore-storefront/references/faststore-v3-v4-migration.md
+++ b/skills/faststore-storefront/references/faststore-v3-v4-migration.md
@@ -38,7 +38,7 @@ FastStore v4's dependency tree (e.g. `eslint-visitor-keys@5`) declares
 older Node (e.g. 20.12) fails with `Found incompatible module`.
 
 - Use Node 24 for install, build and dev.
-- Set `volta.node` to `"24"` in `packages/discovery/package.json`.
+- Set `volta.node` to `"24.0.2"` (or the latest Node 24 patch) in `packages/discovery/package.json`.
 - Set `experimental.nodeVersion: 24` in `discovery.config.js`.
 
 ---
@@ -56,15 +56,33 @@ app dependencies — e.g. `crypto-js`, `draft-js` — alongside these):
 {
   "@faststore/cli": "<published v4 release>",
   "@vtex/faststore-plugin-buyer-portal": "<published v4 release>",
-  "next": "^16.2.6",
+  "graphql": "^16.11.0",
   "react": "^18.2.0",
   "react-dom": "^18.2.0",
   "react-router-dom": "^6.24.1"
 }
 ```
 
+**Important:** do **not** declare `next` in `dependencies` — Next.js is now
+managed internally by `@faststore/cli`, and declaring it separately causes
+version conflicts. Also update `typescript` in `devDependencies` to `^5.9.3`.
+
+`graphql` must be declared explicitly because it is a `peerDependency` of
+`@faststore/cli` — yarn v1 does not install peer dependencies automatically.
+
 Root `package.json`: `@faststore/cli` (devDependency) +
 `@vtex/faststore-plugin-buyer-portal` (dependency).
+
+**Monorepo stores only:** add `@inquirer/type` to the `resolutions` field in
+the root `package.json` to avoid version conflicts with the `inquirer` package:
+
+```json
+{
+  "resolutions": {
+    "@inquirer/type": "^1.5.5"
+  }
+}
+```
 
 **Pin npm releases, not pkg.pr.new / pkg.csb.dev tarballs.** The faststore v4
 monorepo uses pnpm `catalog:` / `workspace:*` specs. `npm publish` (via
@@ -201,7 +219,32 @@ partial actually contributes CSS/members before keeping it.
 
 ---
 
-## 5. v3 patches
+## 5. GraphQL import migration
+
+`@faststore/graphql-utils` is **deprecated** in v4. The `gql` tag used for
+GraphQL documents must be imported from `@faststore/core/api` instead.
+
+Search for all usages in `src/`:
+
+```bash
+grep -r "faststore/graphql-utils" src/
+```
+
+Replace every occurrence:
+
+```ts
+// before
+import { gql } from '@faststore/graphql-utils'
+
+// after
+import { gql } from '@faststore/core/api'
+```
+
+If the grep returns no matches, skip this step.
+
+---
+
+## 6. v3 patches
 
 `patch-package` patches are version-tagged (`@faststore+core+<v3>.patch`) and
 will not apply to v4. Inspect each:
@@ -313,10 +356,11 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 
 ## Appendix — migration checklist
 
-- [ ] Node 24 (`volta.node`, `experimental.nodeVersion`).
+- [ ] Node 24 (`volta.node` must be a full semver e.g. "24.0.2", `experimental.nodeVersion: 24`).
 - [ ] `package.json` (root + discovery): `@faststore/cli` + plugin pinned to
-      published v4 releases; v3 transitive deps removed; `next ^16.2.6`,
-      `react-router-dom` added.
+      published v4 releases; v3 transitive deps removed; `next` **removed**
+      from dependencies (managed by cli); `graphql ^16.11.0` and
+      `react-router-dom ^6.24.1` added; `typescript ^5.9.3` in devDependencies.
 - [ ] `discovery.config.js`: no `path`/`dotenv` requires; no `webpack()`
       callback; `nodeVersion: 24`; `transpilePackages` if needed.
 - [ ] Every `.scss`: top-level `@import` → `@use`; nested `@import` kept;
@@ -327,3 +371,162 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
       `patches/`.
 - [ ] `yarn build` and `yarn dev` verified (§8).
 - [ ] Local-linking machinery (§9) reverted before committing.
+- [ ] CMS type detected via `contentSource` in `discovery.config.js` (§11.1).
+- [ ] CMS sync instructions shown to user (§10 next steps): case detected from `discovery.config.js` + `cms/faststore/`; commands presented for manual execution (never run automatically).
+- [ ] New CMS fields configured in Admin → Storefront → Headless CMS / Content and pages republished (§11.4 — human step).
+- [ ] Tested locally with `yarn dev` — no empty labels/buttons/toasts.
+- [ ] Only then: v4 deployed to production + Node.js v24 set in WebOps.
+
+---
+
+## 10. Post-migration summary (mandatory output)
+
+> **MANDATORY prerequisite — do NOT display this summary until `yarn build`
+> passes.**
+>
+> Before showing the summary, run (using Node 24):
+> ```bash
+> yarn install
+> yarn build
+> ```
+> Fix any build errors first. Only after a successful build should you
+> proceed to display the summary below.
+
+After the build passes, display the following two sections.
+
+---
+
+### What was done
+
+A table covering every file touched and the change applied. Adapt rows to
+what actually changed; mark items that were not applicable as `—`.
+
+| File | Change | Status |
+|------|--------|--------|
+| `package.json` | `@faststore/cli` bumped to v4; `next` removed; `graphql`, `react-router-dom` added; `typescript` bumped to `^5.9.3`; `volta.node` set to `24` | ✅ Done |
+| `discovery.config.js` | `experimental.nodeVersion` → `24` | ✅ Done |
+| `src/**/*.scss` | Top-level `@import` → `@use`; `@include media/layout-content` namespaced to `u.*` | ✅ Done |
+| `patches/` | Stale v3 patches assessed / moved | ✅ Done / N/A |
+
+---
+
+### Important next steps
+
+#### 1. CMS sync (run manually in your terminal)
+
+> **Do NOT run `vtex content` commands automatically.** These require
+> interactive authentication and may have CLI plugin issues in Homebrew
+> environments.
+
+Check `discovery.config.js` and `cms/faststore/` to identify the case,
+then present the matching instructions to the user.
+
+**Headless CMS (legacy)** — `contentSource` field absent in `discovery.config.js`:
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+> If `cms-sync` errors with `Cannot find module 'vtex'`, run
+> `vtex plugins install @vtex/cli-plugin-cms` or `vtex update`.
+
+**Content Platform (CP)** — `contentSource: { type: 'CP' }` present.
+Identify the sub-case by inspecting `cms/faststore/`:
+
+| Case | Signal | Commands to run |
+|------|--------|-----------------|
+| **A** — no custom schemas | No `.jsonc` files, no `components/` folder | Create `cms/faststore/schema.json` with `{ "$base": "vtex.faststore" }`, then `vtex content upload-schema cms/faststore/schema.json` |
+| **B** — already split | `cms/faststore/components/*.jsonc` exists | `vtex content generate-schema cms/faststore/components cms/faststore/pages -o cms/faststore/schema.json` then `vtex content upload-schema cms/faststore/schema.json` |
+| **C** — legacy format | Only `sections.json` / `content-types.json` | Split first (see §11), then generate + upload |
+
+For the full command listing of each case see §11.
+
+---
+
+#### 2. Fill in new CMS fields and republish
+
+After the CMS sync, v4 exposes new configurable fields that were previously
+hardcoded. Configure them in **Admin → Storefront → Headless CMS / Content**
+and republish the affected pages:
+
+| Page | Fields to configure |
+|------|---------------------|
+| **All pages** | `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel` |
+| **Home** (product shelf) | `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`, `includeTaxesLabel`, `sponsoredLabel` |
+| **PLP** | `Breadcrumb → Fallback label`, `ProductGallery → sortBySelector`, `Filter → FilterSlider / FilterDesktop labels`, `ProductCard / ProductCardContent` |
+| **Search** | `SearchInput`, `SearchTop`, `SearchHistory`, `EmptyGallery → labels`, `ProductCard / ProductCardContent` |
+| **PDP** | `Breadcrumb → Fallback label`, `ProductDetails → invalidQuantityToast / buyButtonTitle` |
+| **Cart** | `EmptyCart → title / buttonLabel` |
+
+Full field reference: [developers.vtex.com → Upgrading FastStore to v4](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4)
+
+> Do not deploy v4 to production before filling these fields — they render
+> blank until configured.
+
+---
+
+#### 3. Update Node.js v24 in WebOps
+
+In VTEX Admin → **Storefront → FastStore WebOps → Settings → Node.js
+version** → set to `v24` → Save → trigger a new deploy.
+
+---
+
+#### 4. Check Sass `@import` deprecation warnings
+
+`@import` inside selector blocks emits Dart Sass deprecation warnings.
+
+---
+
+## 11. CMS sync — command reference
+
+This section is a command reference. The agent must **not** run these
+commands automatically — always present them to the user to run manually.
+
+### 11.1 Headless CMS (legacy)
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+`cms-sync` is safe while v3 is live — it only pushes the schema.
+
+### 11.2 Content Platform — Case A (no custom schemas)
+
+```bash
+# 1. Create the minimal schema (if not already present)
+# cms/faststore/schema.json content:
+# { "$base": "vtex.faststore" }
+# (use "vtex.faststore@4.1.0" to pin an explicit version)
+
+vtex login <accountName>
+vtex content upload-schema cms/faststore/schema.json
+# The local schema.json can be deleted after upload
+```
+
+### 11.3 Content Platform — Case B (components already in .jsonc format)
+
+```bash
+vtex login <accountName>
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```
+
+### 11.4 Content Platform — Case C (legacy sections.json)
+
+```bash
+vtex login <accountName>
+
+vtex content split-components -i cms/faststore/sections.json \
+                              -o cms/faststore/components
+vtex content split-content-types -i cms/faststore/content-types.json \
+                                 -s cms/faststore/sections.json \
+                                 -o cms/faststore/pages
+
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```

--- a/skills/faststore-storefront/scripts/cms-sync.sh
+++ b/skills/faststore-storefront/scripts/cms-sync.sh
@@ -2,14 +2,14 @@
 #
 # DEPRECATED — Headless CMS schema publishing
 # Prefer running from the project root (global VTEX CLI):
-#   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+#   vtex content generate-schema -o cms/faststore/schema.json  
 #   vtex content upload-schema cms/faststore/schema.json
 # Do not use yarn/npm cms-sync or faststore cms-sync for this workflow.
 # See references/cms-schema-and-section-registration.md and skill.md.
 #
 
 # Generate final schema.json for Headless CMS (canonical flags — matches skill.md)
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 
 # Upload final schema.json to Headless CMS (expects interactive prompts or use expect — see reference)
 expect -c 'spawn vtex content upload-schema cms/faststore/schema.json; expect "store ID"; send "faststore\r"; expect "uploaded with"; send "y\r"; expect "Are you sure"; send "y\r"; expect eof' 2>&1

--- a/tracks/faststore/skills/faststore-storefront/references/cms-schema-and-section-registration.md
+++ b/tracks/faststore/skills/faststore-storefront/references/cms-schema-and-section-registration.md
@@ -233,7 +233,7 @@ Follow this EXACT sequence. Do NOT skip steps.
 
 ### Phase 4: Schema Management (SAME SESSION)
 
-- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4`
+- [ ] Generate: `vtex content generate-schema -o cms/faststore/schema.json  `
 - [ ] Verify: `grep -A 5 '"<ComponentName>"' cms/faststore/schema.json` (search for the `$componentKey` string)
   - If it does not appear, fix JSONC or registration — **do not** edit `schema.json` manually
 - [ ] **Account check** (before upload): read `api.storeId` from `discovery.config.js` and run `vtex whoami` — confirm both match. If they differ, ask the user to run `vtex login <correct-account>` and **stop**.
@@ -292,7 +292,7 @@ From the **project root**:
 1. **Generate** (canonical command — matches the storefront skill):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 ```
 
 2. **Validate** — for new or renamed sections, grep or read `cms/faststore/schema.json` and confirm the `"$componentKey"` is present.

--- a/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
+++ b/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
@@ -73,6 +73,17 @@ version conflicts. Also update `typescript` in `devDependencies` to `^5.9.3`.
 Root `package.json`: `@faststore/cli` (devDependency) +
 `@vtex/faststore-plugin-buyer-portal` (dependency).
 
+**Monorepo stores only:** add `@inquirer/type` to the `resolutions` field in
+the root `package.json` to avoid version conflicts with the `inquirer` package:
+
+```json
+{
+  "resolutions": {
+    "@inquirer/type": "^1.5.5"
+  }
+}
+```
+
 **Pin npm releases, not pkg.pr.new / pkg.csb.dev tarballs.** The faststore v4
 monorepo uses pnpm `catalog:` / `workspace:*` specs. `npm publish` (via
 `pnpm publish`) resolves these to concrete versions, so npm releases install
@@ -208,7 +219,32 @@ partial actually contributes CSS/members before keeping it.
 
 ---
 
-## 5. v3 patches
+## 5. GraphQL import migration
+
+`@faststore/graphql-utils` is **deprecated** in v4. The `gql` tag used for
+GraphQL documents must be imported from `@faststore/core/api` instead.
+
+Search for all usages in `src/`:
+
+```bash
+grep -r "faststore/graphql-utils" src/
+```
+
+Replace every occurrence:
+
+```ts
+// before
+import { gql } from '@faststore/graphql-utils'
+
+// after
+import { gql } from '@faststore/core/api'
+```
+
+If the grep returns no matches, skip this step.
+
+---
+
+## 6. v3 patches
 
 `patch-package` patches are version-tagged (`@faststore+core+<v3>.patch`) and
 will not apply to v4. Inspect each:

--- a/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
+++ b/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
@@ -38,7 +38,7 @@ FastStore v4's dependency tree (e.g. `eslint-visitor-keys@5`) declares
 older Node (e.g. 20.12) fails with `Found incompatible module`.
 
 - Use Node 24 for install, build and dev.
-- Set `volta.node` to `"24"` in `packages/discovery/package.json`.
+- Set `volta.node` to `"24.0.2"` (or the latest Node 24 patch) in `packages/discovery/package.json`.
 - Set `experimental.nodeVersion: 24` in `discovery.config.js`.
 
 ---
@@ -320,7 +320,7 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 
 ## Appendix — migration checklist
 
-- [ ] Node 24 (`volta.node`, `experimental.nodeVersion`).
+- [ ] Node 24 (`volta.node` must be a full semver e.g. "24.0.2", `experimental.nodeVersion: 24`).
 - [ ] `package.json` (root + discovery): `@faststore/cli` + plugin pinned to
       published v4 releases; v3 transitive deps removed; `next` **removed**
       from dependencies (managed by cli); `graphql ^16.11.0` and

--- a/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
+++ b/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
@@ -56,12 +56,19 @@ app dependencies — e.g. `crypto-js`, `draft-js` — alongside these):
 {
   "@faststore/cli": "<published v4 release>",
   "@vtex/faststore-plugin-buyer-portal": "<published v4 release>",
-  "next": "^16.2.6",
+  "graphql": "^16.11.0",
   "react": "^18.2.0",
   "react-dom": "^18.2.0",
   "react-router-dom": "^6.24.1"
 }
 ```
+
+**Important:** do **not** declare `next` in `dependencies` — Next.js is now
+managed internally by `@faststore/cli`, and declaring it separately causes
+version conflicts. Also update `typescript` in `devDependencies` to `^5.9.3`.
+
+`graphql` must be declared explicitly because it is a `peerDependency` of
+`@faststore/cli` — yarn v1 does not install peer dependencies automatically.
 
 Root `package.json`: `@faststore/cli` (devDependency) +
 `@vtex/faststore-plugin-buyer-portal` (dependency).
@@ -315,8 +322,9 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 
 - [ ] Node 24 (`volta.node`, `experimental.nodeVersion`).
 - [ ] `package.json` (root + discovery): `@faststore/cli` + plugin pinned to
-      published v4 releases; v3 transitive deps removed; `next ^16.2.6`,
-      `react-router-dom` added.
+      published v4 releases; v3 transitive deps removed; `next` **removed**
+      from dependencies (managed by cli); `graphql ^16.11.0` and
+      `react-router-dom ^6.24.1` added; `typescript ^5.9.3` in devDependencies.
 - [ ] `discovery.config.js`: no `path`/`dotenv` requires; no `webpack()`
       callback; `nodeVersion: 24`; `transpilePackages` if needed.
 - [ ] Every `.scss`: top-level `@import` → `@use`; nested `@import` kept;

--- a/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
+++ b/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
@@ -336,8 +336,8 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 - [ ] `yarn build` and `yarn dev` verified (§8).
 - [ ] Local-linking machinery (§9) reverted before committing.
 - [ ] CMS type detected via `contentSource` in `discovery.config.js` (§11.1).
-- [ ] CMS sync run: `yarn cms-sync` (legacy) or `generate-schema` + `upload-schema` (CP) — §11.2 / §11.3.
-- [ ] New CMS fields configured in Admin → Storefront → Content and pages republished (§11.4 — human step).
+- [ ] CMS sync instructions shown to user (§10 next steps): case detected from `discovery.config.js` + `cms/faststore/`; commands presented for manual execution (never run automatically).
+- [ ] New CMS fields configured in Admin → Storefront → Headless CMS / Content and pages republished (§11.4 — human step).
 - [ ] Tested locally with `yarn dev` — no empty labels/buttons/toasts.
 - [ ] Only then: v4 deployed to production + Node.js v24 set in WebOps.
 
@@ -345,149 +345,152 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
 
 ## 10. Post-migration summary (mandatory output)
 
-After completing all migration steps, **always display a structured summary**
-with two sections:
+> **MANDATORY prerequisite — do NOT display this summary until `yarn build`
+> passes.**
+>
+> Before showing the summary, run (using Node 24):
+> ```bash
+> yarn install
+> yarn build
+> ```
+> Fix any build errors first. Only after a successful build should you
+> proceed to display the summary below.
+
+After the build passes, display the following two sections.
+
+---
 
 ### What was done
 
-A table covering every file touched and the change applied:
+A table covering every file touched and the change applied. Adapt rows to
+what actually changed; mark items that were not applicable as `—`.
 
 | File | Change | Status |
 |------|--------|--------|
-| `package.json` | `@faststore/cli` bumped to v4; `next` removed; `graphql`, `react-router-dom` added; `typescript` bumped to `^5.9.3`; `volta.node` set to `24.x` | ✅ Done |
+| `package.json` | `@faststore/cli` bumped to v4; `next` removed; `graphql`, `react-router-dom` added; `typescript` bumped to `^5.9.3`; `volta.node` set to `24` | ✅ Done |
 | `discovery.config.js` | `experimental.nodeVersion` → `24` | ✅ Done |
 | `src/**/*.scss` | Top-level `@import` → `@use`; `@include media/layout-content` namespaced to `u.*` | ✅ Done |
 | `patches/` | Stale v3 patches assessed / moved | ✅ Done / N/A |
 
-Adapt the table rows to what actually changed in the store being migrated.
-Mark items that were not applicable as `—`.
-
-### Important next steps (do not block the build)
-
-Items that **do not block the build** but must be addressed before going
-to production:
-
-- **Node.js v24 in WebOps** — For production, update the
-  runtime in VTEX Admin → **Storefront → FastStore WebOps → Settings →
-  Node.js version** → `v24`, then trigger a new deploy. Without this, the
-  WebOps build still runs on the previously configured Node version.
-
-- **CMS content review** — After the v4 deploy, new configurable fields
-  will appear blank until filled in. Review and republish the pages below
-  in **Admin → Storefront → Content**:
-
-  | Page | Sections with new fields |
-  |------|--------------------------|
-  | **All pages** | `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel` |
-  | **Home** (if it has a product shelf) | `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`, `includeTaxesLabel`, `sponsoredLabel` |
-  | **PLP** (e.g. `/electronics`) | `Breadcrumb → Fallback label`, `ProductGallery → sortBySelector`, `Filter → FilterSlider / FilterDesktop labels`, `ProductCard / ProductCardContent` |
-  | **Search** (`/s?q=...`) | `SearchInput`, `SearchTop`, `SearchHistory`, `EmptyGallery → labels`, `ProductCard / ProductCardContent` |
-  | **PDP** (e.g. `/mouse/p`) | `Breadcrumb → Fallback label`, `ProductDetails → invalidQuantityToast / buyButtonTitle` |
-  | **Cart** | `EmptyCart → title / buttonLabel` |
-
-  Full field reference: [developers.vtex.com → Upgrading FastStore to v4 — Step 5: Update CMS content](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4)
-
-- **Nested `@import` deprecation warnings (Sass)** — `@import` inside a
-  selector block emits a Dart Sass deprecation warning (not an error). The
-  imports must stay nested to preserve CSS Modules purity (see §4.3), but
-  the underlying components can be refactored to avoid importing
-  `@faststore/ui` styles manually once the store moves to fully custom
-  styling or the UI components expose a cleaner API.
-
 ---
 
-## 11. CMS sync
+### Important next steps
 
-### 11.1 Detect CMS type
+#### 1. CMS sync (run manually in your terminal)
 
-**Always check `discovery.config.js` before deciding the CMS path.**
+> **Do NOT run `vtex content` commands automatically.** These require
+> interactive authentication and may have CLI plugin issues in Homebrew
+> environments.
 
-```js
-// Content Platform (CP)
-contentSource: {
-  type: 'CP',
-},
+Check `discovery.config.js` and `cms/faststore/` to identify the case,
+then present the matching instructions to the user.
 
-// Headless CMS (legacy) — no contentSource field at all
-```
-
-| Signal | CMS type |
-|--------|----------|
-| `contentSource: { type: 'CP' }` present | Content Platform |
-| `contentSource` absent | Headless CMS (legacy) |
-
----
-
-### 11.2 Headless CMS (legacy) path
-
-**Run `yarn cms-sync`** — requires interactive browser login, so it must be
-run in the user's own terminal:
+**Headless CMS (legacy)** — `contentSource` field absent in `discovery.config.js`:
 
 ```bash
-vtex login <accountName>   # authenticate first
+vtex login <accountName>
 yarn cms-sync
 ```
 
-`cms-sync` is safe to run while v3 is still live in production — it only
-pushes the schema; it does not affect page content or rendered output.
-
-> **Note:** `faststore cms-sync` internally calls `vtex cms sync` via the
-> `@vtex/cli-plugin-cms` plugin. If that plugin errors with
-> `Cannot find module 'vtex'`, the plugin's module resolution is broken
-> (common with Homebrew VTEX CLI installs). Fix with:
+> If `cms-sync` errors with `Cannot find module 'vtex'`, run
 > `vtex plugins install @vtex/cli-plugin-cms` or `vtex update`.
 
----
+**Content Platform (CP)** — `contentSource: { type: 'CP' }` present.
+Identify the sub-case by inspecting `cms/faststore/`:
 
-### 11.3 Content Platform (CP) path
+| Case | Signal | Commands to run |
+|------|--------|-----------------|
+| **A** — no custom schemas | No `.jsonc` files, no `components/` folder | Create `cms/faststore/schema.json` with `{ "$base": "vtex.faststore" }`, then `vtex content upload-schema cms/faststore/schema.json` |
+| **B** — already split | `cms/faststore/components/*.jsonc` exists | `vtex content generate-schema cms/faststore/components cms/faststore/pages -o cms/faststore/schema.json` then `vtex content upload-schema cms/faststore/schema.json` |
+| **C** — legacy format | Only `sections.json` / `content-types.json` | Split first (see §11), then generate + upload |
 
-First check whether `cms/faststore/components/` already contains `.jsonc`
-files (already split) or the store is still using the legacy `sections.json`
-format:
-
-```
-contentSource.type === 'CP'
-├── cms/faststore/components/*.jsonc exists?
-│   ├── YES → already in new format → skip to generate-schema
-│   └── NO  → split first:
-│             vtex content split-components -i cms/faststore/sections.json \
-│                                           -o cms/faststore/components
-│             vtex content split-content-types \
-│                                           -i cms/faststore/content-types.json \
-│                                           -s cms/faststore/sections.json \
-│                                           -o cms/faststore/pages
-└── then generate + upload:
-      vtex content generate-schema cms/faststore/components cms/faststore/pages \
-                                   -o cms/faststore/schema.json
-      vtex content upload-schema cms/faststore/schema.json
-```
+For the full command listing of each case see §11.
 
 ---
 
-### 11.4 Safe deploy order
+#### 2. Fill in new CMS fields and republish
 
-**Do not deploy v4 to production until all CMS fields are configured and
-tested locally.** The schema sync is safe to run while v3 is live, but
-deploying v4 before filling the new fields causes empty UI (labels, buttons,
-toasts render blank).
+After the CMS sync, v4 exposes new configurable fields that were previously
+hardcoded. Configure them in **Admin → Storefront → Headless CMS / Content**
+and republish the affected pages:
 
-Correct order:
+| Page | Fields to configure |
+|------|---------------------|
+| **All pages** | `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel` |
+| **Home** (product shelf) | `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`, `includeTaxesLabel`, `sponsoredLabel` |
+| **PLP** | `Breadcrumb → Fallback label`, `ProductGallery → sortBySelector`, `Filter → FilterSlider / FilterDesktop labels`, `ProductCard / ProductCardContent` |
+| **Search** | `SearchInput`, `SearchTop`, `SearchHistory`, `EmptyGallery → labels`, `ProductCard / ProductCardContent` |
+| **PDP** | `Breadcrumb → Fallback label`, `ProductDetails → invalidQuantityToast / buyButtonTitle` |
+| **Cart** | `EmptyCart → title / buttonLabel` |
 
-1. Run the CMS sync (§11.2 or §11.3) — safe while v3 is live
-2. Fill in all new configurable fields in **Admin → Storefront → Content**
-   (human step — values are store-specific):
-   - `Breadcrumb` → `Fallback label`
-   - `ProductGallery` → `sortBySelector` (sort option labels)
-   - `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel`
-   - `ProductDetails` → `invalidQuantityToast`, `buyButtonTitle`
-   - `EmptyCart` → `title`, `buttonLabel`
-   - `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`,
-     `includeTaxesLabel`, `sponsoredLabel`
-   - `EmptyGallery`, `SearchInput`, `SearchTop`, `SearchHistory` → labels
-   - `Filter` → `FilterSlider`, `FilterDesktop` labels
-3. Republish the affected pages
-4. Test locally with `yarn dev` pointing to the account — verify nothing
-   renders empty
-5. Deploy v4 to production
-6. Update Node.js v24 in WebOps (Admin → Storefront → FastStore WebOps →
-   Settings → Node.js version → `v24`)
+Full field reference: [developers.vtex.com → Upgrading FastStore to v4](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4)
+
+> Do not deploy v4 to production before filling these fields — they render
+> blank until configured.
+
+---
+
+#### 3. Update Node.js v24 in WebOps
+
+In VTEX Admin → **Storefront → FastStore WebOps → Settings → Node.js
+version** → set to `v24` → Save → trigger a new deploy.
+
+---
+
+#### 4. Check Sass `@import` deprecation warnings
+
+`@import` inside selector blocks emits Dart Sass deprecation warnings.
+
+---
+
+## 11. CMS sync — command reference
+
+This section is a command reference. The agent must **not** run these
+commands automatically — always present them to the user to run manually.
+
+### 11.1 Headless CMS (legacy)
+
+```bash
+vtex login <accountName>
+yarn cms-sync
+```
+
+`cms-sync` is safe while v3 is live — it only pushes the schema.
+
+### 11.2 Content Platform — Case A (no custom schemas)
+
+```bash
+# 1. Create the minimal schema (if not already present)
+# cms/faststore/schema.json content:
+# { "$base": "vtex.faststore" }
+# (use "vtex.faststore@4.1.0" to pin an explicit version)
+
+vtex login <accountName>
+vtex content upload-schema cms/faststore/schema.json
+# The local schema.json can be deleted after upload
+```
+
+### 11.3 Content Platform — Case B (components already in .jsonc format)
+
+```bash
+vtex login <accountName>
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```
+
+### 11.4 Content Platform — Case C (legacy sections.json)
+
+```bash
+vtex login <accountName>
+
+vtex content split-components -i cms/faststore/sections.json \
+                              -o cms/faststore/components
+vtex content split-content-types -i cms/faststore/content-types.json \
+                                 -s cms/faststore/sections.json \
+                                 -o cms/faststore/pages
+
+vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                             -o cms/faststore/schema.json
+vtex content upload-schema cms/faststore/schema.json
+```

--- a/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
+++ b/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
@@ -335,3 +335,42 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
       `patches/`.
 - [ ] `yarn build` and `yarn dev` verified (§8).
 - [ ] Local-linking machinery (§9) reverted before committing.
+
+---
+
+## 10. Post-migration summary (mandatory output)
+
+After completing all migration steps, **always display a structured summary**
+with two sections:
+
+### What was done
+
+A table covering every file touched and the change applied:
+
+| File | Change | Status |
+|------|--------|--------|
+| `package.json` | `@faststore/cli` bumped to v4; `next` removed; `graphql`, `react-router-dom` added; `typescript` bumped to `^5.9.3`; `volta.node` set to `24.x` | ✅ Done |
+| `discovery.config.js` | `experimental.nodeVersion` → `24` | ✅ Done |
+| `src/**/*.scss` | Top-level `@import` → `@use`; `@include media/layout-content` namespaced to `u.*` | ✅ Done |
+| `patches/` | Stale v3 patches assessed / moved | ✅ Done / N/A |
+
+Adapt the table rows to what actually changed in the store being migrated.
+Mark items that were not applicable as `—`.
+
+### Optional next steps
+
+Items that **do not block the build** but are worth addressing before going
+to production:
+
+- **Nested `@import` deprecation warnings (Sass)** — `@import` inside a
+  selector block emits a Dart Sass deprecation warning (not an error). The
+  imports must stay nested to preserve CSS Modules purity (see §4.3), but
+  the underlying components can be refactored to avoid importing
+  `@faststore/ui` styles manually once the store moves to fully custom
+  styling or the UI components expose a cleaner API.
+- **Node.js v24 in WebOps** — For production, update the
+  runtime in VTEX Admin → **Storefront → FastStore WebOps → Settings →
+  Node.js version** → `v24`, then trigger a new deploy. Without this, the
+  WebOps build still runs on the previously configured Node version.
+
+See the [official v4 upgrade guide](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4) for more details.

--- a/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
+++ b/tracks/faststore/skills/faststore-storefront/references/faststore-v3-v4-migration.md
@@ -335,6 +335,11 @@ script, and `rm -rf node_modules && yarn install` so no symlinks remain.
       `patches/`.
 - [ ] `yarn build` and `yarn dev` verified (§8).
 - [ ] Local-linking machinery (§9) reverted before committing.
+- [ ] CMS type detected via `contentSource` in `discovery.config.js` (§11.1).
+- [ ] CMS sync run: `yarn cms-sync` (legacy) or `generate-schema` + `upload-schema` (CP) — §11.2 / §11.3.
+- [ ] New CMS fields configured in Admin → Storefront → Content and pages republished (§11.4 — human step).
+- [ ] Tested locally with `yarn dev` — no empty labels/buttons/toasts.
+- [ ] Only then: v4 deployed to production + Node.js v24 set in WebOps.
 
 ---
 
@@ -357,10 +362,30 @@ A table covering every file touched and the change applied:
 Adapt the table rows to what actually changed in the store being migrated.
 Mark items that were not applicable as `—`.
 
-### Optional next steps
+### Important next steps (do not block the build)
 
-Items that **do not block the build** but are worth addressing before going
+Items that **do not block the build** but must be addressed before going
 to production:
+
+- **Node.js v24 in WebOps** — For production, update the
+  runtime in VTEX Admin → **Storefront → FastStore WebOps → Settings →
+  Node.js version** → `v24`, then trigger a new deploy. Without this, the
+  WebOps build still runs on the previously configured Node version.
+
+- **CMS content review** — After the v4 deploy, new configurable fields
+  will appear blank until filled in. Review and republish the pages below
+  in **Admin → Storefront → Content**:
+
+  | Page | Sections with new fields |
+  |------|--------------------------|
+  | **All pages** | `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel` |
+  | **Home** (if it has a product shelf) | `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`, `includeTaxesLabel`, `sponsoredLabel` |
+  | **PLP** (e.g. `/electronics`) | `Breadcrumb → Fallback label`, `ProductGallery → sortBySelector`, `Filter → FilterSlider / FilterDesktop labels`, `ProductCard / ProductCardContent` |
+  | **Search** (`/s?q=...`) | `SearchInput`, `SearchTop`, `SearchHistory`, `EmptyGallery → labels`, `ProductCard / ProductCardContent` |
+  | **PDP** (e.g. `/mouse/p`) | `Breadcrumb → Fallback label`, `ProductDetails → invalidQuantityToast / buyButtonTitle` |
+  | **Cart** | `EmptyCart → title / buttonLabel` |
+
+  Full field reference: [developers.vtex.com → Upgrading FastStore to v4 — Step 5: Update CMS content](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4)
 
 - **Nested `@import` deprecation warnings (Sass)** — `@import` inside a
   selector block emits a Dart Sass deprecation warning (not an error). The
@@ -368,9 +393,101 @@ to production:
   the underlying components can be refactored to avoid importing
   `@faststore/ui` styles manually once the store moves to fully custom
   styling or the UI components expose a cleaner API.
-- **Node.js v24 in WebOps** — For production, update the
-  runtime in VTEX Admin → **Storefront → FastStore WebOps → Settings →
-  Node.js version** → `v24`, then trigger a new deploy. Without this, the
-  WebOps build still runs on the previously configured Node version.
 
-See the [official v4 upgrade guide](https://developers.vtex.com/docs/guides/faststore/getting-started-upgrading-faststore-to-v4) for more details.
+---
+
+## 11. CMS sync
+
+### 11.1 Detect CMS type
+
+**Always check `discovery.config.js` before deciding the CMS path.**
+
+```js
+// Content Platform (CP)
+contentSource: {
+  type: 'CP',
+},
+
+// Headless CMS (legacy) — no contentSource field at all
+```
+
+| Signal | CMS type |
+|--------|----------|
+| `contentSource: { type: 'CP' }` present | Content Platform |
+| `contentSource` absent | Headless CMS (legacy) |
+
+---
+
+### 11.2 Headless CMS (legacy) path
+
+**Run `yarn cms-sync`** — requires interactive browser login, so it must be
+run in the user's own terminal:
+
+```bash
+vtex login <accountName>   # authenticate first
+yarn cms-sync
+```
+
+`cms-sync` is safe to run while v3 is still live in production — it only
+pushes the schema; it does not affect page content or rendered output.
+
+> **Note:** `faststore cms-sync` internally calls `vtex cms sync` via the
+> `@vtex/cli-plugin-cms` plugin. If that plugin errors with
+> `Cannot find module 'vtex'`, the plugin's module resolution is broken
+> (common with Homebrew VTEX CLI installs). Fix with:
+> `vtex plugins install @vtex/cli-plugin-cms` or `vtex update`.
+
+---
+
+### 11.3 Content Platform (CP) path
+
+First check whether `cms/faststore/components/` already contains `.jsonc`
+files (already split) or the store is still using the legacy `sections.json`
+format:
+
+```
+contentSource.type === 'CP'
+├── cms/faststore/components/*.jsonc exists?
+│   ├── YES → already in new format → skip to generate-schema
+│   └── NO  → split first:
+│             vtex content split-components -i cms/faststore/sections.json \
+│                                           -o cms/faststore/components
+│             vtex content split-content-types \
+│                                           -i cms/faststore/content-types.json \
+│                                           -s cms/faststore/sections.json \
+│                                           -o cms/faststore/pages
+└── then generate + upload:
+      vtex content generate-schema cms/faststore/components cms/faststore/pages \
+                                   -o cms/faststore/schema.json
+      vtex content upload-schema cms/faststore/schema.json
+```
+
+---
+
+### 11.4 Safe deploy order
+
+**Do not deploy v4 to production until all CMS fields are configured and
+tested locally.** The schema sync is safe to run while v3 is live, but
+deploying v4 before filling the new fields causes empty UI (labels, buttons,
+toasts render blank).
+
+Correct order:
+
+1. Run the CMS sync (§11.2 or §11.3) — safe while v3 is live
+2. Fill in all new configurable fields in **Admin → Storefront → Content**
+   (human step — values are store-specific):
+   - `Breadcrumb` → `Fallback label`
+   - `ProductGallery` → `sortBySelector` (sort option labels)
+   - `Navbar` → `invalidQuantityToast`, `collapseSearchAriaLabel`
+   - `ProductDetails` → `invalidQuantityToast`, `buyButtonTitle`
+   - `EmptyCart` → `title`, `buttonLabel`
+   - `ProductCard` / `ProductCardContent` → `buttonLabel`, `outOfStockLabel`,
+     `includeTaxesLabel`, `sponsoredLabel`
+   - `EmptyGallery`, `SearchInput`, `SearchTop`, `SearchHistory` → labels
+   - `Filter` → `FilterSlider`, `FilterDesktop` labels
+3. Republish the affected pages
+4. Test locally with `yarn dev` pointing to the account — verify nothing
+   renders empty
+5. Deploy v4 to production
+6. Update Node.js v24 in WebOps (Admin → Storefront → FastStore WebOps →
+   Settings → Node.js version → `v24`)

--- a/tracks/faststore/skills/faststore-storefront/scripts/cms-sync.sh
+++ b/tracks/faststore/skills/faststore-storefront/scripts/cms-sync.sh
@@ -2,14 +2,14 @@
 #
 # DEPRECATED — Headless CMS schema publishing
 # Prefer running from the project root (global VTEX CLI):
-#   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+#   vtex content generate-schema -o cms/faststore/schema.json  
 #   vtex content upload-schema cms/faststore/schema.json
 # Do not use yarn/npm cms-sync or faststore cms-sync for this workflow.
 # See references/cms-schema-and-section-registration.md and skill.md.
 #
 
 # Generate final schema.json for Headless CMS (canonical flags — matches skill.md)
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 
 # Upload final schema.json to Headless CMS (expects interactive prompts or use expect — see reference)
 expect -c 'spawn vtex content upload-schema cms/faststore/schema.json; expect "store ID"; send "faststore\r"; expect "uploaded with"; send "y\r"; expect "Are you sure"; send "y\r"; expect eof' 2>&1

--- a/tracks/faststore/skills/faststore-storefront/skill.md
+++ b/tracks/faststore/skills/faststore-storefront/skill.md
@@ -111,7 +111,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 
 1. **Generate** — from the project root, run:
    ```bash
-   vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+   vtex content generate-schema -o cms/faststore/schema.json  
    ```
 
 2. **Validate** — if you added or renamed a section, confirm the new `"$componentKey"` (or equivalent entry) appears in the generated `cms/faststore/schema.json`. If it is missing, fix the JSONC or registration in `src/components/index.tsx` and regenerate — **never** patch `schema.json` manually.
@@ -129,7 +129,7 @@ After **every** change to `cms/faststore/components/*.jsonc` or `cms/faststore/p
 Canonical commands (project root):
 
 ```bash
-vtex content generate-schema -o cms/faststore/schema.json -b vtex.faststore4
+vtex content generate-schema -o cms/faststore/schema.json  
 vtex content upload-schema cms/faststore/schema.json
 ```
 


### PR DESCRIPTION
## Description

- Adds **Post-migration summary** — mandatory structured output after completing all migration steps, including a per-file change table and a curated "Important next steps" section (WebOps Node.js v24, CMS content review, nested `@import` deprecation warnings).

- Adds **CMS sync** — step-by-step guidance for both Headless CMS (legacy `yarn cms-sync`) and Content Platform (`generate-schema` + `upload-schema`) paths, including the `split-components` / `split-content-types` pre-requisite for stores not yet in the new `.jsonc` format.

- Adds **Safe deploy order** — explicit 6-step sequence to avoid blank UI caused by deploying v4 before CMS fields are filled.

- Updates the **review checklist** to include CMS sync steps, local `yarn dev` verification, and the production deploy + WebOps Node.js v24 step.

- Fixes `package.json` snippet: removes `next` from `dependencies` (now managed internally by `@faststore/cli`) and adds `graphql ^16.11.0` + note about `typescript ^5.9.3` in devDependencies.

---

## Contribution Checklist

Before submitting, please verify:

- [x] **Source files only**: Edited skill files in `tracks/{track}/skills/{name}/skill.md`, not in `skills/`, `exports/`, or `rules/` directories
- [x] **Correct file name**: Skill file is named `skill.md` (lowercase), not `SKILL.md` or other variants
- [x] **Frontmatter complete**: Includes `name`, `description`, and `metadata` with `track` and `tags` fields
- [x] **Validation passed**: Ran `bun run validate` and all hard checks pass
- [x] **Exports regenerated**: Ran `bun run export` and committed both source and generated files
- [x] **Skill name format**: Uses kebab-case and is unique across the repository
- [x] **Track directory correct**: Track name in frontmatter matches the directory structure

---

## Public Documentation Sync

Public VTEX docs on `developers.vtex.com` and `help.vtex.com` may need to be updated when this PR ships. Pick one:

- [ ] **No public docs change needed**
- [ ] **Public docs update required** — list the affected pages and link the follow-up below:

See [Public documentation sync](../CONTRIBUTING.md#public-documentation-sync) in `CONTRIBUTING.md` for what triggers a docs update and how to find every affected page.

---

## Related Issues